### PR TITLE
Set the latest tag for buildpack-deps base images for Alpine Linux and Fedora to 3.6 and 25 respectively

### DIFF
--- a/buildpack-deps/generate-stackbrew-library.sh
+++ b/buildpack-deps/generate-stackbrew-library.sh
@@ -45,8 +45,8 @@ function generate_library(){
 declare -A aliases
 aliases=(
 	[jessie]='latest'
-	[3.5]='latest'
-	[24]='latest'
+	[3.6]='latest'
+	[25]='latest'
 )
 
 cd "$(dirname "$(readlink -f "$BASH_SOURCE[0]")")"


### PR DESCRIPTION
Can I have your review please @imrehg?