### PR TITLE
Remove unnecessary Raspbian repository.

### DIFF
--- a/device-base/Dockerfile.armv7hf.rpi.tpl
+++ b/device-base/Dockerfile.armv7hf.rpi.tpl
@@ -2,10 +2,8 @@ FROM #{FROM}
 
 LABEL io.resin.device-type="#{DEV_TYPE}"
 
-RUN echo "deb http://archive.raspbian.org/raspbian #{SUITE} main contrib non-free rpi firmware" >>  /etc/apt/sources.list \
-	&& apt-key adv --keyserver pgp.mit.edu  --recv-key 0x9165938D90FDDD2E \
-	&& echo "deb http://archive.raspberrypi.org/debian #{SUITE} main" >>  /etc/apt/sources.list.d/raspi.list \
-	&& apt-key adv --keyserver pgp.mit.edu  --recv-key 0x82B129927FA3303E
+RUN echo "deb http://archive.raspbian.org/raspbian #{SUITE} main contrib non-free rpi firmware" >>  /etc/apt/sources.list.d/raspi.list \
+	&& apt-key adv --keyserver pgp.mit.edu  --recv-key 0x9165938D90FDDD2E
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
 		less \


### PR DESCRIPTION
We should keep the master Raspbian repository only for RPi family base
images.