### PR TITLE
Add RESIN_DEVTMPFS flag.

### DIFF
--- a/systemd/Dockerfile.tpl
+++ b/systemd/Dockerfile.tpl
@@ -16,7 +16,9 @@ RUN systemctl mask \
     systemd-remount-fs.service \
 
     getty.target \
-    graphical.target  
+    graphical.target
+
+ENV RESIN_DEVTMPFS 1
 
 COPY entry.sh /usr/bin/entry.sh    
 COPY launch.service /etc/systemd/system/launch.service

--- a/systemd/entry.sh
+++ b/systemd/entry.sh
@@ -1,27 +1,30 @@
 #!/bin/bash
 
-HOSTNAME=$(cat /etc/hostname)-${RESIN_DEVICE_UUID:0:6}
-echo $HOSTNAME > /etc/hostname
-echo "127.0.1.1 $HOSTNAME" >> /etc/hosts
-hostname $HOSTNAME
+# Trigger on device only
+if [ "$RESIN_DEVTMPFS" = '1' ]; then
+	HOSTNAME=$(cat /etc/hostname)-${RESIN_DEVICE_UUID:0:6}
+	echo $HOSTNAME > /etc/hostname
+	echo "127.0.1.1 $HOSTNAME" >> /etc/hosts
+	hostname $HOSTNAME
 
-mkdir -p /tmp
-mount -t devtmpfs none /tmp
-mkdir -p /tmp/shm
-mount --move /dev/shm /tmp/shm
-mkdir -p /tmp/mqueue
-mount --move /dev/mqueue /tmp/mqueue
-mkdir -p /tmp/pts
-mount --move /dev/pts /tmp/pts
-touch /tmp/console
-mount --move /dev/console /tmp/console
-umount /dev || true
-mount --move /tmp /dev
+	mkdir -p /tmp
+	mount -t devtmpfs none /tmp
+	mkdir -p /tmp/shm
+	mount --move /dev/shm /tmp/shm
+	mkdir -p /tmp/mqueue
+	mount --move /dev/mqueue /tmp/mqueue
+	mkdir -p /tmp/pts
+	mount --move /dev/pts /tmp/pts
+	touch /tmp/console
+	mount --move /dev/console /tmp/console
+	umount /dev || true
+	mount --move /tmp /dev
 
-# Since the devpts is mounted with -o newinstance by Docker, we need to make
-# /dev/ptmx point to its ptmx.
-# ref: https://www.kernel.org/doc/Documentation/filesystems/devpts.txt
-ln -sf /dev/pts/ptmx /dev/ptmx
+	# Since the devpts is mounted with -o newinstance by Docker, we need to make
+	# /dev/ptmx point to its ptmx.
+	# ref: https://www.kernel.org/doc/Documentation/filesystems/devpts.txt
+	ln -sf /dev/pts/ptmx /dev/ptmx
+fi
 
 if [ "$INITSYSTEM" = "on" ]; then
 	GREEN='\033[0;32m'


### PR DESCRIPTION
RESIN_DEVTMPFS is an environment variable that triggers mounting commands which meant to
be executed on a resin device only.

If RESIN_DEVTMPFS is set to 1 then commands executed. Otherwise, they are
ignored.