### PR TITLE
Fix file name in library generating script for buildpack-deps base images

### DIFF
--- a/buildpack-deps/generate-stackbrew-library.sh
+++ b/buildpack-deps/generate-stackbrew-library.sh
@@ -6,7 +6,7 @@ set -o pipefail
 # $1 : device type
 # $2 : distribution
 function generate_library(){
-	lib_name="$1-$2"
+	lib_name="$1-$2-buildpack-deps"
 	path="$1/$2"
 
 	cd $path


### PR DESCRIPTION
File name must use this scheme <device>-<distro>-buildpack-deps