### PR TITLE
Update MRAA and UPM for edison base images

### DIFF
--- a/device-base/Dockerfile.alpine.i386.edison.tpl
+++ b/device-base/Dockerfile.alpine.i386.edison.tpl
@@ -10,8 +10,8 @@ RUN apk add --update \
 		usbutils \
 	&& rm -rf /var/cache/apk/*
 
-# MRAA v0.8.1 commit 
-ENV MRAA_COMMIT 049ba5fa9f2d18ac0ec6729c46916b34998d3c5f
+# MRAA commit
+ENV MRAA_COMMIT #{MRAA_COMMIT}
 
 # Install mraa
 RUN set -x \

--- a/device-base/Dockerfile.i386.edison.tpl
+++ b/device-base/Dockerfile.i386.edison.tpl
@@ -14,11 +14,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 	&& rm -rf /var/lib/apt/lists/*
 
 # MRAA
-ENV MRAA_COMMIT 6f9b470d8d25e2c8ba1586cd9d707b870ab30010
-ENV MRAA_VERSION 1.5.1
+ENV MRAA_COMMIT #{MRAA_COMMIT}
+ENV MRAA_VERSION #{MRAA_VERSION}
 # UPM
-ENV UPM_COMMIT 1849e22154177096f1725e9cc96ec62ac2ef3635
-ENV UPM_VERSION 0.7.2
+ENV UPM_COMMIT #{UPM_COMMIT}
+ENV UPM_VERSION #{UPM_VERSION}
 
 # Install mraa
 RUN set -x \
@@ -51,6 +51,7 @@ RUN set -x \
 	&& cd / \
 	&& git clone https://github.com/intel-iot-devkit/upm.git \
 	&& cd /upm \
+	&& git checkout $UPM_COMMIT \
 	&& mkdir build && cd build \
 	&& cmake .. -DBUILDSWIGNODE=OFF -DBUILDSWIGPYTHON=OFF -DCMAKE_INSTALL_PREFIX:PATH=/usr \
 	&& make -j $(nproc) \

--- a/device-base/Dockerfile.i386.edison.tpl
+++ b/device-base/Dockerfile.i386.edison.tpl
@@ -14,8 +14,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 	&& rm -rf /var/lib/apt/lists/*
 
 # MRAA
-ENV MRAA_COMMIT d336e9f8d69a85b6ed1aeb5b324910234031d4a8
-ENV MRAA_VERSION 1.1.1
+ENV MRAA_COMMIT 6f9b470d8d25e2c8ba1586cd9d707b870ab30010
+ENV MRAA_VERSION 1.5.1
 # UPM
 ENV UPM_COMMIT 1849e22154177096f1725e9cc96ec62ac2ef3635
 ENV UPM_VERSION 0.7.2

--- a/device-base/edison/debian/jessie/Dockerfile
+++ b/device-base/edison/debian/jessie/Dockerfile
@@ -14,11 +14,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 	&& rm -rf /var/lib/apt/lists/*
 
 # MRAA
-ENV MRAA_COMMIT d336e9f8d69a85b6ed1aeb5b324910234031d4a8
-ENV MRAA_VERSION 1.1.1
+ENV MRAA_COMMIT 6f9b470d8d25e2c8ba1586cd9d707b870ab30010
+ENV MRAA_VERSION 1.5.1
 # UPM
-ENV UPM_COMMIT 1849e22154177096f1725e9cc96ec62ac2ef3635
-ENV UPM_VERSION 0.7.2
+ENV UPM_COMMIT cde747439f7ada792509dd2b56075d4744ac15e4
+ENV UPM_VERSION 1.0.2
 
 # Install mraa
 RUN set -x \
@@ -51,6 +51,7 @@ RUN set -x \
 	&& cd / \
 	&& git clone https://github.com/intel-iot-devkit/upm.git \
 	&& cd /upm \
+	&& git checkout $UPM_COMMIT \
 	&& mkdir build && cd build \
 	&& cmake .. -DBUILDSWIGNODE=OFF -DBUILDSWIGPYTHON=OFF -DCMAKE_INSTALL_PREFIX:PATH=/usr \
 	&& make -j $(nproc) \

--- a/device-base/edison/debian/wheezy/Dockerfile
+++ b/device-base/edison/debian/wheezy/Dockerfile
@@ -14,11 +14,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 	&& rm -rf /var/lib/apt/lists/*
 
 # MRAA
-ENV MRAA_COMMIT d336e9f8d69a85b6ed1aeb5b324910234031d4a8
-ENV MRAA_VERSION 1.1.1
+ENV MRAA_COMMIT 6f9b470d8d25e2c8ba1586cd9d707b870ab30010
+ENV MRAA_VERSION 1.5.1
 # UPM
-ENV UPM_COMMIT 1849e22154177096f1725e9cc96ec62ac2ef3635
-ENV UPM_VERSION 0.7.2
+ENV UPM_COMMIT 13e2e7aeb8769707b91b62f23d6669d3ee1a8651
+ENV UPM_VERSION 1.0.0
 
 # Install mraa
 RUN set -x \
@@ -51,6 +51,7 @@ RUN set -x \
 	&& cd / \
 	&& git clone https://github.com/intel-iot-devkit/upm.git \
 	&& cd /upm \
+	&& git checkout $UPM_COMMIT \
 	&& mkdir build && cd build \
 	&& cmake .. -DBUILDSWIGNODE=OFF -DBUILDSWIGPYTHON=OFF -DCMAKE_INSTALL_PREFIX:PATH=/usr \
 	&& make -j $(nproc) \

--- a/device-base/intel-quark/debian/jessie/Dockerfile
+++ b/device-base/intel-quark/debian/jessie/Dockerfile
@@ -6,61 +6,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		less \
 		module-init-tools \
 		nano \
-		net-tools \		
+		net-tools \
+		ifupdown \	
+		iputils-ping \	
 		i2c-tools \
-		iputils-ping \		
-		ifupdown \				
-		usbutils \		
+		usbutils \	
 	&& rm -rf /var/lib/apt/lists/*
-
-# MRAA
-ENV MRAA_COMMIT d336e9f8d69a85b6ed1aeb5b324910234031d4a8
-ENV MRAA_VERSION 1.1.1
-# UPM
-ENV UPM_COMMIT 1849e22154177096f1725e9cc96ec62ac2ef3635
-ENV UPM_VERSION 0.7.2
-
-# Install mraa
-RUN set -x \
-	&& buildDeps=' \
-		build-essential \
-		git-core \
-		libpcre3-dev \
-		python-dev \
-		swig \
-		pkg-config \
-		curl \
-	' \
-	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
-	&& mkdir /cmake \ 
-	&& curl -SL https://cmake.org/files/v3.5/cmake-3.5.2.tar.gz -o cmake.tar.gz \
-	&& echo "92d8410d3d981bb881dfff2aed466da55a58d34c7390d50449aa59b32bb5e62a  cmake.tar.gz" | sha256sum -c - \
-	&& tar -xzf cmake.tar.gz -C /cmake --strip-components=1 \
-	&& cd /cmake \
-	&& ./configure \
-	&& make -j $(nproc) \
-	&& make install \
-	&& cd / \
-	&& git clone https://github.com/intel-iot-devkit/mraa.git \
-	&& cd /mraa \
-	&& git checkout $MRAA_COMMIT \
-	&& mkdir build && cd build \
-	&& cmake .. -DBUILDSWIGNODE=OFF -DBUILDSWIGPYTHON=OFF -DCMAKE_INSTALL_PREFIX:PATH=/usr \
-	&& make -j $(nproc) \
-	&& make install \
-	&& cd / \
-	&& git clone https://github.com/intel-iot-devkit/upm.git \
-	&& cd /upm \
-	&& mkdir build && cd build \
-	&& cmake .. -DBUILDSWIGNODE=OFF -DBUILDSWIGPYTHON=OFF -DCMAKE_INSTALL_PREFIX:PATH=/usr \
-	&& make -j $(nproc) \
-	&& make install \
-	&& cd /cmake \
-	&& make uninstall \
-	&& apt-get purge -y --auto-remove $buildDeps \
-	&& cd / && rm -rf mraa upm cmake
-
-
-# Update Shared Library Cache
-RUN echo "/usr/local/lib/i386-linux-gnu/" >> /etc/ld.so.conf \
-	&& ldconfig

--- a/device-base/intel-quark/debian/wheezy/Dockerfile
+++ b/device-base/intel-quark/debian/wheezy/Dockerfile
@@ -6,61 +6,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		less \
 		module-init-tools \
 		nano \
-		net-tools \		
+		net-tools \
+		ifupdown \	
+		iputils-ping \	
 		i2c-tools \
-		iputils-ping \		
-		ifupdown \				
-		usbutils \		
+		usbutils \	
 	&& rm -rf /var/lib/apt/lists/*
-
-# MRAA
-ENV MRAA_COMMIT d336e9f8d69a85b6ed1aeb5b324910234031d4a8
-ENV MRAA_VERSION 1.1.1
-# UPM
-ENV UPM_COMMIT 1849e22154177096f1725e9cc96ec62ac2ef3635
-ENV UPM_VERSION 0.7.2
-
-# Install mraa
-RUN set -x \
-	&& buildDeps=' \
-		build-essential \
-		git-core \
-		libpcre3-dev \
-		python-dev \
-		swig \
-		pkg-config \
-		curl \
-	' \
-	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
-	&& mkdir /cmake \ 
-	&& curl -SL https://cmake.org/files/v3.5/cmake-3.5.2.tar.gz -o cmake.tar.gz \
-	&& echo "92d8410d3d981bb881dfff2aed466da55a58d34c7390d50449aa59b32bb5e62a  cmake.tar.gz" | sha256sum -c - \
-	&& tar -xzf cmake.tar.gz -C /cmake --strip-components=1 \
-	&& cd /cmake \
-	&& ./configure \
-	&& make -j $(nproc) \
-	&& make install \
-	&& cd / \
-	&& git clone https://github.com/intel-iot-devkit/mraa.git \
-	&& cd /mraa \
-	&& git checkout $MRAA_COMMIT \
-	&& mkdir build && cd build \
-	&& cmake .. -DBUILDSWIGNODE=OFF -DBUILDSWIGPYTHON=OFF -DCMAKE_INSTALL_PREFIX:PATH=/usr \
-	&& make -j $(nproc) \
-	&& make install \
-	&& cd / \
-	&& git clone https://github.com/intel-iot-devkit/upm.git \
-	&& cd /upm \
-	&& mkdir build && cd build \
-	&& cmake .. -DBUILDSWIGNODE=OFF -DBUILDSWIGPYTHON=OFF -DCMAKE_INSTALL_PREFIX:PATH=/usr \
-	&& make -j $(nproc) \
-	&& make install \
-	&& cd /cmake \
-	&& make uninstall \
-	&& apt-get purge -y --auto-remove $buildDeps \
-	&& cd / && rm -rf mraa upm cmake
-
-
-# Update Shared Library Cache
-RUN echo "/usr/local/lib/i386-linux-gnu/" >> /etc/ld.so.conf \
-	&& ldconfig

--- a/device-base/qemux86/debian/jessie/Dockerfile
+++ b/device-base/qemux86/debian/jessie/Dockerfile
@@ -6,61 +6,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		less \
 		module-init-tools \
 		nano \
-		net-tools \		
+		net-tools \
+		ifupdown \	
+		iputils-ping \	
 		i2c-tools \
-		iputils-ping \		
-		ifupdown \				
-		usbutils \		
+		usbutils \	
 	&& rm -rf /var/lib/apt/lists/*
-
-# MRAA
-ENV MRAA_COMMIT d336e9f8d69a85b6ed1aeb5b324910234031d4a8
-ENV MRAA_VERSION 1.1.1
-# UPM
-ENV UPM_COMMIT 1849e22154177096f1725e9cc96ec62ac2ef3635
-ENV UPM_VERSION 0.7.2
-
-# Install mraa
-RUN set -x \
-	&& buildDeps=' \
-		build-essential \
-		git-core \
-		libpcre3-dev \
-		python-dev \
-		swig \
-		pkg-config \
-		curl \
-	' \
-	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
-	&& mkdir /cmake \ 
-	&& curl -SL https://cmake.org/files/v3.5/cmake-3.5.2.tar.gz -o cmake.tar.gz \
-	&& echo "92d8410d3d981bb881dfff2aed466da55a58d34c7390d50449aa59b32bb5e62a  cmake.tar.gz" | sha256sum -c - \
-	&& tar -xzf cmake.tar.gz -C /cmake --strip-components=1 \
-	&& cd /cmake \
-	&& ./configure \
-	&& make -j $(nproc) \
-	&& make install \
-	&& cd / \
-	&& git clone https://github.com/intel-iot-devkit/mraa.git \
-	&& cd /mraa \
-	&& git checkout $MRAA_COMMIT \
-	&& mkdir build && cd build \
-	&& cmake .. -DBUILDSWIGNODE=OFF -DBUILDSWIGPYTHON=OFF -DCMAKE_INSTALL_PREFIX:PATH=/usr \
-	&& make -j $(nproc) \
-	&& make install \
-	&& cd / \
-	&& git clone https://github.com/intel-iot-devkit/upm.git \
-	&& cd /upm \
-	&& mkdir build && cd build \
-	&& cmake .. -DBUILDSWIGNODE=OFF -DBUILDSWIGPYTHON=OFF -DCMAKE_INSTALL_PREFIX:PATH=/usr \
-	&& make -j $(nproc) \
-	&& make install \
-	&& cd /cmake \
-	&& make uninstall \
-	&& apt-get purge -y --auto-remove $buildDeps \
-	&& cd / && rm -rf mraa upm cmake
-
-
-# Update Shared Library Cache
-RUN echo "/usr/local/lib/i386-linux-gnu/" >> /etc/ld.so.conf \
-	&& ldconfig

--- a/device-base/qemux86/debian/wheezy/Dockerfile
+++ b/device-base/qemux86/debian/wheezy/Dockerfile
@@ -6,61 +6,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		less \
 		module-init-tools \
 		nano \
-		net-tools \		
+		net-tools \
+		ifupdown \	
+		iputils-ping \	
 		i2c-tools \
-		iputils-ping \		
-		ifupdown \				
-		usbutils \		
+		usbutils \	
 	&& rm -rf /var/lib/apt/lists/*
-
-# MRAA
-ENV MRAA_COMMIT d336e9f8d69a85b6ed1aeb5b324910234031d4a8
-ENV MRAA_VERSION 1.1.1
-# UPM
-ENV UPM_COMMIT 1849e22154177096f1725e9cc96ec62ac2ef3635
-ENV UPM_VERSION 0.7.2
-
-# Install mraa
-RUN set -x \
-	&& buildDeps=' \
-		build-essential \
-		git-core \
-		libpcre3-dev \
-		python-dev \
-		swig \
-		pkg-config \
-		curl \
-	' \
-	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
-	&& mkdir /cmake \ 
-	&& curl -SL https://cmake.org/files/v3.5/cmake-3.5.2.tar.gz -o cmake.tar.gz \
-	&& echo "92d8410d3d981bb881dfff2aed466da55a58d34c7390d50449aa59b32bb5e62a  cmake.tar.gz" | sha256sum -c - \
-	&& tar -xzf cmake.tar.gz -C /cmake --strip-components=1 \
-	&& cd /cmake \
-	&& ./configure \
-	&& make -j $(nproc) \
-	&& make install \
-	&& cd / \
-	&& git clone https://github.com/intel-iot-devkit/mraa.git \
-	&& cd /mraa \
-	&& git checkout $MRAA_COMMIT \
-	&& mkdir build && cd build \
-	&& cmake .. -DBUILDSWIGNODE=OFF -DBUILDSWIGPYTHON=OFF -DCMAKE_INSTALL_PREFIX:PATH=/usr \
-	&& make -j $(nproc) \
-	&& make install \
-	&& cd / \
-	&& git clone https://github.com/intel-iot-devkit/upm.git \
-	&& cd /upm \
-	&& mkdir build && cd build \
-	&& cmake .. -DBUILDSWIGNODE=OFF -DBUILDSWIGPYTHON=OFF -DCMAKE_INSTALL_PREFIX:PATH=/usr \
-	&& make -j $(nproc) \
-	&& make install \
-	&& cd /cmake \
-	&& make uninstall \
-	&& apt-get purge -y --auto-remove $buildDeps \
-	&& cd / && rm -rf mraa upm cmake
-
-
-# Update Shared Library Cache
-RUN echo "/usr/local/lib/i386-linux-gnu/" >> /etc/ld.so.conf \
-	&& ldconfig

--- a/node/generate-latest-dockerfile.sh
+++ b/node/generate-latest-dockerfile.sh
@@ -222,7 +222,7 @@ for device in $devices; do
 		fi
 
 		# Only for intel edison
-		if [ $device == "edison" ] || [ $device == "qemux86" ]; then
+		if [ $device == "edison" ]; then
 			sed -e s~#{FROM}~resin/$device-buildpack-deps:jessie~g \
 				-e s~#{BINARY_URL}~$binaryUrl~g \
 				-e s~#{NODE_VERSION}~$nodeVersion~g \

--- a/node/qemux86/debian/0.10/Dockerfile
+++ b/node/qemux86/debian/0.10/Dockerfile
@@ -7,8 +7,6 @@ RUN curl -SLO "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/node-v
 	&& echo "6ff9db1265c85edabbf5dd3b18821c97bb5e80f6d29e2330f3298d7d89c5032b  node-v0.10.48-linux-i386.tar.gz" | sha256sum -c - \
 	&& tar -xzf "node-v$NODE_VERSION-linux-i386.tar.gz" -C /usr/local --strip-components=1 \
 	&& rm "node-v$NODE_VERSION-linux-i386.tar.gz" \
-	&& npm install mraa@$MRAA_VERSION \
-	&& npm cache clear \
 	&& npm config set unsafe-perm true -g --unsafe-perm \
 	&& rm -rf /tmp/*
 

--- a/node/qemux86/debian/0.10/slim/Dockerfile
+++ b/node/qemux86/debian/0.10/slim/Dockerfile
@@ -3,7 +3,7 @@ FROM resin/qemux86-debian:jessie
 
 ENV NODE_VERSION 0.10.48
 
-RUN buildDeps='curl build-essential python' \
+RUN buildDeps='curl' \
 	&& set -x \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends \
 	&& rm -rf /var/lib/apt/lists/* \
@@ -11,10 +11,8 @@ RUN buildDeps='curl build-essential python' \
 	&& echo "6ff9db1265c85edabbf5dd3b18821c97bb5e80f6d29e2330f3298d7d89c5032b  node-v0.10.48-linux-i386.tar.gz" | sha256sum -c - \
 	&& tar -xzf "node-v$NODE_VERSION-linux-i386.tar.gz" -C /usr/local --strip-components=1 \
 	&& rm "node-v$NODE_VERSION-linux-i386.tar.gz" \
-	&& npm install mraa@$MRAA_VERSION \
-	&& npm cache clear \
-	&& npm config set unsafe-perm true -g --unsafe-perm \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& npm config set unsafe-perm true -g --unsafe-perm \
 	&& rm -rf /tmp/*
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/deployment/dockerfile"]

--- a/node/qemux86/debian/0.12/Dockerfile
+++ b/node/qemux86/debian/0.12/Dockerfile
@@ -7,8 +7,6 @@ RUN curl -SLO "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/node-v
 	&& echo "62b43c74e683bed3e13e5949fd93e8e587a1d686e42167babb221f65ba625ebb  node-v0.12.15-linux-i386.tar.gz" | sha256sum -c - \
 	&& tar -xzf "node-v$NODE_VERSION-linux-i386.tar.gz" -C /usr/local --strip-components=1 \
 	&& rm "node-v$NODE_VERSION-linux-i386.tar.gz" \
-	&& npm install mraa@$MRAA_VERSION \
-	&& npm cache clear \
 	&& npm config set unsafe-perm true -g --unsafe-perm \
 	&& rm -rf /tmp/*
 

--- a/node/qemux86/debian/0.12/slim/Dockerfile
+++ b/node/qemux86/debian/0.12/slim/Dockerfile
@@ -3,7 +3,7 @@ FROM resin/qemux86-debian:jessie
 
 ENV NODE_VERSION 0.12.15
 
-RUN buildDeps='curl build-essential python' \
+RUN buildDeps='curl' \
 	&& set -x \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends \
 	&& rm -rf /var/lib/apt/lists/* \
@@ -11,10 +11,8 @@ RUN buildDeps='curl build-essential python' \
 	&& echo "62b43c74e683bed3e13e5949fd93e8e587a1d686e42167babb221f65ba625ebb  node-v0.12.15-linux-i386.tar.gz" | sha256sum -c - \
 	&& tar -xzf "node-v$NODE_VERSION-linux-i386.tar.gz" -C /usr/local --strip-components=1 \
 	&& rm "node-v$NODE_VERSION-linux-i386.tar.gz" \
-	&& npm install mraa@$MRAA_VERSION \
-	&& npm cache clear \
-	&& npm config set unsafe-perm true -g --unsafe-perm \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& npm config set unsafe-perm true -g --unsafe-perm \
 	&& rm -rf /tmp/*
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/deployment/dockerfile"]

--- a/node/qemux86/debian/4.7/Dockerfile
+++ b/node/qemux86/debian/4.7/Dockerfile
@@ -7,8 +7,6 @@ RUN curl -SLO "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/node-v
 	&& echo "ceffc1f5d301fbd9b0e46ccb05b93e32b7b4dff8a1be59f6f03e7eb17372a7c8  node-v4.7.0-linux-i386.tar.gz" | sha256sum -c - \
 	&& tar -xzf "node-v$NODE_VERSION-linux-i386.tar.gz" -C /usr/local --strip-components=1 \
 	&& rm "node-v$NODE_VERSION-linux-i386.tar.gz" \
-	&& npm install mraa@$MRAA_VERSION \
-	&& npm cache clear \
 	&& npm config set unsafe-perm true -g --unsafe-perm \
 	&& rm -rf /tmp/*
 

--- a/node/qemux86/debian/4.7/slim/Dockerfile
+++ b/node/qemux86/debian/4.7/slim/Dockerfile
@@ -3,7 +3,7 @@ FROM resin/qemux86-debian:jessie
 
 ENV NODE_VERSION 4.7.0
 
-RUN buildDeps='curl build-essential python' \
+RUN buildDeps='curl' \
 	&& set -x \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends \
 	&& rm -rf /var/lib/apt/lists/* \
@@ -11,10 +11,8 @@ RUN buildDeps='curl build-essential python' \
 	&& echo "ceffc1f5d301fbd9b0e46ccb05b93e32b7b4dff8a1be59f6f03e7eb17372a7c8  node-v4.7.0-linux-i386.tar.gz" | sha256sum -c - \
 	&& tar -xzf "node-v$NODE_VERSION-linux-i386.tar.gz" -C /usr/local --strip-components=1 \
 	&& rm "node-v$NODE_VERSION-linux-i386.tar.gz" \
-	&& npm install mraa@$MRAA_VERSION \
-	&& npm cache clear \
-	&& npm config set unsafe-perm true -g --unsafe-perm \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& npm config set unsafe-perm true -g --unsafe-perm \
 	&& rm -rf /tmp/*
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/deployment/dockerfile"]

--- a/node/qemux86/debian/5.12/Dockerfile
+++ b/node/qemux86/debian/5.12/Dockerfile
@@ -7,8 +7,6 @@ RUN curl -SLO "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/node-v
 	&& echo "566dac853617197601895295e3b679561c908186f9fb79a66668dcb29d689cf2  node-v5.12.0-linux-i386.tar.gz" | sha256sum -c - \
 	&& tar -xzf "node-v$NODE_VERSION-linux-i386.tar.gz" -C /usr/local --strip-components=1 \
 	&& rm "node-v$NODE_VERSION-linux-i386.tar.gz" \
-	&& npm install mraa@$MRAA_VERSION \
-	&& npm cache clear \
 	&& npm config set unsafe-perm true -g --unsafe-perm \
 	&& rm -rf /tmp/*
 

--- a/node/qemux86/debian/5.12/slim/Dockerfile
+++ b/node/qemux86/debian/5.12/slim/Dockerfile
@@ -3,7 +3,7 @@ FROM resin/qemux86-debian:jessie
 
 ENV NODE_VERSION 5.12.0
 
-RUN buildDeps='curl build-essential python' \
+RUN buildDeps='curl' \
 	&& set -x \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends \
 	&& rm -rf /var/lib/apt/lists/* \
@@ -11,10 +11,8 @@ RUN buildDeps='curl build-essential python' \
 	&& echo "566dac853617197601895295e3b679561c908186f9fb79a66668dcb29d689cf2  node-v5.12.0-linux-i386.tar.gz" | sha256sum -c - \
 	&& tar -xzf "node-v$NODE_VERSION-linux-i386.tar.gz" -C /usr/local --strip-components=1 \
 	&& rm "node-v$NODE_VERSION-linux-i386.tar.gz" \
-	&& npm install mraa@$MRAA_VERSION \
-	&& npm cache clear \
-	&& npm config set unsafe-perm true -g --unsafe-perm \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& npm config set unsafe-perm true -g --unsafe-perm \
 	&& rm -rf /tmp/*
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/deployment/dockerfile"]

--- a/node/qemux86/debian/6.3/wheezy/Dockerfile
+++ b/node/qemux86/debian/6.3/wheezy/Dockerfile
@@ -7,8 +7,6 @@ RUN curl -SLO "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/node-v
 	&& echo "" | sha256sum -c - \
 	&& tar -xzf "node-v$NODE_VERSION-linux-i386.tar.gz" -C /usr/local --strip-components=1 \
 	&& rm "node-v$NODE_VERSION-linux-i386.tar.gz" \
-	&& npm install mraa@$MRAA_VERSION \
-	&& npm cache clear \
 	&& npm config set unsafe-perm true -g --unsafe-perm \
 	&& rm -rf /tmp/*
 

--- a/node/qemux86/debian/6.9/Dockerfile
+++ b/node/qemux86/debian/6.9/Dockerfile
@@ -7,8 +7,6 @@ RUN curl -SLO "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/node-v
 	&& echo "603f819b83f711420503a2498aeb673c32d169de4a067890185a2de56e0fa15d  node-v6.9.2-linux-i386.tar.gz" | sha256sum -c - \
 	&& tar -xzf "node-v$NODE_VERSION-linux-i386.tar.gz" -C /usr/local --strip-components=1 \
 	&& rm "node-v$NODE_VERSION-linux-i386.tar.gz" \
-	&& npm install mraa@$MRAA_VERSION \
-	&& npm cache clear \
 	&& npm config set unsafe-perm true -g --unsafe-perm \
 	&& rm -rf /tmp/*
 

--- a/node/qemux86/debian/6.9/slim/Dockerfile
+++ b/node/qemux86/debian/6.9/slim/Dockerfile
@@ -3,7 +3,7 @@ FROM resin/qemux86-debian:jessie
 
 ENV NODE_VERSION 6.9.2
 
-RUN buildDeps='curl build-essential python' \
+RUN buildDeps='curl' \
 	&& set -x \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends \
 	&& rm -rf /var/lib/apt/lists/* \
@@ -11,10 +11,8 @@ RUN buildDeps='curl build-essential python' \
 	&& echo "603f819b83f711420503a2498aeb673c32d169de4a067890185a2de56e0fa15d  node-v6.9.2-linux-i386.tar.gz" | sha256sum -c - \
 	&& tar -xzf "node-v$NODE_VERSION-linux-i386.tar.gz" -C /usr/local --strip-components=1 \
 	&& rm "node-v$NODE_VERSION-linux-i386.tar.gz" \
-	&& npm install mraa@$MRAA_VERSION \
-	&& npm cache clear \
-	&& npm config set unsafe-perm true -g --unsafe-perm \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& npm config set unsafe-perm true -g --unsafe-perm \
 	&& rm -rf /tmp/*
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/deployment/dockerfile"]

--- a/node/qemux86/debian/7.2/Dockerfile
+++ b/node/qemux86/debian/7.2/Dockerfile
@@ -7,8 +7,6 @@ RUN curl -SLO "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/node-v
 	&& echo "f895607b0dcfb84c2273cff3006a827e83add318cb8d1cc796a3ba602e5377c2  node-v7.2.1-linux-i386.tar.gz" | sha256sum -c - \
 	&& tar -xzf "node-v$NODE_VERSION-linux-i386.tar.gz" -C /usr/local --strip-components=1 \
 	&& rm "node-v$NODE_VERSION-linux-i386.tar.gz" \
-	&& npm install mraa@$MRAA_VERSION \
-	&& npm cache clear \
 	&& npm config set unsafe-perm true -g --unsafe-perm \
 	&& rm -rf /tmp/*
 

--- a/node/qemux86/debian/7.2/slim/Dockerfile
+++ b/node/qemux86/debian/7.2/slim/Dockerfile
@@ -3,7 +3,7 @@ FROM resin/qemux86-debian:jessie
 
 ENV NODE_VERSION 7.2.1
 
-RUN buildDeps='curl build-essential python' \
+RUN buildDeps='curl' \
 	&& set -x \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends \
 	&& rm -rf /var/lib/apt/lists/* \
@@ -11,10 +11,8 @@ RUN buildDeps='curl build-essential python' \
 	&& echo "f895607b0dcfb84c2273cff3006a827e83add318cb8d1cc796a3ba602e5377c2  node-v7.2.1-linux-i386.tar.gz" | sha256sum -c - \
 	&& tar -xzf "node-v$NODE_VERSION-linux-i386.tar.gz" -C /usr/local --strip-components=1 \
 	&& rm "node-v$NODE_VERSION-linux-i386.tar.gz" \
-	&& npm install mraa@$MRAA_VERSION \
-	&& npm cache clear \
-	&& npm config set unsafe-perm true -g --unsafe-perm \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& npm config set unsafe-perm true -g --unsafe-perm \
 	&& rm -rf /tmp/*
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/deployment/dockerfile"]

--- a/node/qemux86/debian/default/Dockerfile
+++ b/node/qemux86/debian/default/Dockerfile
@@ -7,8 +7,6 @@ RUN curl -SLO "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/node-v
 	&& echo "19e29099a9548d6a7f46e0b6433fde862db5839172bb471fc444e9ccaaf16357  node-v0.10.22-linux-i386.tar.gz" | sha256sum -c - \
 	&& tar -xzf "node-v$NODE_VERSION-linux-i386.tar.gz" -C /usr/local --strip-components=1 \
 	&& rm "node-v$NODE_VERSION-linux-i386.tar.gz" \
-	&& npm install mraa@$MRAA_VERSION \
-	&& npm cache clear \
 	&& npm config set unsafe-perm true -g --unsafe-perm \
 	&& rm -rf /tmp/*
 

--- a/node/qemux86/debian/default/slim/Dockerfile
+++ b/node/qemux86/debian/default/slim/Dockerfile
@@ -3,7 +3,7 @@ FROM resin/qemux86-debian:jessie
 
 ENV NODE_VERSION 0.10.22
 
-RUN buildDeps='curl build-essential python' \
+RUN buildDeps='curl' \
 	&& set -x \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends \
 	&& rm -rf /var/lib/apt/lists/* \
@@ -11,10 +11,8 @@ RUN buildDeps='curl build-essential python' \
 	&& echo "19e29099a9548d6a7f46e0b6433fde862db5839172bb471fc444e9ccaaf16357  node-v0.10.22-linux-i386.tar.gz" | sha256sum -c - \
 	&& tar -xzf "node-v$NODE_VERSION-linux-i386.tar.gz" -C /usr/local --strip-components=1 \
 	&& rm "node-v$NODE_VERSION-linux-i386.tar.gz" \
-	&& npm install mraa@$MRAA_VERSION \
-	&& npm cache clear \
-	&& npm config set unsafe-perm true -g --unsafe-perm \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& npm config set unsafe-perm true -g --unsafe-perm \
 	&& rm -rf /tmp/*
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/deployment/dockerfile"]


### PR DESCRIPTION
Update MRAA to v1.5.1.
Update UPM to v1.0.2.

Since latest UPM version can not be built on debian wheezy, we set UPM version on debian wheezy base images to v1.0.0