### PR TITLE
 Mount devtmpfs _over_ /dev/pts.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## 2015-11-18
+
+### Changed
+
+- Mount devtmpfs _over_ `/dev/pts` to avoid `/dev/ptmx` misbehaving and . See commit
+  message for more gory details.
+
 ## 2015-11-13
 
 ### Changed

--- a/systemd/amd64/jessie/entry.sh
+++ b/systemd/amd64/jessie/entry.sh
@@ -5,14 +5,15 @@ echo $HOSTNAME > /etc/hostname
 echo "127.0.1.1 $HOSTNAME" >> /etc/hosts
 hostname $HOSTNAME
 
-mkdir -p /tmp
+mkdir -p /tmp/pts
+mount --move /dev/pts /tmp/pts
+
 mount -t devtmpfs none /tmp
+
 mkdir -p /tmp/shm
 mount --move /dev/shm /tmp/shm
 mkdir -p /tmp/mqueue
 mount --move /dev/mqueue /tmp/mqueue
-mkdir -p /tmp/pts
-mount --move /dev/pts /tmp/pts
 touch /tmp/console
 mount --move /dev/console /tmp/console
 umount /dev || true
@@ -34,9 +35,9 @@ if [ "$INITSYSTEM" = "on" ]; then
 
 	exec /sbin/init quiet
 else
-	udevd & 
+	udevd &
 	udevadm trigger &> /dev/null
-	
+
 	CMD=$(which $1)
 	shift
 	exec "$CMD" "$@"

--- a/systemd/amd64/wheezy/entry.sh
+++ b/systemd/amd64/wheezy/entry.sh
@@ -5,22 +5,23 @@ echo $HOSTNAME > /etc/hostname
 echo "127.0.1.1 $HOSTNAME" >> /etc/hosts
 hostname $HOSTNAME
 
-mkdir -p /tmp
+mkdir -p /tmp/pts
+mount --move /dev/pts /tmp/pts
+
 mount -t devtmpfs none /tmp
+
 mkdir -p /tmp/shm
 mount --move /dev/shm /tmp/shm
 mkdir -p /tmp/mqueue
 mount --move /dev/mqueue /tmp/mqueue
-mkdir -p /tmp/pts
-mount --move /dev/pts /tmp/pts
 touch /tmp/console
 mount --move /dev/console /tmp/console
 umount /dev || true
 mount --move /tmp /dev
 mount -t debugfs nodev /sys/kernel/debug
-udevd & 
+udevd &
 udevadm trigger &> /dev/null
-	
+
 CMD=$(which $1)
 shift
 exec "$CMD" "$@"

--- a/systemd/armv7hf/jessie/entry.sh
+++ b/systemd/armv7hf/jessie/entry.sh
@@ -5,14 +5,15 @@ echo $HOSTNAME > /etc/hostname
 echo "127.0.1.1 $HOSTNAME" >> /etc/hosts
 hostname $HOSTNAME
 
-mkdir -p /tmp
+mkdir -p /tmp/pts
+mount --move /dev/pts /tmp/pts
+
 mount -t devtmpfs none /tmp
+
 mkdir -p /tmp/shm
 mount --move /dev/shm /tmp/shm
 mkdir -p /tmp/mqueue
 mount --move /dev/mqueue /tmp/mqueue
-mkdir -p /tmp/pts
-mount --move /dev/pts /tmp/pts
 touch /tmp/console
 mount --move /dev/console /tmp/console
 umount /dev || true
@@ -34,9 +35,9 @@ if [ "$INITSYSTEM" = "on" ]; then
 
 	exec /sbin/init quiet
 else
-	udevd & 
+	udevd &
 	udevadm trigger &> /dev/null
-	
+
 	CMD=$(which $1)
 	shift
 	exec "$CMD" "$@"

--- a/systemd/armv7hf/sid/entry.sh
+++ b/systemd/armv7hf/sid/entry.sh
@@ -5,14 +5,15 @@ echo $HOSTNAME > /etc/hostname
 echo "127.0.1.1 $HOSTNAME" >> /etc/hosts
 hostname $HOSTNAME
 
-mkdir -p /tmp
+mkdir -p /tmp/pts
+mount --move /dev/pts /tmp/pts
+
 mount -t devtmpfs none /tmp
+
 mkdir -p /tmp/shm
 mount --move /dev/shm /tmp/shm
 mkdir -p /tmp/mqueue
 mount --move /dev/mqueue /tmp/mqueue
-mkdir -p /tmp/pts
-mount --move /dev/pts /tmp/pts
 touch /tmp/console
 mount --move /dev/console /tmp/console
 umount /dev || true
@@ -34,9 +35,9 @@ if [ "$INITSYSTEM" = "on" ]; then
 
 	exec /sbin/init quiet
 else
-	udevd & 
+	udevd &
 	udevadm trigger &> /dev/null
-	
+
 	CMD=$(which $1)
 	shift
 	exec "$CMD" "$@"

--- a/systemd/armv7hf/wheezy/entry.sh
+++ b/systemd/armv7hf/wheezy/entry.sh
@@ -5,22 +5,23 @@ echo $HOSTNAME > /etc/hostname
 echo "127.0.1.1 $HOSTNAME" >> /etc/hosts
 hostname $HOSTNAME
 
-mkdir -p /tmp
+mkdir -p /tmp/pts
+mount --move /dev/pts /tmp/pts
+
 mount -t devtmpfs none /tmp
+
 mkdir -p /tmp/shm
 mount --move /dev/shm /tmp/shm
 mkdir -p /tmp/mqueue
 mount --move /dev/mqueue /tmp/mqueue
-mkdir -p /tmp/pts
-mount --move /dev/pts /tmp/pts
 touch /tmp/console
 mount --move /dev/console /tmp/console
 umount /dev || true
 mount --move /tmp /dev
 mount -t debugfs nodev /sys/kernel/debug
-udevd & 
+udevd &
 udevadm trigger &> /dev/null
-	
+
 CMD=$(which $1)
 shift
 exec "$CMD" "$@"

--- a/systemd/entry-nosystemd.sh
+++ b/systemd/entry-nosystemd.sh
@@ -5,22 +5,23 @@ echo $HOSTNAME > /etc/hostname
 echo "127.0.1.1 $HOSTNAME" >> /etc/hosts
 hostname $HOSTNAME
 
-mkdir -p /tmp
+mkdir -p /tmp/pts
+mount --move /dev/pts /tmp/pts
+
 mount -t devtmpfs none /tmp
+
 mkdir -p /tmp/shm
 mount --move /dev/shm /tmp/shm
 mkdir -p /tmp/mqueue
 mount --move /dev/mqueue /tmp/mqueue
-mkdir -p /tmp/pts
-mount --move /dev/pts /tmp/pts
 touch /tmp/console
 mount --move /dev/console /tmp/console
 umount /dev || true
 mount --move /tmp /dev
 mount -t debugfs nodev /sys/kernel/debug
-udevd & 
+udevd &
 udevadm trigger &> /dev/null
-	
+
 CMD=$(which $1)
 shift
 exec "$CMD" "$@"

--- a/systemd/entry.sh
+++ b/systemd/entry.sh
@@ -5,14 +5,15 @@ echo $HOSTNAME > /etc/hostname
 echo "127.0.1.1 $HOSTNAME" >> /etc/hosts
 hostname $HOSTNAME
 
-mkdir -p /tmp
+mkdir -p /tmp/pts
+mount --move /dev/pts /tmp/pts
+
 mount -t devtmpfs none /tmp
+
 mkdir -p /tmp/shm
 mount --move /dev/shm /tmp/shm
 mkdir -p /tmp/mqueue
 mount --move /dev/mqueue /tmp/mqueue
-mkdir -p /tmp/pts
-mount --move /dev/pts /tmp/pts
 touch /tmp/console
 mount --move /dev/console /tmp/console
 umount /dev || true
@@ -34,9 +35,9 @@ if [ "$INITSYSTEM" = "on" ]; then
 
 	exec /sbin/init quiet
 else
-	udevd & 
+	udevd &
 	udevadm trigger &> /dev/null
-	
+
 	CMD=$(which $1)
 	shift
 	exec "$CMD" "$@"

--- a/systemd/i386/jessie/entry.sh
+++ b/systemd/i386/jessie/entry.sh
@@ -5,14 +5,15 @@ echo $HOSTNAME > /etc/hostname
 echo "127.0.1.1 $HOSTNAME" >> /etc/hosts
 hostname $HOSTNAME
 
-mkdir -p /tmp
+mkdir -p /tmp/pts
+mount --move /dev/pts /tmp/pts
+
 mount -t devtmpfs none /tmp
+
 mkdir -p /tmp/shm
 mount --move /dev/shm /tmp/shm
 mkdir -p /tmp/mqueue
 mount --move /dev/mqueue /tmp/mqueue
-mkdir -p /tmp/pts
-mount --move /dev/pts /tmp/pts
 touch /tmp/console
 mount --move /dev/console /tmp/console
 umount /dev || true
@@ -34,9 +35,9 @@ if [ "$INITSYSTEM" = "on" ]; then
 
 	exec /sbin/init quiet
 else
-	udevd & 
+	udevd &
 	udevadm trigger &> /dev/null
-	
+
 	CMD=$(which $1)
 	shift
 	exec "$CMD" "$@"

--- a/systemd/i386/wheezy/entry.sh
+++ b/systemd/i386/wheezy/entry.sh
@@ -5,22 +5,23 @@ echo $HOSTNAME > /etc/hostname
 echo "127.0.1.1 $HOSTNAME" >> /etc/hosts
 hostname $HOSTNAME
 
-mkdir -p /tmp
+mkdir -p /tmp/pts
+mount --move /dev/pts /tmp/pts
+
 mount -t devtmpfs none /tmp
+
 mkdir -p /tmp/shm
 mount --move /dev/shm /tmp/shm
 mkdir -p /tmp/mqueue
 mount --move /dev/mqueue /tmp/mqueue
-mkdir -p /tmp/pts
-mount --move /dev/pts /tmp/pts
 touch /tmp/console
 mount --move /dev/console /tmp/console
 umount /dev || true
 mount --move /tmp /dev
 mount -t debugfs nodev /sys/kernel/debug
-udevd & 
+udevd &
 udevadm trigger &> /dev/null
-	
+
 CMD=$(which $1)
 shift
 exec "$CMD" "$@"

--- a/systemd/rpi/jessie/entry.sh
+++ b/systemd/rpi/jessie/entry.sh
@@ -5,14 +5,15 @@ echo $HOSTNAME > /etc/hostname
 echo "127.0.1.1 $HOSTNAME" >> /etc/hosts
 hostname $HOSTNAME
 
-mkdir -p /tmp
+mkdir -p /tmp/pts
+mount --move /dev/pts /tmp/pts
+
 mount -t devtmpfs none /tmp
+
 mkdir -p /tmp/shm
 mount --move /dev/shm /tmp/shm
 mkdir -p /tmp/mqueue
 mount --move /dev/mqueue /tmp/mqueue
-mkdir -p /tmp/pts
-mount --move /dev/pts /tmp/pts
 touch /tmp/console
 mount --move /dev/console /tmp/console
 umount /dev || true
@@ -34,9 +35,9 @@ if [ "$INITSYSTEM" = "on" ]; then
 
 	exec /sbin/init quiet
 else
-	udevd & 
+	udevd &
 	udevadm trigger &> /dev/null
-	
+
 	CMD=$(which $1)
 	shift
 	exec "$CMD" "$@"

--- a/systemd/rpi/wheezy/entry.sh
+++ b/systemd/rpi/wheezy/entry.sh
@@ -5,22 +5,23 @@ echo $HOSTNAME > /etc/hostname
 echo "127.0.1.1 $HOSTNAME" >> /etc/hosts
 hostname $HOSTNAME
 
-mkdir -p /tmp
+mkdir -p /tmp/pts
+mount --move /dev/pts /tmp/pts
+
 mount -t devtmpfs none /tmp
+
 mkdir -p /tmp/shm
 mount --move /dev/shm /tmp/shm
 mkdir -p /tmp/mqueue
 mount --move /dev/mqueue /tmp/mqueue
-mkdir -p /tmp/pts
-mount --move /dev/pts /tmp/pts
 touch /tmp/console
 mount --move /dev/console /tmp/console
 umount /dev || true
 mount --move /tmp /dev
 mount -t debugfs nodev /sys/kernel/debug
-udevd & 
+udevd &
 udevadm trigger &> /dev/null
-	
+
 CMD=$(which $1)
 shift
 exec "$CMD" "$@"


### PR DESCRIPTION
Failing to do so results in devtmpfs's /dev/ptmx causing /dev/ttyp[0-f] files to be used rather than /dev/pts/<fd> and if we then move /dev/pts back into place after mounting devtmpfs, libc gets confused and tries to get /dev/ptmx allocated files in /dev/pts/<fd>, causing forkpty calls (+ anything that tries to look up the pty path) to fail.
    
Alternative working solutions are to symlink or loop mount /dev/pts/ptmx to /dev/ptmx (this doesn't seem to retain /dev/pts/[0-2]), or to unmount /dev/pts (this results in use of /dev/ttyp[0-f] rather than /dev/pts/<fd> however.)