### PR TITLE
Symlink /dev/pts/ptmx to /dev/ptmx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## 2015-11-19
+
+- Symlink /dev/pts/ptmx to /dev/ptmx as /dev/pts is mounted -o newinstance. See
+  https://www.kernel.org/doc/Documentation/filesystems/devpts.txt for more
+  details.
+
 ## 2015-11-13
 
 ### Changed

--- a/systemd/amd64/jessie/entry.sh
+++ b/systemd/amd64/jessie/entry.sh
@@ -18,6 +18,11 @@ mount --move /dev/console /tmp/console
 umount /dev || true
 mount --move /tmp /dev
 
+# Since the devpts is mounted with -o newinstance by Docker, we need to make
+# /dev/ptmx point to its ptmx.
+# ref: https://www.kernel.org/doc/Documentation/filesystems/devpts.txt
+ln -sf /dev/pts/ptmx /dev/ptmx
+
 if [ "$INITSYSTEM" = "on" ]; then
 	GREEN='\033[0;32m'
 	echo -e "${GREEN}Systemd init system enabled."

--- a/systemd/amd64/wheezy/entry.sh
+++ b/systemd/amd64/wheezy/entry.sh
@@ -17,6 +17,12 @@ touch /tmp/console
 mount --move /dev/console /tmp/console
 umount /dev || true
 mount --move /tmp /dev
+
+# Since the devpts is mounted with -o newinstance by Docker, we need to make
+# /dev/ptmx point to its ptmx.
+# ref: https://www.kernel.org/doc/Documentation/filesystems/devpts.txt
+ln -sf /dev/pts/ptmx /dev/ptmx
+
 mount -t debugfs nodev /sys/kernel/debug
 udevd & 
 udevadm trigger &> /dev/null

--- a/systemd/armv7hf/jessie/entry.sh
+++ b/systemd/armv7hf/jessie/entry.sh
@@ -18,6 +18,11 @@ mount --move /dev/console /tmp/console
 umount /dev || true
 mount --move /tmp /dev
 
+# Since the devpts is mounted with -o newinstance by Docker, we need to make
+# /dev/ptmx point to its ptmx.
+# ref: https://www.kernel.org/doc/Documentation/filesystems/devpts.txt
+ln -sf /dev/pts/ptmx /dev/ptmx
+
 if [ "$INITSYSTEM" = "on" ]; then
 	GREEN='\033[0;32m'
 	echo -e "${GREEN}Systemd init system enabled."

--- a/systemd/armv7hf/sid/entry.sh
+++ b/systemd/armv7hf/sid/entry.sh
@@ -18,6 +18,11 @@ mount --move /dev/console /tmp/console
 umount /dev || true
 mount --move /tmp /dev
 
+# Since the devpts is mounted with -o newinstance by Docker, we need to make
+# /dev/ptmx point to its ptmx.
+# ref: https://www.kernel.org/doc/Documentation/filesystems/devpts.txt
+ln -sf /dev/pts/ptmx /dev/ptmx
+
 if [ "$INITSYSTEM" = "on" ]; then
 	GREEN='\033[0;32m'
 	echo -e "${GREEN}Systemd init system enabled."

--- a/systemd/armv7hf/wheezy/entry.sh
+++ b/systemd/armv7hf/wheezy/entry.sh
@@ -17,6 +17,12 @@ touch /tmp/console
 mount --move /dev/console /tmp/console
 umount /dev || true
 mount --move /tmp /dev
+
+# Since the devpts is mounted with -o newinstance by Docker, we need to make
+# /dev/ptmx point to its ptmx.
+# ref: https://www.kernel.org/doc/Documentation/filesystems/devpts.txt
+ln -sf /dev/pts/ptmx /dev/ptmx
+
 mount -t debugfs nodev /sys/kernel/debug
 udevd & 
 udevadm trigger &> /dev/null

--- a/systemd/entry-nosystemd.sh
+++ b/systemd/entry-nosystemd.sh
@@ -17,6 +17,12 @@ touch /tmp/console
 mount --move /dev/console /tmp/console
 umount /dev || true
 mount --move /tmp /dev
+
+# Since the devpts is mounted with -o newinstance by Docker, we need to make
+# /dev/ptmx point to its ptmx.
+# ref: https://www.kernel.org/doc/Documentation/filesystems/devpts.txt
+ln -sf /dev/pts/ptmx /dev/ptmx
+
 mount -t debugfs nodev /sys/kernel/debug
 udevd & 
 udevadm trigger &> /dev/null

--- a/systemd/entry.sh
+++ b/systemd/entry.sh
@@ -18,6 +18,11 @@ mount --move /dev/console /tmp/console
 umount /dev || true
 mount --move /tmp /dev
 
+# Since the devpts is mounted with -o newinstance by Docker, we need to make
+# /dev/ptmx point to its ptmx.
+# ref: https://www.kernel.org/doc/Documentation/filesystems/devpts.txt
+ln -sf /dev/pts/ptmx /dev/ptmx
+
 if [ "$INITSYSTEM" = "on" ]; then
 	GREEN='\033[0;32m'
 	echo -e "${GREEN}Systemd init system enabled."

--- a/systemd/i386/jessie/entry.sh
+++ b/systemd/i386/jessie/entry.sh
@@ -18,6 +18,11 @@ mount --move /dev/console /tmp/console
 umount /dev || true
 mount --move /tmp /dev
 
+# Since the devpts is mounted with -o newinstance by Docker, we need to make
+# /dev/ptmx point to its ptmx.
+# ref: https://www.kernel.org/doc/Documentation/filesystems/devpts.txt
+ln -sf /dev/pts/ptmx /dev/ptmx
+
 if [ "$INITSYSTEM" = "on" ]; then
 	GREEN='\033[0;32m'
 	echo -e "${GREEN}Systemd init system enabled."

--- a/systemd/i386/wheezy/entry.sh
+++ b/systemd/i386/wheezy/entry.sh
@@ -17,6 +17,12 @@ touch /tmp/console
 mount --move /dev/console /tmp/console
 umount /dev || true
 mount --move /tmp /dev
+
+# Since the devpts is mounted with -o newinstance by Docker, we need to make
+# /dev/ptmx point to its ptmx.
+# ref: https://www.kernel.org/doc/Documentation/filesystems/devpts.txt
+ln -sf /dev/pts/ptmx /dev/ptmx
+
 mount -t debugfs nodev /sys/kernel/debug
 udevd & 
 udevadm trigger &> /dev/null

--- a/systemd/rpi/jessie/entry.sh
+++ b/systemd/rpi/jessie/entry.sh
@@ -18,6 +18,11 @@ mount --move /dev/console /tmp/console
 umount /dev || true
 mount --move /tmp /dev
 
+# Since the devpts is mounted with -o newinstance by Docker, we need to make
+# /dev/ptmx point to its ptmx.
+# ref: https://www.kernel.org/doc/Documentation/filesystems/devpts.txt
+ln -sf /dev/pts/ptmx /dev/ptmx
+
 if [ "$INITSYSTEM" = "on" ]; then
 	GREEN='\033[0;32m'
 	echo -e "${GREEN}Systemd init system enabled."

--- a/systemd/rpi/wheezy/entry.sh
+++ b/systemd/rpi/wheezy/entry.sh
@@ -17,6 +17,12 @@ touch /tmp/console
 mount --move /dev/console /tmp/console
 umount /dev || true
 mount --move /tmp /dev
+
+# Since the devpts is mounted with -o newinstance by Docker, we need to make
+# /dev/ptmx point to its ptmx.
+# ref: https://www.kernel.org/doc/Documentation/filesystems/devpts.txt
+ln -sf /dev/pts/ptmx /dev/ptmx
+
 mount -t debugfs nodev /sys/kernel/debug
 udevd & 
 udevadm trigger &> /dev/null


### PR DESCRIPTION
On container start, Docker mounts /dev/pts with the -o newinstance option which provides a separate ptmx for access to ptys in its new instance. /dev/ptmx refers to a separate instance so having /dev/ptmx in place while an -o newinstance /dev/pts is mounted results in inability to obtain new ptys.
    
The solution is to symlink the new instance's ptmx to /dev/ptmx, which is precisely how /dev/ptmx was configured prior to mounting devtmpfs.
    
See https://www.kernel.org/doc/Documentation/filesystems/devpts.txt for more details.