### PR TITLE
Fix issue of missing packages when using Python compiled from source and reorganize libmraa installation on edison

### DIFF
--- a/device-base/Dockerfile.i386.edison.tpl
+++ b/device-base/Dockerfile.i386.edison.tpl
@@ -30,7 +30,7 @@ RUN set -x \
 	&& cd mraa \
 	&& git checkout $MRAA_COMMIT \
 	&& mkdir build && cd build \
-	&& cmake .. -DBUILDSWIGNODE=OFF \
+	&& cmake .. -DBUILDSWIGNODE=OFF -DBUILDSWIGPYTHON=OFF \
 	&& make -j $(nproc) \
 	&& make install \
 	&& apt-get purge -y --auto-remove $buildDeps \

--- a/device-base/edison/jessie/Dockerfile
+++ b/device-base/edison/jessie/Dockerfile
@@ -30,7 +30,7 @@ RUN set -x \
 	&& cd mraa \
 	&& git checkout $MRAA_COMMIT \
 	&& mkdir build && cd build \
-	&& cmake .. -DBUILDSWIGNODE=OFF \
+	&& cmake .. -DBUILDSWIGNODE=OFF -DBUILDSWIGPYTHON=OFF \
 	&& make -j $(nproc) \
 	&& make install \
 	&& apt-get purge -y --auto-remove $buildDeps \

--- a/device-base/edison/wheezy/Dockerfile
+++ b/device-base/edison/wheezy/Dockerfile
@@ -30,7 +30,7 @@ RUN set -x \
 	&& cd mraa \
 	&& git checkout $MRAA_COMMIT \
 	&& mkdir build && cd build \
-	&& cmake .. -DBUILDSWIGNODE=OFF \
+	&& cmake .. -DBUILDSWIGNODE=OFF -DBUILDSWIGPYTHON=OFF \
 	&& make -j $(nproc) \
 	&& make install \
 	&& apt-get purge -y --auto-remove $buildDeps \

--- a/python/Dockerfile.slim.tpl
+++ b/python/Dockerfile.slim.tpl
@@ -114,5 +114,3 @@ RUN set -x \
 	&& rm -rf /usr/src/dbus-python
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
-
-#{PYTHON_EDISON_MRAA}

--- a/python/Dockerfile.tpl
+++ b/python/Dockerfile.tpl
@@ -86,5 +86,3 @@ RUN set -x \
 	&& rm -rf /usr/src/dbus-python
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
-
-#{PYTHON_EDISON_MRAA}

--- a/python/apalis-imx6/2.7/Dockerfile
+++ b/python/apalis-imx6/2.7/Dockerfile
@@ -86,5 +86,4 @@ RUN set -x \
 	&& rm -rf /usr/src/dbus-python
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
-
-
+ENV PYTHONPATH /usr/lib/python2.7/dist-packages

--- a/python/apalis-imx6/2.7/slim/Dockerfile
+++ b/python/apalis-imx6/2.7/slim/Dockerfile
@@ -114,5 +114,4 @@ RUN set -x \
 	&& rm -rf /usr/src/dbus-python
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
-
-
+ENV PYTHONPATH /usr/lib/python2.7/dist-packages

--- a/python/apalis-imx6/2.7/wheezy/Dockerfile
+++ b/python/apalis-imx6/2.7/wheezy/Dockerfile
@@ -86,5 +86,4 @@ RUN set -x \
 	&& rm -rf /usr/src/dbus-python
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
-
-
+ENV PYTHONPATH /usr/lib/python2.7/dist-packages

--- a/python/apalis-imx6/3.2/Dockerfile
+++ b/python/apalis-imx6/3.2/Dockerfile
@@ -95,3 +95,4 @@ RUN cd /usr/local/bin \
 	&& ln -sf python-config3 python-config
 	
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/apalis-imx6/3.2/slim/Dockerfile
+++ b/python/apalis-imx6/3.2/slim/Dockerfile
@@ -123,3 +123,4 @@ RUN cd /usr/local/bin \
 	&& ln -sf python-config3 python-config
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/apalis-imx6/3.2/wheezy/Dockerfile
+++ b/python/apalis-imx6/3.2/wheezy/Dockerfile
@@ -95,3 +95,4 @@ RUN cd /usr/local/bin \
 	&& ln -sf python-config3 python-config
 	
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/apalis-imx6/3.3/Dockerfile
+++ b/python/apalis-imx6/3.3/Dockerfile
@@ -95,3 +95,4 @@ RUN cd /usr/local/bin \
 	&& ln -sf python-config3 python-config
 	
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/apalis-imx6/3.3/slim/Dockerfile
+++ b/python/apalis-imx6/3.3/slim/Dockerfile
@@ -123,3 +123,4 @@ RUN cd /usr/local/bin \
 	&& ln -sf python-config3 python-config
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/apalis-imx6/3.3/wheezy/Dockerfile
+++ b/python/apalis-imx6/3.3/wheezy/Dockerfile
@@ -95,3 +95,4 @@ RUN cd /usr/local/bin \
 	&& ln -sf python-config3 python-config
 	
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/apalis-imx6/3.4/Dockerfile
+++ b/python/apalis-imx6/3.4/Dockerfile
@@ -95,3 +95,4 @@ RUN cd /usr/local/bin \
 	&& ln -sf python-config3 python-config
 	
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/apalis-imx6/3.4/slim/Dockerfile
+++ b/python/apalis-imx6/3.4/slim/Dockerfile
@@ -123,3 +123,4 @@ RUN cd /usr/local/bin \
 	&& ln -sf python-config3 python-config
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/apalis-imx6/3.4/wheezy/Dockerfile
+++ b/python/apalis-imx6/3.4/wheezy/Dockerfile
@@ -95,3 +95,4 @@ RUN cd /usr/local/bin \
 	&& ln -sf python-config3 python-config
 	
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/apalis-imx6/3.5/Dockerfile
+++ b/python/apalis-imx6/3.5/Dockerfile
@@ -95,3 +95,4 @@ RUN cd /usr/local/bin \
 	&& ln -sf python-config3 python-config
 	
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/apalis-imx6/3.5/slim/Dockerfile
+++ b/python/apalis-imx6/3.5/slim/Dockerfile
@@ -123,3 +123,4 @@ RUN cd /usr/local/bin \
 	&& ln -sf python-config3 python-config
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/apalis-imx6/3.5/wheezy/Dockerfile
+++ b/python/apalis-imx6/3.5/wheezy/Dockerfile
@@ -95,3 +95,4 @@ RUN cd /usr/local/bin \
 	&& ln -sf python-config3 python-config
 	
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/beaglebone/2.7/Dockerfile
+++ b/python/beaglebone/2.7/Dockerfile
@@ -86,5 +86,4 @@ RUN set -x \
 	&& rm -rf /usr/src/dbus-python
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
-
-
+ENV PYTHONPATH /usr/lib/python2.7/dist-packages

--- a/python/beaglebone/2.7/slim/Dockerfile
+++ b/python/beaglebone/2.7/slim/Dockerfile
@@ -114,5 +114,4 @@ RUN set -x \
 	&& rm -rf /usr/src/dbus-python
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
-
-
+ENV PYTHONPATH /usr/lib/python2.7/dist-packages

--- a/python/beaglebone/2.7/wheezy/Dockerfile
+++ b/python/beaglebone/2.7/wheezy/Dockerfile
@@ -86,5 +86,4 @@ RUN set -x \
 	&& rm -rf /usr/src/dbus-python
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
-
-
+ENV PYTHONPATH /usr/lib/python2.7/dist-packages

--- a/python/beaglebone/3.2/Dockerfile
+++ b/python/beaglebone/3.2/Dockerfile
@@ -95,3 +95,4 @@ RUN cd /usr/local/bin \
 	&& ln -sf python-config3 python-config
 	
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/beaglebone/3.2/slim/Dockerfile
+++ b/python/beaglebone/3.2/slim/Dockerfile
@@ -123,3 +123,4 @@ RUN cd /usr/local/bin \
 	&& ln -sf python-config3 python-config
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/beaglebone/3.2/wheezy/Dockerfile
+++ b/python/beaglebone/3.2/wheezy/Dockerfile
@@ -95,3 +95,4 @@ RUN cd /usr/local/bin \
 	&& ln -sf python-config3 python-config
 	
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/beaglebone/3.3/Dockerfile
+++ b/python/beaglebone/3.3/Dockerfile
@@ -95,3 +95,4 @@ RUN cd /usr/local/bin \
 	&& ln -sf python-config3 python-config
 	
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/beaglebone/3.3/slim/Dockerfile
+++ b/python/beaglebone/3.3/slim/Dockerfile
@@ -123,3 +123,4 @@ RUN cd /usr/local/bin \
 	&& ln -sf python-config3 python-config
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/beaglebone/3.3/wheezy/Dockerfile
+++ b/python/beaglebone/3.3/wheezy/Dockerfile
@@ -95,3 +95,4 @@ RUN cd /usr/local/bin \
 	&& ln -sf python-config3 python-config
 	
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/beaglebone/3.4/Dockerfile
+++ b/python/beaglebone/3.4/Dockerfile
@@ -95,3 +95,4 @@ RUN cd /usr/local/bin \
 	&& ln -sf python-config3 python-config
 	
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/beaglebone/3.4/slim/Dockerfile
+++ b/python/beaglebone/3.4/slim/Dockerfile
@@ -123,3 +123,4 @@ RUN cd /usr/local/bin \
 	&& ln -sf python-config3 python-config
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/beaglebone/3.4/wheezy/Dockerfile
+++ b/python/beaglebone/3.4/wheezy/Dockerfile
@@ -95,3 +95,4 @@ RUN cd /usr/local/bin \
 	&& ln -sf python-config3 python-config
 	
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/beaglebone/3.5/Dockerfile
+++ b/python/beaglebone/3.5/Dockerfile
@@ -95,3 +95,4 @@ RUN cd /usr/local/bin \
 	&& ln -sf python-config3 python-config
 	
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/beaglebone/3.5/slim/Dockerfile
+++ b/python/beaglebone/3.5/slim/Dockerfile
@@ -123,3 +123,4 @@ RUN cd /usr/local/bin \
 	&& ln -sf python-config3 python-config
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/beaglebone/3.5/wheezy/Dockerfile
+++ b/python/beaglebone/3.5/wheezy/Dockerfile
@@ -95,3 +95,4 @@ RUN cd /usr/local/bin \
 	&& ln -sf python-config3 python-config
 	
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/colibri-imx6/2.7/Dockerfile
+++ b/python/colibri-imx6/2.7/Dockerfile
@@ -86,5 +86,4 @@ RUN set -x \
 	&& rm -rf /usr/src/dbus-python
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
-
-
+ENV PYTHONPATH /usr/lib/python2.7/dist-packages

--- a/python/colibri-imx6/2.7/slim/Dockerfile
+++ b/python/colibri-imx6/2.7/slim/Dockerfile
@@ -114,5 +114,4 @@ RUN set -x \
 	&& rm -rf /usr/src/dbus-python
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
-
-
+ENV PYTHONPATH /usr/lib/python2.7/dist-packages

--- a/python/colibri-imx6/2.7/wheezy/Dockerfile
+++ b/python/colibri-imx6/2.7/wheezy/Dockerfile
@@ -86,5 +86,4 @@ RUN set -x \
 	&& rm -rf /usr/src/dbus-python
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
-
-
+ENV PYTHONPATH /usr/lib/python2.7/dist-packages

--- a/python/colibri-imx6/3.2/Dockerfile
+++ b/python/colibri-imx6/3.2/Dockerfile
@@ -95,3 +95,4 @@ RUN cd /usr/local/bin \
 	&& ln -sf python-config3 python-config
 	
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/colibri-imx6/3.2/slim/Dockerfile
+++ b/python/colibri-imx6/3.2/slim/Dockerfile
@@ -123,3 +123,4 @@ RUN cd /usr/local/bin \
 	&& ln -sf python-config3 python-config
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/colibri-imx6/3.2/wheezy/Dockerfile
+++ b/python/colibri-imx6/3.2/wheezy/Dockerfile
@@ -95,3 +95,4 @@ RUN cd /usr/local/bin \
 	&& ln -sf python-config3 python-config
 	
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/colibri-imx6/3.3/Dockerfile
+++ b/python/colibri-imx6/3.3/Dockerfile
@@ -95,3 +95,4 @@ RUN cd /usr/local/bin \
 	&& ln -sf python-config3 python-config
 	
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/colibri-imx6/3.3/slim/Dockerfile
+++ b/python/colibri-imx6/3.3/slim/Dockerfile
@@ -123,3 +123,4 @@ RUN cd /usr/local/bin \
 	&& ln -sf python-config3 python-config
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/colibri-imx6/3.3/wheezy/Dockerfile
+++ b/python/colibri-imx6/3.3/wheezy/Dockerfile
@@ -95,3 +95,4 @@ RUN cd /usr/local/bin \
 	&& ln -sf python-config3 python-config
 	
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/colibri-imx6/3.4/Dockerfile
+++ b/python/colibri-imx6/3.4/Dockerfile
@@ -95,3 +95,4 @@ RUN cd /usr/local/bin \
 	&& ln -sf python-config3 python-config
 	
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/colibri-imx6/3.4/slim/Dockerfile
+++ b/python/colibri-imx6/3.4/slim/Dockerfile
@@ -123,3 +123,4 @@ RUN cd /usr/local/bin \
 	&& ln -sf python-config3 python-config
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/colibri-imx6/3.4/wheezy/Dockerfile
+++ b/python/colibri-imx6/3.4/wheezy/Dockerfile
@@ -95,3 +95,4 @@ RUN cd /usr/local/bin \
 	&& ln -sf python-config3 python-config
 	
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/colibri-imx6/3.5/Dockerfile
+++ b/python/colibri-imx6/3.5/Dockerfile
@@ -95,3 +95,4 @@ RUN cd /usr/local/bin \
 	&& ln -sf python-config3 python-config
 	
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/colibri-imx6/3.5/slim/Dockerfile
+++ b/python/colibri-imx6/3.5/slim/Dockerfile
@@ -123,3 +123,4 @@ RUN cd /usr/local/bin \
 	&& ln -sf python-config3 python-config
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/colibri-imx6/3.5/wheezy/Dockerfile
+++ b/python/colibri-imx6/3.5/wheezy/Dockerfile
@@ -95,3 +95,4 @@ RUN cd /usr/local/bin \
 	&& ln -sf python-config3 python-config
 	
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/cubox-i/2.7/Dockerfile
+++ b/python/cubox-i/2.7/Dockerfile
@@ -86,5 +86,4 @@ RUN set -x \
 	&& rm -rf /usr/src/dbus-python
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
-
-
+ENV PYTHONPATH /usr/lib/python2.7/dist-packages

--- a/python/cubox-i/2.7/slim/Dockerfile
+++ b/python/cubox-i/2.7/slim/Dockerfile
@@ -114,5 +114,4 @@ RUN set -x \
 	&& rm -rf /usr/src/dbus-python
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
-
-
+ENV PYTHONPATH /usr/lib/python2.7/dist-packages

--- a/python/cubox-i/2.7/wheezy/Dockerfile
+++ b/python/cubox-i/2.7/wheezy/Dockerfile
@@ -86,5 +86,4 @@ RUN set -x \
 	&& rm -rf /usr/src/dbus-python
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
-
-
+ENV PYTHONPATH /usr/lib/python2.7/dist-packages

--- a/python/cubox-i/3.2/Dockerfile
+++ b/python/cubox-i/3.2/Dockerfile
@@ -95,3 +95,4 @@ RUN cd /usr/local/bin \
 	&& ln -sf python-config3 python-config
 	
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/cubox-i/3.2/slim/Dockerfile
+++ b/python/cubox-i/3.2/slim/Dockerfile
@@ -123,3 +123,4 @@ RUN cd /usr/local/bin \
 	&& ln -sf python-config3 python-config
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/cubox-i/3.2/wheezy/Dockerfile
+++ b/python/cubox-i/3.2/wheezy/Dockerfile
@@ -95,3 +95,4 @@ RUN cd /usr/local/bin \
 	&& ln -sf python-config3 python-config
 	
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/cubox-i/3.3/Dockerfile
+++ b/python/cubox-i/3.3/Dockerfile
@@ -95,3 +95,4 @@ RUN cd /usr/local/bin \
 	&& ln -sf python-config3 python-config
 	
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/cubox-i/3.3/slim/Dockerfile
+++ b/python/cubox-i/3.3/slim/Dockerfile
@@ -123,3 +123,4 @@ RUN cd /usr/local/bin \
 	&& ln -sf python-config3 python-config
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/cubox-i/3.3/wheezy/Dockerfile
+++ b/python/cubox-i/3.3/wheezy/Dockerfile
@@ -95,3 +95,4 @@ RUN cd /usr/local/bin \
 	&& ln -sf python-config3 python-config
 	
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/cubox-i/3.4/Dockerfile
+++ b/python/cubox-i/3.4/Dockerfile
@@ -95,3 +95,4 @@ RUN cd /usr/local/bin \
 	&& ln -sf python-config3 python-config
 	
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/cubox-i/3.4/slim/Dockerfile
+++ b/python/cubox-i/3.4/slim/Dockerfile
@@ -123,3 +123,4 @@ RUN cd /usr/local/bin \
 	&& ln -sf python-config3 python-config
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/cubox-i/3.4/wheezy/Dockerfile
+++ b/python/cubox-i/3.4/wheezy/Dockerfile
@@ -95,3 +95,4 @@ RUN cd /usr/local/bin \
 	&& ln -sf python-config3 python-config
 	
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/cubox-i/3.5/Dockerfile
+++ b/python/cubox-i/3.5/Dockerfile
@@ -95,3 +95,4 @@ RUN cd /usr/local/bin \
 	&& ln -sf python-config3 python-config
 	
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/cubox-i/3.5/slim/Dockerfile
+++ b/python/cubox-i/3.5/slim/Dockerfile
@@ -123,3 +123,4 @@ RUN cd /usr/local/bin \
 	&& ln -sf python-config3 python-config
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/cubox-i/3.5/wheezy/Dockerfile
+++ b/python/cubox-i/3.5/wheezy/Dockerfile
@@ -95,3 +95,4 @@ RUN cd /usr/local/bin \
 	&& ln -sf python-config3 python-config
 	
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/edison/2.7/Dockerfile
+++ b/python/edison/2.7/Dockerfile
@@ -86,4 +86,6 @@ RUN set -x \
 	&& rm -rf /usr/src/dbus-python
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
+COPY setup.sh /setup.sh
+RUN bash /setup.sh && rm /setup.sh
 ENV PYTHONPATH /usr/lib/python2.7/dist-packages

--- a/python/edison/2.7/Dockerfile
+++ b/python/edison/2.7/Dockerfile
@@ -86,5 +86,4 @@ RUN set -x \
 	&& rm -rf /usr/src/dbus-python
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
-
-RUN sed -i -e '2s@$@export PYTHONPATH="/usr/local/lib/python/site-packages"@' usr/bin/entry.sh
+ENV PYTHONPATH /usr/lib/python2.7/dist-packages

--- a/python/edison/2.7/setup.sh
+++ b/python/edison/2.7/setup.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+set -e
+
+set -x \
+&& buildDeps='
+	curl 
+	build-essential 
+	ca-certificates 
+	cmake 
+	git-core 
+	libpcre3-dev 
+	swig 
+	' \
+&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
+&& git clone https://github.com/intel-iot-devkit/mraa.git \
+&& cd mraa \
+&& git checkout $MRAA_COMMIT \
+&& mkdir build && cd build \
+&& cmake .. -DBUILDSWIGNODE=OFF \
+&& make -j $(nproc) \
+&& make install \
+&& apt-get purge -y --auto-remove $buildDeps \
+&& cd / \
+&& rm -rf mraa
+
+echo "/usr/local/lib/i386-linux-gnu/" >> /etc/ld.so.conf \
+&& ldconfig

--- a/python/edison/2.7/slim/Dockerfile
+++ b/python/edison/2.7/slim/Dockerfile
@@ -114,4 +114,6 @@ RUN set -x \
 	&& rm -rf /usr/src/dbus-python
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
+COPY setup.sh /setup.sh
+RUN bash /setup.sh && rm /setup.sh
 ENV PYTHONPATH /usr/lib/python2.7/dist-packages

--- a/python/edison/2.7/slim/Dockerfile
+++ b/python/edison/2.7/slim/Dockerfile
@@ -114,5 +114,4 @@ RUN set -x \
 	&& rm -rf /usr/src/dbus-python
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
-
-RUN sed -i -e '2s@$@export PYTHONPATH="/usr/local/lib/python/site-packages"@' usr/bin/entry.sh
+ENV PYTHONPATH /usr/lib/python2.7/dist-packages

--- a/python/edison/2.7/slim/setup.sh
+++ b/python/edison/2.7/slim/setup.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+set -e
+
+set -x \
+&& buildDeps='
+	curl 
+	build-essential 
+	ca-certificates 
+	cmake 
+	git-core 
+	libpcre3-dev 
+	swig 
+	' \
+&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
+&& git clone https://github.com/intel-iot-devkit/mraa.git \
+&& cd mraa \
+&& git checkout $MRAA_COMMIT \
+&& mkdir build && cd build \
+&& cmake .. -DBUILDSWIGNODE=OFF \
+&& make -j $(nproc) \
+&& make install \
+&& apt-get purge -y --auto-remove $buildDeps \
+&& cd / \
+&& rm -rf mraa
+
+echo "/usr/local/lib/i386-linux-gnu/" >> /etc/ld.so.conf \
+&& ldconfig

--- a/python/edison/2.7/wheezy/Dockerfile
+++ b/python/edison/2.7/wheezy/Dockerfile
@@ -86,4 +86,6 @@ RUN set -x \
 	&& rm -rf /usr/src/dbus-python
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
+COPY setup.sh /setup.sh
+RUN bash /setup.sh && rm /setup.sh
 ENV PYTHONPATH /usr/lib/python2.7/dist-packages

--- a/python/edison/2.7/wheezy/Dockerfile
+++ b/python/edison/2.7/wheezy/Dockerfile
@@ -86,5 +86,4 @@ RUN set -x \
 	&& rm -rf /usr/src/dbus-python
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
-
-RUN sed -i -e '2s@$@export PYTHONPATH="/usr/local/lib/python/site-packages"@' usr/bin/entry.sh
+ENV PYTHONPATH /usr/lib/python2.7/dist-packages

--- a/python/edison/2.7/wheezy/setup.sh
+++ b/python/edison/2.7/wheezy/setup.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+set -e
+
+set -x \
+&& buildDeps='
+	curl 
+	build-essential 
+	ca-certificates 
+	cmake 
+	git-core 
+	libpcre3-dev 
+	swig 
+	' \
+&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
+&& git clone https://github.com/intel-iot-devkit/mraa.git \
+&& cd mraa \
+&& git checkout $MRAA_COMMIT \
+&& mkdir build && cd build \
+&& cmake .. -DBUILDSWIGNODE=OFF \
+&& make -j $(nproc) \
+&& make install \
+&& apt-get purge -y --auto-remove $buildDeps \
+&& cd / \
+&& rm -rf mraa
+
+echo "/usr/local/lib/i386-linux-gnu/" >> /etc/ld.so.conf \
+&& ldconfig

--- a/python/edison/3.2/Dockerfile
+++ b/python/edison/3.2/Dockerfile
@@ -97,4 +97,4 @@ RUN cd /usr/local/bin \
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
 COPY setup.sh /setup.sh
 RUN bash /setup.sh && rm /setup.sh
-RUN sed -i -e '2s@$@export PYTHONPATH="/usr/local/lib/python3.2/site-packages"@' usr/bin/entry.sh
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/edison/3.2/slim/Dockerfile
+++ b/python/edison/3.2/slim/Dockerfile
@@ -125,4 +125,4 @@ RUN cd /usr/local/bin \
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
 COPY setup.sh /setup.sh
 RUN bash /setup.sh && rm /setup.sh
-RUN sed -i -e '2s@$@export PYTHONPATH="/usr/local/lib/python3.2/site-packages"@' usr/bin/entry.sh
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/edison/3.2/wheezy/Dockerfile
+++ b/python/edison/3.2/wheezy/Dockerfile
@@ -97,4 +97,4 @@ RUN cd /usr/local/bin \
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
 COPY setup.sh /setup.sh
 RUN bash /setup.sh && rm /setup.sh
-RUN sed -i -e '2s@$@export PYTHONPATH="/usr/local/lib/python3.2/site-packages"@' usr/bin/entry.sh
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/edison/3.3/Dockerfile
+++ b/python/edison/3.3/Dockerfile
@@ -97,4 +97,4 @@ RUN cd /usr/local/bin \
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
 COPY setup.sh /setup.sh
 RUN bash /setup.sh && rm /setup.sh
-RUN sed -i -e '2s@$@export PYTHONPATH="/usr/local/lib/python3.3/site-packages"@' usr/bin/entry.sh
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/edison/3.3/slim/Dockerfile
+++ b/python/edison/3.3/slim/Dockerfile
@@ -125,4 +125,4 @@ RUN cd /usr/local/bin \
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
 COPY setup.sh /setup.sh
 RUN bash /setup.sh && rm /setup.sh
-RUN sed -i -e '2s@$@export PYTHONPATH="/usr/local/lib/python3.3/site-packages"@' usr/bin/entry.sh
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/edison/3.3/wheezy/Dockerfile
+++ b/python/edison/3.3/wheezy/Dockerfile
@@ -97,4 +97,4 @@ RUN cd /usr/local/bin \
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
 COPY setup.sh /setup.sh
 RUN bash /setup.sh && rm /setup.sh
-RUN sed -i -e '2s@$@export PYTHONPATH="/usr/local/lib/python3.3/site-packages"@' usr/bin/entry.sh
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/edison/3.4/Dockerfile
+++ b/python/edison/3.4/Dockerfile
@@ -97,4 +97,4 @@ RUN cd /usr/local/bin \
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
 COPY setup.sh /setup.sh
 RUN bash /setup.sh && rm /setup.sh
-RUN sed -i -e '2s@$@export PYTHONPATH="/usr/local/lib/python3.4/site-packages"@' usr/bin/entry.sh
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/edison/3.4/slim/Dockerfile
+++ b/python/edison/3.4/slim/Dockerfile
@@ -125,4 +125,4 @@ RUN cd /usr/local/bin \
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
 COPY setup.sh /setup.sh
 RUN bash /setup.sh && rm /setup.sh
-RUN sed -i -e '2s@$@export PYTHONPATH="/usr/local/lib/python3.4/site-packages"@' usr/bin/entry.sh
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/edison/3.4/wheezy/Dockerfile
+++ b/python/edison/3.4/wheezy/Dockerfile
@@ -97,4 +97,4 @@ RUN cd /usr/local/bin \
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
 COPY setup.sh /setup.sh
 RUN bash /setup.sh && rm /setup.sh
-RUN sed -i -e '2s@$@export PYTHONPATH="/usr/local/lib/python3.4/site-packages"@' usr/bin/entry.sh
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/edison/3.5/Dockerfile
+++ b/python/edison/3.5/Dockerfile
@@ -97,4 +97,4 @@ RUN cd /usr/local/bin \
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
 COPY setup.sh /setup.sh
 RUN bash /setup.sh && rm /setup.sh
-RUN sed -i -e '2s@$@export PYTHONPATH="/usr/local/lib/python3.5/site-packages"@' usr/bin/entry.sh
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/edison/3.5/slim/Dockerfile
+++ b/python/edison/3.5/slim/Dockerfile
@@ -125,4 +125,4 @@ RUN cd /usr/local/bin \
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
 COPY setup.sh /setup.sh
 RUN bash /setup.sh && rm /setup.sh
-RUN sed -i -e '2s@$@export PYTHONPATH="/usr/local/lib/python3.5/site-packages"@' usr/bin/entry.sh
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/edison/3.5/wheezy/Dockerfile
+++ b/python/edison/3.5/wheezy/Dockerfile
@@ -97,4 +97,4 @@ RUN cd /usr/local/bin \
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
 COPY setup.sh /setup.sh
 RUN bash /setup.sh && rm /setup.sh
-RUN sed -i -e '2s@$@export PYTHONPATH="/usr/local/lib/python3.5/site-packages"@' usr/bin/entry.sh
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/generate-dockerfile.sh
+++ b/python/generate-dockerfile.sh
@@ -3,13 +3,18 @@ set -e
 
 PYTHON2_PATH="/usr/lib/python2.7/dist-packages"
 PYTHON3_PATH="/usr/lib/python3/dist-packages"
+PYTHON2_ARGS="-DBUILDSWIGNODE=OFF"
+PYTHON3_ARGS="-DBUILDSWIGNODE=OFF -DBUILDPYTHON3=ON -DPYTHON_INCLUDE_DIR=/usr/local/include/python3.5m/ -DPYTHON_LIBRARY=/usr/local/lib/libpython3.so"
 
 # append mraa build script to the bottom of Dockerfile.
 append_setup_script() {
+	cp setup.sh $2
+	echo "COPY setup.sh /setup.sh" >> $2/Dockerfile
+	echo "RUN bash /setup.sh && rm /setup.sh" >> $2/Dockerfile
 	if [ $1 != "2.7" ]; then
-		cp setup.sh $2
-		echo "COPY setup.sh /setup.sh" >> $2/Dockerfile
-		echo "RUN bash /setup.sh && rm /setup.sh" >> $2/Dockerfile
+		sed -i -e s~#{ARGS}~"$PYTHON3_ARGS"~g $2/setup.sh
+	else
+		sed -i -e s~#{ARGS}~"$PYTHON2_ARGS"~g $2/setup.sh
 	fi
 }
 

--- a/python/generate-dockerfile.sh
+++ b/python/generate-dockerfile.sh
@@ -1,17 +1,34 @@
 #!/bin/bash
 set -e
 
+PYTHON2_PATH="/usr/lib/python2.7/dist-packages"
+PYTHON3_PATH="/usr/lib/python3/dist-packages"
+
 # append mraa build script to the bottom of Dockerfile.
 append_setup_script() {
-	cp setup.sh $1
-	echo "COPY setup.sh /setup.sh" >> $1/Dockerfile
-	echo "RUN bash /setup.sh && rm /setup.sh" >> $1/Dockerfile
-	echo "RUN sed -i -e '2s@\$@export PYTHONPATH=\"/usr/local/lib/python$baseVersion/site-packages\"@' usr/bin/entry.sh" >> $1/Dockerfile
+	if [ $1 != "2.7" ]; then
+		cp setup.sh $2
+		echo "COPY setup.sh /setup.sh" >> $2/Dockerfile
+		echo "RUN bash /setup.sh && rm /setup.sh" >> $2/Dockerfile
+	fi
 }
+
+# set PYTHONPATH to point to dist-packages
+set_pythonpath() {
+	if [ $1 != "2.7" ]; then
+		echo "ENV PYTHONPATH $PYTHON3_PATH" >> $2/Dockerfile
+		echo "ENV PYTHONPATH $PYTHON3_PATH" >> $2/wheezy/Dockerfile
+		echo "ENV PYTHONPATH $PYTHON3_PATH" >> $2/slim/Dockerfile
+	else
+		echo "ENV PYTHONPATH $PYTHON2_PATH" >> $2/Dockerfile
+		echo "ENV PYTHONPATH $PYTHON2_PATH" >> $2/wheezy/Dockerfile
+		echo "ENV PYTHONPATH $PYTHON2_PATH" >> $2/slim/Dockerfile
+	fi
+}
+
 
 devices='raspberrypi raspberrypi2 beaglebone edison nuc vab820-quad zc702-zynq7 odroid-c1 odroid-ux3 parallella-hdmi-resin nitrogen6x cubox-i ts4900 colibri-imx6 apalis-imx6'
 pythonVersions='2.7.10 3.2.6 3.3.6 3.4.3 3.5.0'
-edisonScript="RUN sed -i -e '2s@\$@export PYTHONPATH=\"/usr/local/lib/python$baseVersion/site-packages\"@' usr/bin/entry.sh"
 
 for device in $devices; do
 	for pythonVersion in $pythonVersions; do
@@ -49,61 +66,54 @@ for device in $devices; do
 		sed -e s~#{FROM}~"resin/$device-buildpack-deps:jessie"~g \
 			-e s~#{PYTHON_VERSION}~"$pythonVersion"~g \
 			-e s~#{PYTHON_BASE_VERSION}~"$baseVersion"~g \
-			-e s~#{GPG_KEY}~"$gpgKey"~g \
-			-e s~#{PYTHON_EDISON_MRAA}~''~g $template > $dockerfilePath/Dockerfile
+			-e s~#{GPG_KEY}~"$gpgKey"~g $template > $dockerfilePath/Dockerfile
 
-			mkdir -p $dockerfilePath/wheezy
+		mkdir -p $dockerfilePath/wheezy
+		sed -e s~#{FROM}~"resin/$device-buildpack-deps:wheezy"~g \
+			-e s~#{PYTHON_VERSION}~"$pythonVersion"~g \
+			-e s~#{PYTHON_BASE_VERSION}~"$baseVersion"~g \
+			-e s~#{GPG_KEY}~"$gpgKey"~g $template > $dockerfilePath/wheezy/Dockerfile
+
+		mkdir -p $dockerfilePath/onbuild
+		sed -e s~#{FROM}~"resin/$device-python:$pythonVersion"~g Dockerfile.onbuild.tpl > $dockerfilePath/onbuild/Dockerfile
+		mkdir -p $dockerfilePath/slim
+
+		# Only for RPI1 device
+		if [ $device == "raspberrypi" ]; then
+			sed -e s~#{FROM}~"resin/$device-systemd:jessie"~g \
+				-e s~#{PYTHON_VERSION}~"$pythonVersion"~g \
+				-e s~#{PYTHON_BASE_VERSION}~"$baseVersion"~g \
+				-e s~#{GPG_KEY}~"$gpgKey"~g $slimTemplate > $dockerfilePath/slim/Dockerfile
+		else
+			sed -e s~#{FROM}~"resin/$device-debian:jessie"~g \
+				-e s~#{PYTHON_VERSION}~"$pythonVersion"~g \
+				-e s~#{PYTHON_BASE_VERSION}~"$baseVersion"~g \
+				-e s~#{GPG_KEY}~"$gpgKey"~g $slimTemplate > $dockerfilePath/slim/Dockerfile
+		fi
+
+		# Only for intel edison
+		if [ $device == "edison" ]; then
+			sed -e s~#{FROM}~"resin/$device-buildpack-deps:jessie"~g \
+				-e s~#{PYTHON_VERSION}~"$pythonVersion"~g \
+				-e s~#{PYTHON_BASE_VERSION}~"$baseVersion"~g \
+				-e s~#{GPG_KEY}~"$gpgKey"~g $template > $dockerfilePath/Dockerfile
+
 			sed -e s~#{FROM}~"resin/$device-buildpack-deps:wheezy"~g \
 				-e s~#{PYTHON_VERSION}~"$pythonVersion"~g \
 				-e s~#{PYTHON_BASE_VERSION}~"$baseVersion"~g \
-				-e s~#{GPG_KEY}~"$gpgKey"~g \
-				-e s~#{PYTHON_EDISON_MRAA}~''~g $template > $dockerfilePath/wheezy/Dockerfile
+				-e s~#{GPG_KEY}~"$gpgKey"~g $template > $dockerfilePath/wheezy/Dockerfile
 
-			mkdir -p $dockerfilePath/onbuild
-			sed -e s~#{FROM}~"resin/$device-python:$pythonVersion"~g Dockerfile.onbuild.tpl > $dockerfilePath/onbuild/Dockerfile
-			mkdir -p $dockerfilePath/slim
+			sed -e s~#{FROM}~"resin/$device-debian:jessie"~g \
+				-e s~#{PYTHON_VERSION}~"$pythonVersion"~g \
+				-e s~#{PYTHON_BASE_VERSION}~"$baseVersion"~g \
+				-e s~#{GPG_KEY}~"$gpgKey"~g $slimTemplate > $dockerfilePath/slim/Dockerfile
 
-			# Only for RPI1 device
-			if [ $device == "raspberrypi" ]; then
-				sed -e s~#{FROM}~"resin/$device-systemd:jessie"~g \
-					-e s~#{PYTHON_VERSION}~"$pythonVersion"~g \
-					-e s~#{PYTHON_BASE_VERSION}~"$baseVersion"~g \
-					-e s~#{GPG_KEY}~"$gpgKey"~g \
-					-e s~#{PYTHON_EDISON_MRAA}~''~g $slimTemplate > $dockerfilePath/slim/Dockerfile
-			else
-				sed -e s~#{FROM}~"resin/$device-debian:jessie"~g \
-					-e s~#{PYTHON_VERSION}~"$pythonVersion"~g \
-					-e s~#{PYTHON_BASE_VERSION}~"$baseVersion"~g \
-					-e s~#{GPG_KEY}~"$gpgKey"~g \
-					-e s~#{PYTHON_EDISON_MRAA}~''~g $slimTemplate > $dockerfilePath/slim/Dockerfile
-			fi
+			# Only append setup script to Python3 images
+			append_setup_script $baseVersion $dockerfilePath/
+			append_setup_script $baseVersion $dockerfilePath/wheezy/
+			append_setup_script $baseVersion $dockerfilePath/slim/
+		fi
 
-			# Only for intel edison
-			if [ $device == "edison" ]; then
-				sed -e s~#{FROM}~"resin/$device-buildpack-deps:jessie"~g \
-					-e s~#{PYTHON_VERSION}~"$pythonVersion"~g \
-					-e s~#{PYTHON_BASE_VERSION}~"$baseVersion"~g \
-					-e s~#{GPG_KEY}~"$gpgKey"~g \
-					-e s~#{PYTHON_EDISON_MRAA}~"$edisonScript"~g $template > $dockerfilePath/Dockerfile
-
-				sed -e s~#{FROM}~"resin/$device-buildpack-deps:wheezy"~g \
-					-e s~#{PYTHON_VERSION}~"$pythonVersion"~g \
-					-e s~#{PYTHON_BASE_VERSION}~"$baseVersion"~g \
-					-e s~#{GPG_KEY}~"$gpgKey"~g \
-					-e s~#{PYTHON_EDISON_MRAA}~"$edisonScript"~g $template > $dockerfilePath/wheezy/Dockerfile
-
-				sed -e s~#{FROM}~"resin/$device-debian:jessie"~g \
-					-e s~#{PYTHON_VERSION}~"$pythonVersion"~g \
-					-e s~#{PYTHON_BASE_VERSION}~"$baseVersion"~g \
-					-e s~#{GPG_KEY}~"$gpgKey"~g \
-					-e s~#{PYTHON_EDISON_MRAA}~"$edisonScript"~g $slimTemplate > $dockerfilePath/slim/Dockerfile
-
-				# Only append setup script to Python3 images
-				if [ $pythonVersion != "2.7.10" ]; then
-					append_setup_script $dockerfilePath/
-					append_setup_script $dockerfilePath/wheezy/
-					append_setup_script $dockerfilePath/slim/
-				fi
-			fi
+		set_pythonpath $baseVersion $dockerfilePath/	
 	done
 done

--- a/python/nitrogen6x/2.7/Dockerfile
+++ b/python/nitrogen6x/2.7/Dockerfile
@@ -86,5 +86,4 @@ RUN set -x \
 	&& rm -rf /usr/src/dbus-python
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
-
-
+ENV PYTHONPATH /usr/lib/python2.7/dist-packages

--- a/python/nitrogen6x/2.7/slim/Dockerfile
+++ b/python/nitrogen6x/2.7/slim/Dockerfile
@@ -114,5 +114,4 @@ RUN set -x \
 	&& rm -rf /usr/src/dbus-python
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
-
-
+ENV PYTHONPATH /usr/lib/python2.7/dist-packages

--- a/python/nitrogen6x/2.7/wheezy/Dockerfile
+++ b/python/nitrogen6x/2.7/wheezy/Dockerfile
@@ -86,5 +86,4 @@ RUN set -x \
 	&& rm -rf /usr/src/dbus-python
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
-
-
+ENV PYTHONPATH /usr/lib/python2.7/dist-packages

--- a/python/nitrogen6x/3.2/Dockerfile
+++ b/python/nitrogen6x/3.2/Dockerfile
@@ -95,3 +95,4 @@ RUN cd /usr/local/bin \
 	&& ln -sf python-config3 python-config
 	
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/nitrogen6x/3.2/slim/Dockerfile
+++ b/python/nitrogen6x/3.2/slim/Dockerfile
@@ -123,3 +123,4 @@ RUN cd /usr/local/bin \
 	&& ln -sf python-config3 python-config
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/nitrogen6x/3.2/wheezy/Dockerfile
+++ b/python/nitrogen6x/3.2/wheezy/Dockerfile
@@ -95,3 +95,4 @@ RUN cd /usr/local/bin \
 	&& ln -sf python-config3 python-config
 	
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/nitrogen6x/3.3/Dockerfile
+++ b/python/nitrogen6x/3.3/Dockerfile
@@ -95,3 +95,4 @@ RUN cd /usr/local/bin \
 	&& ln -sf python-config3 python-config
 	
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/nitrogen6x/3.3/slim/Dockerfile
+++ b/python/nitrogen6x/3.3/slim/Dockerfile
@@ -123,3 +123,4 @@ RUN cd /usr/local/bin \
 	&& ln -sf python-config3 python-config
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/nitrogen6x/3.3/wheezy/Dockerfile
+++ b/python/nitrogen6x/3.3/wheezy/Dockerfile
@@ -95,3 +95,4 @@ RUN cd /usr/local/bin \
 	&& ln -sf python-config3 python-config
 	
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/nitrogen6x/3.4/Dockerfile
+++ b/python/nitrogen6x/3.4/Dockerfile
@@ -95,3 +95,4 @@ RUN cd /usr/local/bin \
 	&& ln -sf python-config3 python-config
 	
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/nitrogen6x/3.4/slim/Dockerfile
+++ b/python/nitrogen6x/3.4/slim/Dockerfile
@@ -123,3 +123,4 @@ RUN cd /usr/local/bin \
 	&& ln -sf python-config3 python-config
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/nitrogen6x/3.4/wheezy/Dockerfile
+++ b/python/nitrogen6x/3.4/wheezy/Dockerfile
@@ -95,3 +95,4 @@ RUN cd /usr/local/bin \
 	&& ln -sf python-config3 python-config
 	
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/nitrogen6x/3.5/Dockerfile
+++ b/python/nitrogen6x/3.5/Dockerfile
@@ -95,3 +95,4 @@ RUN cd /usr/local/bin \
 	&& ln -sf python-config3 python-config
 	
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/nitrogen6x/3.5/slim/Dockerfile
+++ b/python/nitrogen6x/3.5/slim/Dockerfile
@@ -123,3 +123,4 @@ RUN cd /usr/local/bin \
 	&& ln -sf python-config3 python-config
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/nitrogen6x/3.5/wheezy/Dockerfile
+++ b/python/nitrogen6x/3.5/wheezy/Dockerfile
@@ -95,3 +95,4 @@ RUN cd /usr/local/bin \
 	&& ln -sf python-config3 python-config
 	
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/nuc/2.7/Dockerfile
+++ b/python/nuc/2.7/Dockerfile
@@ -86,5 +86,4 @@ RUN set -x \
 	&& rm -rf /usr/src/dbus-python
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
-
-
+ENV PYTHONPATH /usr/lib/python2.7/dist-packages

--- a/python/nuc/2.7/slim/Dockerfile
+++ b/python/nuc/2.7/slim/Dockerfile
@@ -114,5 +114,4 @@ RUN set -x \
 	&& rm -rf /usr/src/dbus-python
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
-
-
+ENV PYTHONPATH /usr/lib/python2.7/dist-packages

--- a/python/nuc/2.7/wheezy/Dockerfile
+++ b/python/nuc/2.7/wheezy/Dockerfile
@@ -86,5 +86,4 @@ RUN set -x \
 	&& rm -rf /usr/src/dbus-python
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
-
-
+ENV PYTHONPATH /usr/lib/python2.7/dist-packages

--- a/python/nuc/3.2/Dockerfile
+++ b/python/nuc/3.2/Dockerfile
@@ -95,3 +95,4 @@ RUN cd /usr/local/bin \
 	&& ln -sf python-config3 python-config
 	
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/nuc/3.2/slim/Dockerfile
+++ b/python/nuc/3.2/slim/Dockerfile
@@ -123,3 +123,4 @@ RUN cd /usr/local/bin \
 	&& ln -sf python-config3 python-config
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/nuc/3.2/wheezy/Dockerfile
+++ b/python/nuc/3.2/wheezy/Dockerfile
@@ -95,3 +95,4 @@ RUN cd /usr/local/bin \
 	&& ln -sf python-config3 python-config
 	
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/nuc/3.3/Dockerfile
+++ b/python/nuc/3.3/Dockerfile
@@ -95,3 +95,4 @@ RUN cd /usr/local/bin \
 	&& ln -sf python-config3 python-config
 	
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/nuc/3.3/slim/Dockerfile
+++ b/python/nuc/3.3/slim/Dockerfile
@@ -123,3 +123,4 @@ RUN cd /usr/local/bin \
 	&& ln -sf python-config3 python-config
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/nuc/3.3/wheezy/Dockerfile
+++ b/python/nuc/3.3/wheezy/Dockerfile
@@ -95,3 +95,4 @@ RUN cd /usr/local/bin \
 	&& ln -sf python-config3 python-config
 	
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/nuc/3.4/Dockerfile
+++ b/python/nuc/3.4/Dockerfile
@@ -95,3 +95,4 @@ RUN cd /usr/local/bin \
 	&& ln -sf python-config3 python-config
 	
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/nuc/3.4/slim/Dockerfile
+++ b/python/nuc/3.4/slim/Dockerfile
@@ -123,3 +123,4 @@ RUN cd /usr/local/bin \
 	&& ln -sf python-config3 python-config
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/nuc/3.4/wheezy/Dockerfile
+++ b/python/nuc/3.4/wheezy/Dockerfile
@@ -95,3 +95,4 @@ RUN cd /usr/local/bin \
 	&& ln -sf python-config3 python-config
 	
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/nuc/3.5/Dockerfile
+++ b/python/nuc/3.5/Dockerfile
@@ -95,3 +95,4 @@ RUN cd /usr/local/bin \
 	&& ln -sf python-config3 python-config
 	
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/nuc/3.5/slim/Dockerfile
+++ b/python/nuc/3.5/slim/Dockerfile
@@ -123,3 +123,4 @@ RUN cd /usr/local/bin \
 	&& ln -sf python-config3 python-config
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/nuc/3.5/wheezy/Dockerfile
+++ b/python/nuc/3.5/wheezy/Dockerfile
@@ -95,3 +95,4 @@ RUN cd /usr/local/bin \
 	&& ln -sf python-config3 python-config
 	
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/odroid-c1/2.7/Dockerfile
+++ b/python/odroid-c1/2.7/Dockerfile
@@ -86,5 +86,4 @@ RUN set -x \
 	&& rm -rf /usr/src/dbus-python
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
-
-
+ENV PYTHONPATH /usr/lib/python2.7/dist-packages

--- a/python/odroid-c1/2.7/slim/Dockerfile
+++ b/python/odroid-c1/2.7/slim/Dockerfile
@@ -114,5 +114,4 @@ RUN set -x \
 	&& rm -rf /usr/src/dbus-python
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
-
-
+ENV PYTHONPATH /usr/lib/python2.7/dist-packages

--- a/python/odroid-c1/2.7/wheezy/Dockerfile
+++ b/python/odroid-c1/2.7/wheezy/Dockerfile
@@ -86,5 +86,4 @@ RUN set -x \
 	&& rm -rf /usr/src/dbus-python
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
-
-
+ENV PYTHONPATH /usr/lib/python2.7/dist-packages

--- a/python/odroid-c1/3.2/Dockerfile
+++ b/python/odroid-c1/3.2/Dockerfile
@@ -95,3 +95,4 @@ RUN cd /usr/local/bin \
 	&& ln -sf python-config3 python-config
 	
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/odroid-c1/3.2/slim/Dockerfile
+++ b/python/odroid-c1/3.2/slim/Dockerfile
@@ -123,3 +123,4 @@ RUN cd /usr/local/bin \
 	&& ln -sf python-config3 python-config
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/odroid-c1/3.2/wheezy/Dockerfile
+++ b/python/odroid-c1/3.2/wheezy/Dockerfile
@@ -95,3 +95,4 @@ RUN cd /usr/local/bin \
 	&& ln -sf python-config3 python-config
 	
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/odroid-c1/3.3/Dockerfile
+++ b/python/odroid-c1/3.3/Dockerfile
@@ -95,3 +95,4 @@ RUN cd /usr/local/bin \
 	&& ln -sf python-config3 python-config
 	
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/odroid-c1/3.3/slim/Dockerfile
+++ b/python/odroid-c1/3.3/slim/Dockerfile
@@ -123,3 +123,4 @@ RUN cd /usr/local/bin \
 	&& ln -sf python-config3 python-config
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/odroid-c1/3.3/wheezy/Dockerfile
+++ b/python/odroid-c1/3.3/wheezy/Dockerfile
@@ -95,3 +95,4 @@ RUN cd /usr/local/bin \
 	&& ln -sf python-config3 python-config
 	
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/odroid-c1/3.4/Dockerfile
+++ b/python/odroid-c1/3.4/Dockerfile
@@ -95,3 +95,4 @@ RUN cd /usr/local/bin \
 	&& ln -sf python-config3 python-config
 	
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/odroid-c1/3.4/slim/Dockerfile
+++ b/python/odroid-c1/3.4/slim/Dockerfile
@@ -123,3 +123,4 @@ RUN cd /usr/local/bin \
 	&& ln -sf python-config3 python-config
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/odroid-c1/3.4/wheezy/Dockerfile
+++ b/python/odroid-c1/3.4/wheezy/Dockerfile
@@ -95,3 +95,4 @@ RUN cd /usr/local/bin \
 	&& ln -sf python-config3 python-config
 	
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/odroid-c1/3.5/Dockerfile
+++ b/python/odroid-c1/3.5/Dockerfile
@@ -95,3 +95,4 @@ RUN cd /usr/local/bin \
 	&& ln -sf python-config3 python-config
 	
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/odroid-c1/3.5/slim/Dockerfile
+++ b/python/odroid-c1/3.5/slim/Dockerfile
@@ -123,3 +123,4 @@ RUN cd /usr/local/bin \
 	&& ln -sf python-config3 python-config
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/odroid-c1/3.5/wheezy/Dockerfile
+++ b/python/odroid-c1/3.5/wheezy/Dockerfile
@@ -95,3 +95,4 @@ RUN cd /usr/local/bin \
 	&& ln -sf python-config3 python-config
 	
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/odroid-ux3/2.7/Dockerfile
+++ b/python/odroid-ux3/2.7/Dockerfile
@@ -86,5 +86,4 @@ RUN set -x \
 	&& rm -rf /usr/src/dbus-python
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
-
-
+ENV PYTHONPATH /usr/lib/python2.7/dist-packages

--- a/python/odroid-ux3/2.7/slim/Dockerfile
+++ b/python/odroid-ux3/2.7/slim/Dockerfile
@@ -114,5 +114,4 @@ RUN set -x \
 	&& rm -rf /usr/src/dbus-python
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
-
-
+ENV PYTHONPATH /usr/lib/python2.7/dist-packages

--- a/python/odroid-ux3/2.7/wheezy/Dockerfile
+++ b/python/odroid-ux3/2.7/wheezy/Dockerfile
@@ -86,5 +86,4 @@ RUN set -x \
 	&& rm -rf /usr/src/dbus-python
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
-
-
+ENV PYTHONPATH /usr/lib/python2.7/dist-packages

--- a/python/odroid-ux3/3.2/Dockerfile
+++ b/python/odroid-ux3/3.2/Dockerfile
@@ -95,3 +95,4 @@ RUN cd /usr/local/bin \
 	&& ln -sf python-config3 python-config
 	
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/odroid-ux3/3.2/slim/Dockerfile
+++ b/python/odroid-ux3/3.2/slim/Dockerfile
@@ -123,3 +123,4 @@ RUN cd /usr/local/bin \
 	&& ln -sf python-config3 python-config
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/odroid-ux3/3.2/wheezy/Dockerfile
+++ b/python/odroid-ux3/3.2/wheezy/Dockerfile
@@ -95,3 +95,4 @@ RUN cd /usr/local/bin \
 	&& ln -sf python-config3 python-config
 	
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/odroid-ux3/3.3/Dockerfile
+++ b/python/odroid-ux3/3.3/Dockerfile
@@ -95,3 +95,4 @@ RUN cd /usr/local/bin \
 	&& ln -sf python-config3 python-config
 	
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/odroid-ux3/3.3/slim/Dockerfile
+++ b/python/odroid-ux3/3.3/slim/Dockerfile
@@ -123,3 +123,4 @@ RUN cd /usr/local/bin \
 	&& ln -sf python-config3 python-config
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/odroid-ux3/3.3/wheezy/Dockerfile
+++ b/python/odroid-ux3/3.3/wheezy/Dockerfile
@@ -95,3 +95,4 @@ RUN cd /usr/local/bin \
 	&& ln -sf python-config3 python-config
 	
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/odroid-ux3/3.4/Dockerfile
+++ b/python/odroid-ux3/3.4/Dockerfile
@@ -95,3 +95,4 @@ RUN cd /usr/local/bin \
 	&& ln -sf python-config3 python-config
 	
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/odroid-ux3/3.4/slim/Dockerfile
+++ b/python/odroid-ux3/3.4/slim/Dockerfile
@@ -123,3 +123,4 @@ RUN cd /usr/local/bin \
 	&& ln -sf python-config3 python-config
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/odroid-ux3/3.4/wheezy/Dockerfile
+++ b/python/odroid-ux3/3.4/wheezy/Dockerfile
@@ -95,3 +95,4 @@ RUN cd /usr/local/bin \
 	&& ln -sf python-config3 python-config
 	
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/odroid-ux3/3.5/Dockerfile
+++ b/python/odroid-ux3/3.5/Dockerfile
@@ -95,3 +95,4 @@ RUN cd /usr/local/bin \
 	&& ln -sf python-config3 python-config
 	
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/odroid-ux3/3.5/slim/Dockerfile
+++ b/python/odroid-ux3/3.5/slim/Dockerfile
@@ -123,3 +123,4 @@ RUN cd /usr/local/bin \
 	&& ln -sf python-config3 python-config
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/odroid-ux3/3.5/wheezy/Dockerfile
+++ b/python/odroid-ux3/3.5/wheezy/Dockerfile
@@ -95,3 +95,4 @@ RUN cd /usr/local/bin \
 	&& ln -sf python-config3 python-config
 	
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/parallella-hdmi-resin/2.7/Dockerfile
+++ b/python/parallella-hdmi-resin/2.7/Dockerfile
@@ -86,5 +86,4 @@ RUN set -x \
 	&& rm -rf /usr/src/dbus-python
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
-
-
+ENV PYTHONPATH /usr/lib/python2.7/dist-packages

--- a/python/parallella-hdmi-resin/2.7/slim/Dockerfile
+++ b/python/parallella-hdmi-resin/2.7/slim/Dockerfile
@@ -114,5 +114,4 @@ RUN set -x \
 	&& rm -rf /usr/src/dbus-python
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
-
-
+ENV PYTHONPATH /usr/lib/python2.7/dist-packages

--- a/python/parallella-hdmi-resin/2.7/wheezy/Dockerfile
+++ b/python/parallella-hdmi-resin/2.7/wheezy/Dockerfile
@@ -86,5 +86,4 @@ RUN set -x \
 	&& rm -rf /usr/src/dbus-python
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
-
-
+ENV PYTHONPATH /usr/lib/python2.7/dist-packages

--- a/python/parallella-hdmi-resin/3.2/Dockerfile
+++ b/python/parallella-hdmi-resin/3.2/Dockerfile
@@ -95,3 +95,4 @@ RUN cd /usr/local/bin \
 	&& ln -sf python-config3 python-config
 	
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/parallella-hdmi-resin/3.2/slim/Dockerfile
+++ b/python/parallella-hdmi-resin/3.2/slim/Dockerfile
@@ -123,3 +123,4 @@ RUN cd /usr/local/bin \
 	&& ln -sf python-config3 python-config
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/parallella-hdmi-resin/3.2/wheezy/Dockerfile
+++ b/python/parallella-hdmi-resin/3.2/wheezy/Dockerfile
@@ -95,3 +95,4 @@ RUN cd /usr/local/bin \
 	&& ln -sf python-config3 python-config
 	
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/parallella-hdmi-resin/3.3/Dockerfile
+++ b/python/parallella-hdmi-resin/3.3/Dockerfile
@@ -95,3 +95,4 @@ RUN cd /usr/local/bin \
 	&& ln -sf python-config3 python-config
 	
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/parallella-hdmi-resin/3.3/slim/Dockerfile
+++ b/python/parallella-hdmi-resin/3.3/slim/Dockerfile
@@ -123,3 +123,4 @@ RUN cd /usr/local/bin \
 	&& ln -sf python-config3 python-config
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/parallella-hdmi-resin/3.3/wheezy/Dockerfile
+++ b/python/parallella-hdmi-resin/3.3/wheezy/Dockerfile
@@ -95,3 +95,4 @@ RUN cd /usr/local/bin \
 	&& ln -sf python-config3 python-config
 	
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/parallella-hdmi-resin/3.4/Dockerfile
+++ b/python/parallella-hdmi-resin/3.4/Dockerfile
@@ -95,3 +95,4 @@ RUN cd /usr/local/bin \
 	&& ln -sf python-config3 python-config
 	
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/parallella-hdmi-resin/3.4/slim/Dockerfile
+++ b/python/parallella-hdmi-resin/3.4/slim/Dockerfile
@@ -123,3 +123,4 @@ RUN cd /usr/local/bin \
 	&& ln -sf python-config3 python-config
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/parallella-hdmi-resin/3.4/wheezy/Dockerfile
+++ b/python/parallella-hdmi-resin/3.4/wheezy/Dockerfile
@@ -95,3 +95,4 @@ RUN cd /usr/local/bin \
 	&& ln -sf python-config3 python-config
 	
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/parallella-hdmi-resin/3.5/Dockerfile
+++ b/python/parallella-hdmi-resin/3.5/Dockerfile
@@ -95,3 +95,4 @@ RUN cd /usr/local/bin \
 	&& ln -sf python-config3 python-config
 	
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/parallella-hdmi-resin/3.5/slim/Dockerfile
+++ b/python/parallella-hdmi-resin/3.5/slim/Dockerfile
@@ -123,3 +123,4 @@ RUN cd /usr/local/bin \
 	&& ln -sf python-config3 python-config
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/parallella-hdmi-resin/3.5/wheezy/Dockerfile
+++ b/python/parallella-hdmi-resin/3.5/wheezy/Dockerfile
@@ -95,3 +95,4 @@ RUN cd /usr/local/bin \
 	&& ln -sf python-config3 python-config
 	
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/raspberrypi/2.7/Dockerfile
+++ b/python/raspberrypi/2.7/Dockerfile
@@ -86,5 +86,4 @@ RUN set -x \
 	&& rm -rf /usr/src/dbus-python
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
-
-
+ENV PYTHONPATH /usr/lib/python2.7/dist-packages

--- a/python/raspberrypi/2.7/slim/Dockerfile
+++ b/python/raspberrypi/2.7/slim/Dockerfile
@@ -114,5 +114,4 @@ RUN set -x \
 	&& rm -rf /usr/src/dbus-python
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
-
-
+ENV PYTHONPATH /usr/lib/python2.7/dist-packages

--- a/python/raspberrypi/2.7/wheezy/Dockerfile
+++ b/python/raspberrypi/2.7/wheezy/Dockerfile
@@ -86,5 +86,4 @@ RUN set -x \
 	&& rm -rf /usr/src/dbus-python
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
-
-
+ENV PYTHONPATH /usr/lib/python2.7/dist-packages

--- a/python/raspberrypi/3.2/Dockerfile
+++ b/python/raspberrypi/3.2/Dockerfile
@@ -95,3 +95,4 @@ RUN cd /usr/local/bin \
 	&& ln -sf python-config3 python-config
 	
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/raspberrypi/3.2/slim/Dockerfile
+++ b/python/raspberrypi/3.2/slim/Dockerfile
@@ -123,3 +123,4 @@ RUN cd /usr/local/bin \
 	&& ln -sf python-config3 python-config
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/raspberrypi/3.2/wheezy/Dockerfile
+++ b/python/raspberrypi/3.2/wheezy/Dockerfile
@@ -95,3 +95,4 @@ RUN cd /usr/local/bin \
 	&& ln -sf python-config3 python-config
 	
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/raspberrypi/3.3/Dockerfile
+++ b/python/raspberrypi/3.3/Dockerfile
@@ -95,3 +95,4 @@ RUN cd /usr/local/bin \
 	&& ln -sf python-config3 python-config
 	
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/raspberrypi/3.3/slim/Dockerfile
+++ b/python/raspberrypi/3.3/slim/Dockerfile
@@ -123,3 +123,4 @@ RUN cd /usr/local/bin \
 	&& ln -sf python-config3 python-config
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/raspberrypi/3.3/wheezy/Dockerfile
+++ b/python/raspberrypi/3.3/wheezy/Dockerfile
@@ -95,3 +95,4 @@ RUN cd /usr/local/bin \
 	&& ln -sf python-config3 python-config
 	
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/raspberrypi/3.4/Dockerfile
+++ b/python/raspberrypi/3.4/Dockerfile
@@ -95,3 +95,4 @@ RUN cd /usr/local/bin \
 	&& ln -sf python-config3 python-config
 	
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/raspberrypi/3.4/slim/Dockerfile
+++ b/python/raspberrypi/3.4/slim/Dockerfile
@@ -123,3 +123,4 @@ RUN cd /usr/local/bin \
 	&& ln -sf python-config3 python-config
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/raspberrypi/3.4/wheezy/Dockerfile
+++ b/python/raspberrypi/3.4/wheezy/Dockerfile
@@ -95,3 +95,4 @@ RUN cd /usr/local/bin \
 	&& ln -sf python-config3 python-config
 	
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/raspberrypi/3.5/Dockerfile
+++ b/python/raspberrypi/3.5/Dockerfile
@@ -95,3 +95,4 @@ RUN cd /usr/local/bin \
 	&& ln -sf python-config3 python-config
 	
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/raspberrypi/3.5/slim/Dockerfile
+++ b/python/raspberrypi/3.5/slim/Dockerfile
@@ -123,3 +123,4 @@ RUN cd /usr/local/bin \
 	&& ln -sf python-config3 python-config
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/raspberrypi/3.5/wheezy/Dockerfile
+++ b/python/raspberrypi/3.5/wheezy/Dockerfile
@@ -95,3 +95,4 @@ RUN cd /usr/local/bin \
 	&& ln -sf python-config3 python-config
 	
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/raspberrypi2/2.7/Dockerfile
+++ b/python/raspberrypi2/2.7/Dockerfile
@@ -86,5 +86,4 @@ RUN set -x \
 	&& rm -rf /usr/src/dbus-python
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
-
-
+ENV PYTHONPATH /usr/lib/python2.7/dist-packages

--- a/python/raspberrypi2/2.7/slim/Dockerfile
+++ b/python/raspberrypi2/2.7/slim/Dockerfile
@@ -114,5 +114,4 @@ RUN set -x \
 	&& rm -rf /usr/src/dbus-python
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
-
-
+ENV PYTHONPATH /usr/lib/python2.7/dist-packages

--- a/python/raspberrypi2/2.7/wheezy/Dockerfile
+++ b/python/raspberrypi2/2.7/wheezy/Dockerfile
@@ -86,5 +86,4 @@ RUN set -x \
 	&& rm -rf /usr/src/dbus-python
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
-
-
+ENV PYTHONPATH /usr/lib/python2.7/dist-packages

--- a/python/raspberrypi2/3.2/Dockerfile
+++ b/python/raspberrypi2/3.2/Dockerfile
@@ -95,3 +95,4 @@ RUN cd /usr/local/bin \
 	&& ln -sf python-config3 python-config
 	
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/raspberrypi2/3.2/slim/Dockerfile
+++ b/python/raspberrypi2/3.2/slim/Dockerfile
@@ -123,3 +123,4 @@ RUN cd /usr/local/bin \
 	&& ln -sf python-config3 python-config
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/raspberrypi2/3.2/wheezy/Dockerfile
+++ b/python/raspberrypi2/3.2/wheezy/Dockerfile
@@ -95,3 +95,4 @@ RUN cd /usr/local/bin \
 	&& ln -sf python-config3 python-config
 	
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/raspberrypi2/3.3/Dockerfile
+++ b/python/raspberrypi2/3.3/Dockerfile
@@ -95,3 +95,4 @@ RUN cd /usr/local/bin \
 	&& ln -sf python-config3 python-config
 	
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/raspberrypi2/3.3/slim/Dockerfile
+++ b/python/raspberrypi2/3.3/slim/Dockerfile
@@ -123,3 +123,4 @@ RUN cd /usr/local/bin \
 	&& ln -sf python-config3 python-config
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/raspberrypi2/3.3/wheezy/Dockerfile
+++ b/python/raspberrypi2/3.3/wheezy/Dockerfile
@@ -95,3 +95,4 @@ RUN cd /usr/local/bin \
 	&& ln -sf python-config3 python-config
 	
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/raspberrypi2/3.4/Dockerfile
+++ b/python/raspberrypi2/3.4/Dockerfile
@@ -95,3 +95,4 @@ RUN cd /usr/local/bin \
 	&& ln -sf python-config3 python-config
 	
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/raspberrypi2/3.4/slim/Dockerfile
+++ b/python/raspberrypi2/3.4/slim/Dockerfile
@@ -123,3 +123,4 @@ RUN cd /usr/local/bin \
 	&& ln -sf python-config3 python-config
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/raspberrypi2/3.4/wheezy/Dockerfile
+++ b/python/raspberrypi2/3.4/wheezy/Dockerfile
@@ -95,3 +95,4 @@ RUN cd /usr/local/bin \
 	&& ln -sf python-config3 python-config
 	
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/raspberrypi2/3.5/Dockerfile
+++ b/python/raspberrypi2/3.5/Dockerfile
@@ -95,3 +95,4 @@ RUN cd /usr/local/bin \
 	&& ln -sf python-config3 python-config
 	
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/raspberrypi2/3.5/slim/Dockerfile
+++ b/python/raspberrypi2/3.5/slim/Dockerfile
@@ -123,3 +123,4 @@ RUN cd /usr/local/bin \
 	&& ln -sf python-config3 python-config
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/raspberrypi2/3.5/wheezy/Dockerfile
+++ b/python/raspberrypi2/3.5/wheezy/Dockerfile
@@ -95,3 +95,4 @@ RUN cd /usr/local/bin \
 	&& ln -sf python-config3 python-config
 	
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/setup.sh
+++ b/python/setup.sh
@@ -16,7 +16,7 @@ set -x \
 && cd mraa \
 && git checkout $MRAA_COMMIT \
 && mkdir build && cd build \
-&& cmake .. -DBUILDSWIGNODE=OFF -DBUILDPYTHON3=ON -DPYTHON_INCLUDE_DIR=/usr/local/include/python3.5m/ -DPYTHON_LIBRARY=/usr/local/lib/libpython3.so \
+&& cmake .. #{ARGS} \
 && make -j $(nproc) \
 && make install \
 && apt-get purge -y --auto-remove $buildDeps \

--- a/python/ts4900/2.7/Dockerfile
+++ b/python/ts4900/2.7/Dockerfile
@@ -86,5 +86,4 @@ RUN set -x \
 	&& rm -rf /usr/src/dbus-python
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
-
-
+ENV PYTHONPATH /usr/lib/python2.7/dist-packages

--- a/python/ts4900/2.7/slim/Dockerfile
+++ b/python/ts4900/2.7/slim/Dockerfile
@@ -114,5 +114,4 @@ RUN set -x \
 	&& rm -rf /usr/src/dbus-python
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
-
-
+ENV PYTHONPATH /usr/lib/python2.7/dist-packages

--- a/python/ts4900/2.7/wheezy/Dockerfile
+++ b/python/ts4900/2.7/wheezy/Dockerfile
@@ -86,5 +86,4 @@ RUN set -x \
 	&& rm -rf /usr/src/dbus-python
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
-
-
+ENV PYTHONPATH /usr/lib/python2.7/dist-packages

--- a/python/ts4900/3.2/Dockerfile
+++ b/python/ts4900/3.2/Dockerfile
@@ -95,3 +95,4 @@ RUN cd /usr/local/bin \
 	&& ln -sf python-config3 python-config
 	
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/ts4900/3.2/slim/Dockerfile
+++ b/python/ts4900/3.2/slim/Dockerfile
@@ -123,3 +123,4 @@ RUN cd /usr/local/bin \
 	&& ln -sf python-config3 python-config
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/ts4900/3.2/wheezy/Dockerfile
+++ b/python/ts4900/3.2/wheezy/Dockerfile
@@ -95,3 +95,4 @@ RUN cd /usr/local/bin \
 	&& ln -sf python-config3 python-config
 	
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/ts4900/3.3/Dockerfile
+++ b/python/ts4900/3.3/Dockerfile
@@ -95,3 +95,4 @@ RUN cd /usr/local/bin \
 	&& ln -sf python-config3 python-config
 	
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/ts4900/3.3/slim/Dockerfile
+++ b/python/ts4900/3.3/slim/Dockerfile
@@ -123,3 +123,4 @@ RUN cd /usr/local/bin \
 	&& ln -sf python-config3 python-config
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/ts4900/3.3/wheezy/Dockerfile
+++ b/python/ts4900/3.3/wheezy/Dockerfile
@@ -95,3 +95,4 @@ RUN cd /usr/local/bin \
 	&& ln -sf python-config3 python-config
 	
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/ts4900/3.4/Dockerfile
+++ b/python/ts4900/3.4/Dockerfile
@@ -95,3 +95,4 @@ RUN cd /usr/local/bin \
 	&& ln -sf python-config3 python-config
 	
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/ts4900/3.4/slim/Dockerfile
+++ b/python/ts4900/3.4/slim/Dockerfile
@@ -123,3 +123,4 @@ RUN cd /usr/local/bin \
 	&& ln -sf python-config3 python-config
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/ts4900/3.4/wheezy/Dockerfile
+++ b/python/ts4900/3.4/wheezy/Dockerfile
@@ -95,3 +95,4 @@ RUN cd /usr/local/bin \
 	&& ln -sf python-config3 python-config
 	
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/ts4900/3.5/Dockerfile
+++ b/python/ts4900/3.5/Dockerfile
@@ -95,3 +95,4 @@ RUN cd /usr/local/bin \
 	&& ln -sf python-config3 python-config
 	
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/ts4900/3.5/slim/Dockerfile
+++ b/python/ts4900/3.5/slim/Dockerfile
@@ -123,3 +123,4 @@ RUN cd /usr/local/bin \
 	&& ln -sf python-config3 python-config
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/ts4900/3.5/wheezy/Dockerfile
+++ b/python/ts4900/3.5/wheezy/Dockerfile
@@ -95,3 +95,4 @@ RUN cd /usr/local/bin \
 	&& ln -sf python-config3 python-config
 	
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/vab820-quad/2.7/Dockerfile
+++ b/python/vab820-quad/2.7/Dockerfile
@@ -86,5 +86,4 @@ RUN set -x \
 	&& rm -rf /usr/src/dbus-python
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
-
-
+ENV PYTHONPATH /usr/lib/python2.7/dist-packages

--- a/python/vab820-quad/2.7/slim/Dockerfile
+++ b/python/vab820-quad/2.7/slim/Dockerfile
@@ -114,5 +114,4 @@ RUN set -x \
 	&& rm -rf /usr/src/dbus-python
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
-
-
+ENV PYTHONPATH /usr/lib/python2.7/dist-packages

--- a/python/vab820-quad/2.7/wheezy/Dockerfile
+++ b/python/vab820-quad/2.7/wheezy/Dockerfile
@@ -86,5 +86,4 @@ RUN set -x \
 	&& rm -rf /usr/src/dbus-python
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
-
-
+ENV PYTHONPATH /usr/lib/python2.7/dist-packages

--- a/python/vab820-quad/3.2/Dockerfile
+++ b/python/vab820-quad/3.2/Dockerfile
@@ -95,3 +95,4 @@ RUN cd /usr/local/bin \
 	&& ln -sf python-config3 python-config
 	
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/vab820-quad/3.2/slim/Dockerfile
+++ b/python/vab820-quad/3.2/slim/Dockerfile
@@ -123,3 +123,4 @@ RUN cd /usr/local/bin \
 	&& ln -sf python-config3 python-config
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/vab820-quad/3.2/wheezy/Dockerfile
+++ b/python/vab820-quad/3.2/wheezy/Dockerfile
@@ -95,3 +95,4 @@ RUN cd /usr/local/bin \
 	&& ln -sf python-config3 python-config
 	
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/vab820-quad/3.3/Dockerfile
+++ b/python/vab820-quad/3.3/Dockerfile
@@ -95,3 +95,4 @@ RUN cd /usr/local/bin \
 	&& ln -sf python-config3 python-config
 	
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/vab820-quad/3.3/slim/Dockerfile
+++ b/python/vab820-quad/3.3/slim/Dockerfile
@@ -123,3 +123,4 @@ RUN cd /usr/local/bin \
 	&& ln -sf python-config3 python-config
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/vab820-quad/3.3/wheezy/Dockerfile
+++ b/python/vab820-quad/3.3/wheezy/Dockerfile
@@ -95,3 +95,4 @@ RUN cd /usr/local/bin \
 	&& ln -sf python-config3 python-config
 	
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/vab820-quad/3.4/Dockerfile
+++ b/python/vab820-quad/3.4/Dockerfile
@@ -95,3 +95,4 @@ RUN cd /usr/local/bin \
 	&& ln -sf python-config3 python-config
 	
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/vab820-quad/3.4/slim/Dockerfile
+++ b/python/vab820-quad/3.4/slim/Dockerfile
@@ -123,3 +123,4 @@ RUN cd /usr/local/bin \
 	&& ln -sf python-config3 python-config
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/vab820-quad/3.4/wheezy/Dockerfile
+++ b/python/vab820-quad/3.4/wheezy/Dockerfile
@@ -95,3 +95,4 @@ RUN cd /usr/local/bin \
 	&& ln -sf python-config3 python-config
 	
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/vab820-quad/3.5/Dockerfile
+++ b/python/vab820-quad/3.5/Dockerfile
@@ -95,3 +95,4 @@ RUN cd /usr/local/bin \
 	&& ln -sf python-config3 python-config
 	
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/vab820-quad/3.5/slim/Dockerfile
+++ b/python/vab820-quad/3.5/slim/Dockerfile
@@ -123,3 +123,4 @@ RUN cd /usr/local/bin \
 	&& ln -sf python-config3 python-config
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/vab820-quad/3.5/wheezy/Dockerfile
+++ b/python/vab820-quad/3.5/wheezy/Dockerfile
@@ -95,3 +95,4 @@ RUN cd /usr/local/bin \
 	&& ln -sf python-config3 python-config
 	
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/zc702-zynq7/2.7/Dockerfile
+++ b/python/zc702-zynq7/2.7/Dockerfile
@@ -86,5 +86,4 @@ RUN set -x \
 	&& rm -rf /usr/src/dbus-python
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
-
-
+ENV PYTHONPATH /usr/lib/python2.7/dist-packages

--- a/python/zc702-zynq7/2.7/slim/Dockerfile
+++ b/python/zc702-zynq7/2.7/slim/Dockerfile
@@ -114,5 +114,4 @@ RUN set -x \
 	&& rm -rf /usr/src/dbus-python
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
-
-
+ENV PYTHONPATH /usr/lib/python2.7/dist-packages

--- a/python/zc702-zynq7/2.7/wheezy/Dockerfile
+++ b/python/zc702-zynq7/2.7/wheezy/Dockerfile
@@ -86,5 +86,4 @@ RUN set -x \
 	&& rm -rf /usr/src/dbus-python
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
-
-
+ENV PYTHONPATH /usr/lib/python2.7/dist-packages

--- a/python/zc702-zynq7/3.2/Dockerfile
+++ b/python/zc702-zynq7/3.2/Dockerfile
@@ -95,3 +95,4 @@ RUN cd /usr/local/bin \
 	&& ln -sf python-config3 python-config
 	
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/zc702-zynq7/3.2/slim/Dockerfile
+++ b/python/zc702-zynq7/3.2/slim/Dockerfile
@@ -123,3 +123,4 @@ RUN cd /usr/local/bin \
 	&& ln -sf python-config3 python-config
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/zc702-zynq7/3.2/wheezy/Dockerfile
+++ b/python/zc702-zynq7/3.2/wheezy/Dockerfile
@@ -95,3 +95,4 @@ RUN cd /usr/local/bin \
 	&& ln -sf python-config3 python-config
 	
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/zc702-zynq7/3.3/Dockerfile
+++ b/python/zc702-zynq7/3.3/Dockerfile
@@ -95,3 +95,4 @@ RUN cd /usr/local/bin \
 	&& ln -sf python-config3 python-config
 	
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/zc702-zynq7/3.3/slim/Dockerfile
+++ b/python/zc702-zynq7/3.3/slim/Dockerfile
@@ -123,3 +123,4 @@ RUN cd /usr/local/bin \
 	&& ln -sf python-config3 python-config
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/zc702-zynq7/3.3/wheezy/Dockerfile
+++ b/python/zc702-zynq7/3.3/wheezy/Dockerfile
@@ -95,3 +95,4 @@ RUN cd /usr/local/bin \
 	&& ln -sf python-config3 python-config
 	
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/zc702-zynq7/3.4/Dockerfile
+++ b/python/zc702-zynq7/3.4/Dockerfile
@@ -95,3 +95,4 @@ RUN cd /usr/local/bin \
 	&& ln -sf python-config3 python-config
 	
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/zc702-zynq7/3.4/slim/Dockerfile
+++ b/python/zc702-zynq7/3.4/slim/Dockerfile
@@ -123,3 +123,4 @@ RUN cd /usr/local/bin \
 	&& ln -sf python-config3 python-config
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/zc702-zynq7/3.4/wheezy/Dockerfile
+++ b/python/zc702-zynq7/3.4/wheezy/Dockerfile
@@ -95,3 +95,4 @@ RUN cd /usr/local/bin \
 	&& ln -sf python-config3 python-config
 	
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/zc702-zynq7/3.5/Dockerfile
+++ b/python/zc702-zynq7/3.5/Dockerfile
@@ -95,3 +95,4 @@ RUN cd /usr/local/bin \
 	&& ln -sf python-config3 python-config
 	
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/zc702-zynq7/3.5/slim/Dockerfile
+++ b/python/zc702-zynq7/3.5/slim/Dockerfile
@@ -123,3 +123,4 @@ RUN cd /usr/local/bin \
 	&& ln -sf python-config3 python-config
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
+ENV PYTHONPATH /usr/lib/python3/dist-packages

--- a/python/zc702-zynq7/3.5/wheezy/Dockerfile
+++ b/python/zc702-zynq7/3.5/wheezy/Dockerfile
@@ -95,3 +95,4 @@ RUN cd /usr/local/bin \
 	&& ln -sf python-config3 python-config
 	
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/#/pages/using/dockerfile.md"]
+ENV PYTHONPATH /usr/lib/python3/dist-packages


### PR DESCRIPTION
Debian Python packages reside at `/usr/lib/python2.7/dist-packages` (Python2) or `/usr/lib/python3/dist-packages` (Python3) while compiled Python resides at `/usr/local/bin/python/` and packages installed at `/usr/local/python<version>/site-packages`. This means compiled Python cant access Debian Python packages.
This can be resolved by setting PYTHONPATH env variable to point to `dist-packages`.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/resin-io-library/base-images/44)
<!-- Reviewable:end -->
