### PR TITLE
Fix issue with wrong python version in fedora onbuild python base image.

### DIFF
--- a/python/apalis-imx6/fedora/2/onbuild/Dockerfile
+++ b/python/apalis-imx6/fedora/2/onbuild/Dockerfile
@@ -1,4 +1,4 @@
-FROM resin/apalis-imx6-fedora-python:3.5.2
+FROM resin/apalis-imx6-fedora-python:2
 
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app

--- a/python/apalis-imx6/fedora/3/onbuild/Dockerfile
+++ b/python/apalis-imx6/fedora/3/onbuild/Dockerfile
@@ -1,4 +1,4 @@
-FROM resin/apalis-imx6-fedora-python:3.5.2
+FROM resin/apalis-imx6-fedora-python:3
 
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app

--- a/python/artik10/fedora/2/onbuild/Dockerfile
+++ b/python/artik10/fedora/2/onbuild/Dockerfile
@@ -1,4 +1,4 @@
-FROM resin/artik10-fedora-python:3.5.2
+FROM resin/artik10-fedora-python:2
 
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app

--- a/python/artik10/fedora/3/onbuild/Dockerfile
+++ b/python/artik10/fedora/3/onbuild/Dockerfile
@@ -1,4 +1,4 @@
-FROM resin/artik10-fedora-python:3.5.2
+FROM resin/artik10-fedora-python:3
 
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app

--- a/python/artik5/fedora/2/onbuild/Dockerfile
+++ b/python/artik5/fedora/2/onbuild/Dockerfile
@@ -1,4 +1,4 @@
-FROM resin/artik5-fedora-python:3.5.2
+FROM resin/artik5-fedora-python:2
 
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app

--- a/python/artik5/fedora/3/onbuild/Dockerfile
+++ b/python/artik5/fedora/3/onbuild/Dockerfile
@@ -1,4 +1,4 @@
-FROM resin/artik5-fedora-python:3.5.2
+FROM resin/artik5-fedora-python:3
 
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app

--- a/python/beaglebone-green-wifi/fedora/2/onbuild/Dockerfile
+++ b/python/beaglebone-green-wifi/fedora/2/onbuild/Dockerfile
@@ -1,4 +1,4 @@
-FROM resin/beaglebone-green-wifi-fedora-python:3.5.2
+FROM resin/beaglebone-green-wifi-fedora-python:2
 
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app

--- a/python/beaglebone-green-wifi/fedora/3/onbuild/Dockerfile
+++ b/python/beaglebone-green-wifi/fedora/3/onbuild/Dockerfile
@@ -1,4 +1,4 @@
-FROM resin/beaglebone-green-wifi-fedora-python:3.5.2
+FROM resin/beaglebone-green-wifi-fedora-python:3
 
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app

--- a/python/beaglebone/fedora/2/onbuild/Dockerfile
+++ b/python/beaglebone/fedora/2/onbuild/Dockerfile
@@ -1,4 +1,4 @@
-FROM resin/beaglebone-fedora-python:3.5.2
+FROM resin/beaglebone-fedora-python:2
 
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app

--- a/python/beaglebone/fedora/3/onbuild/Dockerfile
+++ b/python/beaglebone/fedora/3/onbuild/Dockerfile
@@ -1,4 +1,4 @@
-FROM resin/beaglebone-fedora-python:3.5.2
+FROM resin/beaglebone-fedora-python:3
 
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app

--- a/python/colibri-imx6/fedora/2/onbuild/Dockerfile
+++ b/python/colibri-imx6/fedora/2/onbuild/Dockerfile
@@ -1,4 +1,4 @@
-FROM resin/colibri-imx6-fedora-python:3.5.2
+FROM resin/colibri-imx6-fedora-python:2
 
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app

--- a/python/colibri-imx6/fedora/3/onbuild/Dockerfile
+++ b/python/colibri-imx6/fedora/3/onbuild/Dockerfile
@@ -1,4 +1,4 @@
-FROM resin/colibri-imx6-fedora-python:3.5.2
+FROM resin/colibri-imx6-fedora-python:3
 
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app

--- a/python/cubox-i/fedora/2/onbuild/Dockerfile
+++ b/python/cubox-i/fedora/2/onbuild/Dockerfile
@@ -1,4 +1,4 @@
-FROM resin/cubox-i-fedora-python:3.5.2
+FROM resin/cubox-i-fedora-python:2
 
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app

--- a/python/cubox-i/fedora/3/onbuild/Dockerfile
+++ b/python/cubox-i/fedora/3/onbuild/Dockerfile
@@ -1,4 +1,4 @@
-FROM resin/cubox-i-fedora-python:3.5.2
+FROM resin/cubox-i-fedora-python:3
 
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app

--- a/python/generate-dockerfile.sh
+++ b/python/generate-dockerfile.sh
@@ -300,7 +300,7 @@ for device in $devices; do
 			sed -e s~#{FROM}~"resin/$device-fedora-buildpack-deps:23"~g $template > $fedora_dockerfilePath/23/Dockerfile
 
 			mkdir -p $fedora_dockerfilePath/onbuild
-			sed -e s~#{FROM}~"resin/$device-fedora-python:$pythonVersion"~g Dockerfile.onbuild.tpl > $fedora_dockerfilePath/onbuild/Dockerfile
+			sed -e s~#{FROM}~"resin/$device-fedora-python:$version"~g Dockerfile.onbuild.tpl > $fedora_dockerfilePath/onbuild/Dockerfile
 
 			mkdir -p $fedora_dockerfilePath/slim
 			sed -e s~#{FROM}~"resin/$device-fedora:latest"~g $template > $fedora_dockerfilePath/slim/Dockerfile

--- a/python/nitrogen6x/fedora/2/onbuild/Dockerfile
+++ b/python/nitrogen6x/fedora/2/onbuild/Dockerfile
@@ -1,4 +1,4 @@
-FROM resin/nitrogen6x-fedora-python:3.5.2
+FROM resin/nitrogen6x-fedora-python:2
 
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app

--- a/python/nitrogen6x/fedora/3/onbuild/Dockerfile
+++ b/python/nitrogen6x/fedora/3/onbuild/Dockerfile
@@ -1,4 +1,4 @@
-FROM resin/nitrogen6x-fedora-python:3.5.2
+FROM resin/nitrogen6x-fedora-python:3
 
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app

--- a/python/odroid-c1/fedora/2/onbuild/Dockerfile
+++ b/python/odroid-c1/fedora/2/onbuild/Dockerfile
@@ -1,4 +1,4 @@
-FROM resin/odroid-c1-fedora-python:3.5.2
+FROM resin/odroid-c1-fedora-python:2
 
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app

--- a/python/odroid-c1/fedora/3/onbuild/Dockerfile
+++ b/python/odroid-c1/fedora/3/onbuild/Dockerfile
@@ -1,4 +1,4 @@
-FROM resin/odroid-c1-fedora-python:3.5.2
+FROM resin/odroid-c1-fedora-python:3
 
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app

--- a/python/odroid-ux3/fedora/2/onbuild/Dockerfile
+++ b/python/odroid-ux3/fedora/2/onbuild/Dockerfile
@@ -1,4 +1,4 @@
-FROM resin/odroid-ux3-fedora-python:3.5.2
+FROM resin/odroid-ux3-fedora-python:2
 
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app

--- a/python/odroid-ux3/fedora/3/onbuild/Dockerfile
+++ b/python/odroid-ux3/fedora/3/onbuild/Dockerfile
@@ -1,4 +1,4 @@
-FROM resin/odroid-ux3-fedora-python:3.5.2
+FROM resin/odroid-ux3-fedora-python:3
 
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app

--- a/python/parallella-hdmi-resin/fedora/2/onbuild/Dockerfile
+++ b/python/parallella-hdmi-resin/fedora/2/onbuild/Dockerfile
@@ -1,4 +1,4 @@
-FROM resin/parallella-hdmi-resin-fedora-python:3.5.2
+FROM resin/parallella-hdmi-resin-fedora-python:2
 
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app

--- a/python/parallella-hdmi-resin/fedora/3/onbuild/Dockerfile
+++ b/python/parallella-hdmi-resin/fedora/3/onbuild/Dockerfile
@@ -1,4 +1,4 @@
-FROM resin/parallella-hdmi-resin-fedora-python:3.5.2
+FROM resin/parallella-hdmi-resin-fedora-python:3
 
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app

--- a/python/raspberrypi2/fedora/2/onbuild/Dockerfile
+++ b/python/raspberrypi2/fedora/2/onbuild/Dockerfile
@@ -1,4 +1,4 @@
-FROM resin/raspberrypi2-fedora-python:3.5.2
+FROM resin/raspberrypi2-fedora-python:2
 
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app

--- a/python/raspberrypi2/fedora/3/onbuild/Dockerfile
+++ b/python/raspberrypi2/fedora/3/onbuild/Dockerfile
@@ -1,4 +1,4 @@
-FROM resin/raspberrypi2-fedora-python:3.5.2
+FROM resin/raspberrypi2-fedora-python:3
 
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app

--- a/python/raspberrypi3/fedora/2/onbuild/Dockerfile
+++ b/python/raspberrypi3/fedora/2/onbuild/Dockerfile
@@ -1,4 +1,4 @@
-FROM resin/raspberrypi3-fedora-python:3.5.2
+FROM resin/raspberrypi3-fedora-python:2
 
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app

--- a/python/raspberrypi3/fedora/3/onbuild/Dockerfile
+++ b/python/raspberrypi3/fedora/3/onbuild/Dockerfile
@@ -1,4 +1,4 @@
-FROM resin/raspberrypi3-fedora-python:3.5.2
+FROM resin/raspberrypi3-fedora-python:3
 
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app

--- a/python/ts4900/fedora/2/onbuild/Dockerfile
+++ b/python/ts4900/fedora/2/onbuild/Dockerfile
@@ -1,4 +1,4 @@
-FROM resin/ts4900-fedora-python:3.5.2
+FROM resin/ts4900-fedora-python:2
 
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app

--- a/python/ts4900/fedora/3/onbuild/Dockerfile
+++ b/python/ts4900/fedora/3/onbuild/Dockerfile
@@ -1,4 +1,4 @@
-FROM resin/ts4900-fedora-python:3.5.2
+FROM resin/ts4900-fedora-python:3
 
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app

--- a/python/vab820-quad/fedora/2/onbuild/Dockerfile
+++ b/python/vab820-quad/fedora/2/onbuild/Dockerfile
@@ -1,4 +1,4 @@
-FROM resin/vab820-quad-fedora-python:3.5.2
+FROM resin/vab820-quad-fedora-python:2
 
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app

--- a/python/vab820-quad/fedora/3/onbuild/Dockerfile
+++ b/python/vab820-quad/fedora/3/onbuild/Dockerfile
@@ -1,4 +1,4 @@
-FROM resin/vab820-quad-fedora-python:3.5.2
+FROM resin/vab820-quad-fedora-python:3
 
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app

--- a/python/zc702-zynq7/fedora/2/onbuild/Dockerfile
+++ b/python/zc702-zynq7/fedora/2/onbuild/Dockerfile
@@ -1,4 +1,4 @@
-FROM resin/zc702-zynq7-fedora-python:3.5.2
+FROM resin/zc702-zynq7-fedora-python:2
 
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app

--- a/python/zc702-zynq7/fedora/3/onbuild/Dockerfile
+++ b/python/zc702-zynq7/fedora/3/onbuild/Dockerfile
@@ -1,4 +1,4 @@
-FROM resin/zc702-zynq7-fedora-python:3.5.2
+FROM resin/zc702-zynq7-fedora-python:3
 
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app


### PR DESCRIPTION
Since we only have major version tag so onbuild images need to be built on top of major version tag instead of full version.