### PR TITLE
Change the base image for all Debian images to slim variant.

### DIFF
--- a/debian/aarch64/jessie/Dockerfile
+++ b/debian/aarch64/jessie/Dockerfile
@@ -1,4 +1,4 @@
-FROM aarch64/debian:jessie
+FROM aarch64/debian:jessie-slim
 
 LABEL io.resin.architecture="aarch64" io.resin.qemu.version="2.7.0-resin-rc3-aarch64"
 

--- a/debian/amd64/jessie/Dockerfile
+++ b/debian/amd64/jessie/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:jessie
+FROM debian:jessie-slim
 
 LABEL io.resin.architecture="amd64"
 

--- a/debian/amd64/wheezy/Dockerfile
+++ b/debian/amd64/wheezy/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:wheezy
+FROM debian:wheezy-slim
 
 LABEL io.resin.architecture="amd64"
 

--- a/debian/armv7hf/jessie/Dockerfile
+++ b/debian/armv7hf/jessie/Dockerfile
@@ -1,4 +1,4 @@
-FROM armhf/debian:jessie
+FROM armhf/debian:jessie-slim
 
 LABEL io.resin.architecture="armv7hf" io.resin.qemu.version="2.7.0-resin-rc3-arm"
 

--- a/debian/armv7hf/sid/Dockerfile
+++ b/debian/armv7hf/sid/Dockerfile
@@ -1,4 +1,4 @@
-FROM armhf/debian:sid
+FROM armhf/debian:sid-slim
 
 LABEL io.resin.architecture="armv7hf" io.resin.qemu.version="2.7.0-resin-rc3-arm"
 

--- a/debian/armv7hf/wheezy/Dockerfile
+++ b/debian/armv7hf/wheezy/Dockerfile
@@ -1,4 +1,4 @@
-FROM armhf/debian:wheezy
+FROM armhf/debian:wheezy-slim
 
 LABEL io.resin.architecture="armv7hf" io.resin.qemu.version="2.7.0-resin-rc3-arm"
 

--- a/debian/generate-dockerfile.sh
+++ b/debian/generate-dockerfile.sh
@@ -23,6 +23,7 @@ for arch in $archs; do
 		baseImage='armhf/debian'
 		label='io.resin.architecture="armv7hf" io.resin.qemu.version="'$QEMU_VERSION'"'
 		suites='jessie wheezy sid'
+		variant='-slim'
 		qemu='COPY qemu-arm-static /usr/bin/'
 		qemuCpu=''
 	;;
@@ -30,6 +31,7 @@ for arch in $archs; do
 		baseImage='i386/debian'
 		label='io.resin.architecture="i386"'
 		suites='jessie wheezy'
+		variant='-slim'
 		qemu=''
 		qemuCpu=''
 	;;
@@ -37,6 +39,7 @@ for arch in $archs; do
 		baseImage='debian'
 		label='io.resin.architecture="amd64"'
 		suites='jessie wheezy'
+		variant='-slim'
 		qemu=''
 		qemuCpu=''
 	;;
@@ -44,6 +47,7 @@ for arch in $archs; do
 		baseImage='armel/debian'
 		label='io.resin.architecture="armv5e" io.resin.qemu.version="'$QEMU_VERSION'"'
 		suites='jessie wheezy'
+		variant=''
 		qemu='COPY qemu-arm-static /usr/bin/'
 		qemuCpu='ENV QEMU_CPU arm1026'
 	;;
@@ -51,6 +55,7 @@ for arch in $archs; do
 		baseImage='aarch64/debian'
 		label='io.resin.architecture="aarch64" io.resin.qemu.version="'$QEMU_AARCH64_VERSION'"'
 		suites='jessie'
+		variant='-slim'
 		qemu='COPY qemu-aarch64-static /usr/bin/'
 		qemuCpu=''
 	;;
@@ -59,7 +64,7 @@ for arch in $archs; do
 
 		dockerfilePath=$arch/$suite
 		mkdir -p $dockerfilePath
-		sed -e s~#{FROM}~$baseImage:$suite~g \
+		sed -e s~#{FROM}~$baseImage:$suite$variant~g \
 			-e s~#{LABEL}~"$label"~g \
 			-e s~#{QEMU_CPU}~"$qemuCpu"~g \
 			-e s~#{QEMU}~"$qemu"~g Dockerfile.tpl > $dockerfilePath/Dockerfile

--- a/debian/i386/jessie/Dockerfile
+++ b/debian/i386/jessie/Dockerfile
@@ -1,4 +1,4 @@
-FROM i386/debian:jessie
+FROM i386/debian:jessie-slim
 
 LABEL io.resin.architecture="i386"
 

--- a/debian/i386/wheezy/Dockerfile
+++ b/debian/i386/wheezy/Dockerfile
@@ -1,4 +1,4 @@
-FROM i386/debian:wheezy
+FROM i386/debian:wheezy-slim
 
 LABEL io.resin.architecture="i386"
 


### PR DESCRIPTION
it is a slimmer base (removing extra files, docs or manpages). This will save us 20-30 MB in comparison to current base.