### PR TITLE
entry.sh: fix incorrect process exit code

### DIFF
--- a/debian/aarch64/jessie/entry.sh
+++ b/debian/aarch64/jessie/entry.sh
@@ -81,7 +81,6 @@ function init_non_systemd()
 		fi
 		"$CMD" "$@" &
 		pid=$!
-		wait $pid
 		fg &> /dev/null
 	else
 		echo "Command not found: $1"

--- a/debian/amd64/jessie/entry.sh
+++ b/debian/amd64/jessie/entry.sh
@@ -81,7 +81,6 @@ function init_non_systemd()
 		fi
 		"$CMD" "$@" &
 		pid=$!
-		wait $pid
 		fg &> /dev/null
 	else
 		echo "Command not found: $1"

--- a/debian/armel/jessie/entry.sh
+++ b/debian/armel/jessie/entry.sh
@@ -81,7 +81,6 @@ function init_non_systemd()
 		fi
 		"$CMD" "$@" &
 		pid=$!
-		wait $pid
 		fg &> /dev/null
 	else
 		echo "Command not found: $1"

--- a/debian/armv7hf/jessie/entry.sh
+++ b/debian/armv7hf/jessie/entry.sh
@@ -81,7 +81,6 @@ function init_non_systemd()
 		fi
 		"$CMD" "$@" &
 		pid=$!
-		wait $pid
 		fg &> /dev/null
 	else
 		echo "Command not found: $1"

--- a/debian/armv7hf/sid/entry.sh
+++ b/debian/armv7hf/sid/entry.sh
@@ -81,7 +81,6 @@ function init_non_systemd()
 		fi
 		"$CMD" "$@" &
 		pid=$!
-		wait $pid
 		fg &> /dev/null
 	else
 		echo "Command not found: $1"

--- a/debian/entry.sh
+++ b/debian/entry.sh
@@ -81,7 +81,6 @@ function init_non_systemd()
 		fi
 		"$CMD" "$@" &
 		pid=$!
-		wait $pid
 		fg &> /dev/null
 	else
 		echo "Command not found: $1"

--- a/debian/i386/jessie/entry.sh
+++ b/debian/i386/jessie/entry.sh
@@ -81,7 +81,6 @@ function init_non_systemd()
 		fi
 		"$CMD" "$@" &
 		pid=$!
-		wait $pid
 		fg &> /dev/null
 	else
 		echo "Command not found: $1"


### PR DESCRIPTION
running `fg` after having run `wait $pid` always returns withexit code 1 since there is no background process to attach to