### PR TITLE
Only redirect stdout into /dev/null

### DIFF
--- a/debian/aarch64/jessie/entry.sh
+++ b/debian/aarch64/jessie/entry.sh
@@ -83,7 +83,7 @@ function init_non_systemd()
 		fi
 		"$CMD" "$@" &
 		pid=$!
-		fg &> /dev/null
+		fg > /dev/null
 	else
 		echo "Command not found: $1"
 		exit 1

--- a/debian/amd64/jessie/entry.sh
+++ b/debian/amd64/jessie/entry.sh
@@ -83,7 +83,7 @@ function init_non_systemd()
 		fi
 		"$CMD" "$@" &
 		pid=$!
-		fg &> /dev/null
+		fg > /dev/null
 	else
 		echo "Command not found: $1"
 		exit 1

--- a/debian/armel/jessie/entry.sh
+++ b/debian/armel/jessie/entry.sh
@@ -83,7 +83,7 @@ function init_non_systemd()
 		fi
 		"$CMD" "$@" &
 		pid=$!
-		fg &> /dev/null
+		fg > /dev/null
 	else
 		echo "Command not found: $1"
 		exit 1

--- a/debian/armv7hf/jessie/entry.sh
+++ b/debian/armv7hf/jessie/entry.sh
@@ -83,7 +83,7 @@ function init_non_systemd()
 		fi
 		"$CMD" "$@" &
 		pid=$!
-		fg &> /dev/null
+		fg > /dev/null
 	else
 		echo "Command not found: $1"
 		exit 1

--- a/debian/armv7hf/sid/entry.sh
+++ b/debian/armv7hf/sid/entry.sh
@@ -83,7 +83,7 @@ function init_non_systemd()
 		fi
 		"$CMD" "$@" &
 		pid=$!
-		fg &> /dev/null
+		fg > /dev/null
 	else
 		echo "Command not found: $1"
 		exit 1

--- a/debian/entry.sh
+++ b/debian/entry.sh
@@ -83,7 +83,7 @@ function init_non_systemd()
 		fi
 		"$CMD" "$@" &
 		pid=$!
-		fg &> /dev/null
+		fg > /dev/null
 	else
 		echo "Command not found: $1"
 		exit 1

--- a/debian/i386/jessie/entry.sh
+++ b/debian/i386/jessie/entry.sh
@@ -83,7 +83,7 @@ function init_non_systemd()
 		fi
 		"$CMD" "$@" &
 		pid=$!
-		fg &> /dev/null
+		fg > /dev/null
 	else
 		echo "Command not found: $1"
 		exit 1


### PR DESCRIPTION
If we redirect every output to /dev/null. The background process will fail when try to read from stdin (exit code 149). It means we can not start a shell or any commands that require stdin