### PR TITLE
 Use /dev/console as the TTY device path.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## 2015-11-12
+
+### Changed
+
+- Use /dev/console as the TTY device path. Fixes bug with user's Dockerfile CMD
+  directive being ignored when using systemd inside their container.
+
 ## 2015-10-13
 
 ### Changed

--- a/systemd/amd64/jessie/launch.service
+++ b/systemd/amd64/jessie/launch.service
@@ -6,7 +6,7 @@ EnvironmentFile=/etc/docker.env
 ExecStart=/etc/resinApp.sh
 StandardOutput=tty
 StandardError=tty
-TTYPath=/dev/pts/0
+TTYPath=/dev/console
 
 
 [Install]

--- a/systemd/armv7hf/jessie/launch.service
+++ b/systemd/armv7hf/jessie/launch.service
@@ -6,7 +6,7 @@ EnvironmentFile=/etc/docker.env
 ExecStart=/etc/resinApp.sh
 StandardOutput=tty
 StandardError=tty
-TTYPath=/dev/pts/0
+TTYPath=/dev/console
 
 
 [Install]

--- a/systemd/armv7hf/sid/launch.service
+++ b/systemd/armv7hf/sid/launch.service
@@ -6,7 +6,7 @@ EnvironmentFile=/etc/docker.env
 ExecStart=/etc/resinApp.sh
 StandardOutput=tty
 StandardError=tty
-TTYPath=/dev/pts/0
+TTYPath=/dev/console
 
 
 [Install]

--- a/systemd/i386/jessie/launch.service
+++ b/systemd/i386/jessie/launch.service
@@ -6,7 +6,7 @@ EnvironmentFile=/etc/docker.env
 ExecStart=/etc/resinApp.sh
 StandardOutput=tty
 StandardError=tty
-TTYPath=/dev/pts/0
+TTYPath=/dev/console
 
 
 [Install]

--- a/systemd/launch.service
+++ b/systemd/launch.service
@@ -6,7 +6,7 @@ EnvironmentFile=/etc/docker.env
 ExecStart=/etc/resinApp.sh
 StandardOutput=tty
 StandardError=tty
-TTYPath=/dev/pts/0
+TTYPath=/dev/console
 
 
 [Install]

--- a/systemd/rpi/jessie/launch.service
+++ b/systemd/rpi/jessie/launch.service
@@ -6,7 +6,7 @@ EnvironmentFile=/etc/docker.env
 ExecStart=/etc/resinApp.sh
 StandardOutput=tty
 StandardError=tty
-TTYPath=/dev/pts/0
+TTYPath=/dev/console
 
 
 [Install]


### PR DESCRIPTION
In some cases it seems /dev/pty/0 is not populated. If it isn't and we have TTYPath=/dev/pts/0 (as it previously was set), the launch.service service will fail to run with an error and the user's specified CMD line in their Dockerfile simply won't run.
    
/dev/console should always be available, so this is a safe alternative, and is also an appropriate TTY to use.