### PR TITLE
Fix #48. Add UPM v0.7.0 to edison base images. 

### DIFF
--- a/device-base/Dockerfile.i386.edison.tpl
+++ b/device-base/Dockerfile.i386.edison.tpl
@@ -16,28 +16,49 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # MRAA
 ENV MRAA_COMMIT 887acf54e1f674ad2acb506c6e6b982d6074c73e
 ENV MRAA_VERSION 1.0.0
+# UPM
+ENV UPM_COMMIT 29bfa7ef79ec7e944e8803b39fe1fb71ab7c0825
+ENV UPM_VERSION 0.7.0
 
 # Install mraa
 RUN set -x \
 	&& buildDeps=' \
 		build-essential \
-		cmake \
 		git-core \
 		libpcre3-dev \
 		python-dev \
 		swig \
+		pkg-config \
+		curl \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
-	&& git clone https://github.com/intel-iot-devkit/mraa.git \
-	&& cd mraa \
-	&& git checkout $MRAA_COMMIT \
-	&& mkdir build && cd build \
-	&& cmake .. -DBUILDSWIGNODE=OFF -DBUILDSWIGPYTHON=OFF \
+	&& mkdir /cmake \ 
+	&& curl -SL https://cmake.org/files/v3.5/cmake-3.5.2.tar.gz -o cmake.tar.gz \
+	&& echo "92d8410d3d981bb881dfff2aed466da55a58d34c7390d50449aa59b32bb5e62a  cmake.tar.gz" | sha256sum -c - \
+	&& tar -xzf cmake.tar.gz -C /cmake --strip-components=1 \
+	&& cd /cmake \
+	&& ./configure \
 	&& make -j $(nproc) \
 	&& make install \
-	&& apt-get purge -y --auto-remove $buildDeps \
 	&& cd / \
-	&& rm -rf mraa
+	&& git clone https://github.com/intel-iot-devkit/mraa.git \
+	&& cd /mraa \
+	&& git checkout $MRAA_COMMIT \
+	&& mkdir build && cd build \
+	&& cmake .. -DBUILDSWIGNODE=OFF -DBUILDSWIGPYTHON=OFF -DCMAKE_INSTALL_PREFIX:PATH=/usr \
+	&& make -j $(nproc) \
+	&& make install \
+	&& cd / \
+	&& git clone https://github.com/intel-iot-devkit/upm.git \
+	&& cd /upm \
+	&& mkdir build && cd build \
+	&& cmake .. -DBUILDSWIGNODE=OFF -DBUILDSWIGPYTHON=OFF -DCMAKE_INSTALL_PREFIX:PATH=/usr \
+	&& make -j $(nproc) \
+	&& make install \
+	&& cd /cmake \
+	&& make uninstall \
+	&& apt-get purge -y --auto-remove $buildDeps \
+	&& cd / && rm -rf mraa upm cmake
 
 
 # Update Shared Library Cache


### PR DESCRIPTION
UPM provides software drivers for a wide variety of commonly used sensors
and actuators.