### PR TITLE
Manually enable job control in entry script

### DIFF
--- a/debian/aarch64/jessie/entry.sh
+++ b/debian/aarch64/jessie/entry.sh
@@ -1,8 +1,10 @@
 #!/bin/bash
 
+set -m
+
 function start_udev()
 {
-	udevd & 
+	udevd &
 	udevadm trigger &> /dev/null
 }
 

--- a/debian/amd64/jessie/entry.sh
+++ b/debian/amd64/jessie/entry.sh
@@ -1,8 +1,10 @@
 #!/bin/bash
 
+set -m
+
 function start_udev()
 {
-	udevd & 
+	udevd &
 	udevadm trigger &> /dev/null
 }
 

--- a/debian/armel/jessie/entry.sh
+++ b/debian/armel/jessie/entry.sh
@@ -1,8 +1,10 @@
 #!/bin/bash
 
+set -m
+
 function start_udev()
 {
-	udevd & 
+	udevd &
 	udevadm trigger &> /dev/null
 }
 

--- a/debian/armv7hf/jessie/entry.sh
+++ b/debian/armv7hf/jessie/entry.sh
@@ -1,8 +1,10 @@
 #!/bin/bash
 
+set -m
+
 function start_udev()
 {
-	udevd & 
+	udevd &
 	udevadm trigger &> /dev/null
 }
 

--- a/debian/armv7hf/sid/entry.sh
+++ b/debian/armv7hf/sid/entry.sh
@@ -1,8 +1,10 @@
 #!/bin/bash
 
+set -m
+
 function start_udev()
 {
-	udevd & 
+	udevd &
 	udevadm trigger &> /dev/null
 }
 

--- a/debian/entry.sh
+++ b/debian/entry.sh
@@ -1,8 +1,10 @@
 #!/bin/bash
 
+set -m
+
 function start_udev()
 {
-	udevd & 
+	udevd &
 	udevadm trigger &> /dev/null
 }
 

--- a/debian/i386/jessie/entry.sh
+++ b/debian/i386/jessie/entry.sh
@@ -1,8 +1,10 @@
 #!/bin/bash
 
+set -m
+
 function start_udev()
 {
-	udevd & 
+	udevd &
 	udevadm trigger &> /dev/null
 }
 


### PR DESCRIPTION
running `fg` returns no job control since our shell is noninteractive by default. We need to enable monitor mode to make `fg` work properly