### PR TITLE
Fix broken systemd in Debian Stretch

### DIFF
--- a/debian/Dockerfile.systemd.stretch.partial
+++ b/debian/Dockerfile.systemd.stretch.partial
@@ -1,0 +1,32 @@
+# Install Systemd
+
+RUN echo 'deb http://deb.debian.org/debian jessie-backports main' >> /etc/apt/sources.list.d/jessie-backports.list \
+	&& apt-get remove -y --allow-remove-essential systemd libsystemd0 udev libudev1 \
+	&& apt autoremove -y \
+	&& apt-get update \
+	&& apt-get -t jessie-backports install -y --no-install-recommends \
+		systemd \
+		systemd-sysv udev \
+	&& apt-mark hold systemd \
+	&& rm -rf /etc/apt/sources.list.d/jessie-backports.list \
+	&& rm -rf /var/lib/apt/lists/*
+
+ENV container docker
+
+# We only want few core services run in the container.
+RUN find /etc/systemd/system \
+		/lib/systemd/system \
+		-path '*.wants/*' \
+		-not -name '*journald*' \
+		-not -name '*udevd*' \
+		-not -name '*systemd-tmpfiles*' \
+		-not -name '*systemd-user-sessions*' \
+		-exec rm \{} \;
+
+COPY entry.sh /usr/bin/entry.sh
+COPY launch.service /etc/systemd/system/launch.service
+
+RUN systemctl enable /etc/systemd/system/launch.service
+
+STOPSIGNAL 37
+ENTRYPOINT ["/usr/bin/entry.sh"]

--- a/debian/aarch64/stretch/Dockerfile
+++ b/debian/aarch64/stretch/Dockerfile
@@ -41,31 +41,33 @@ COPY 01_buildconfig /etc/apt/apt.conf.d/
 RUN mkdir -p /usr/share/man/man1
 # Install Systemd
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN echo 'deb http://deb.debian.org/debian jessie-backports main' >> /etc/apt/sources.list.d/jessie-backports.list \
+	&& apt-get remove -y --allow-remove-essential systemd libsystemd0 udev libudev1 \
+	&& apt autoremove -y \
+	&& apt-get update \
+	&& apt-get -t jessie-backports install -y --no-install-recommends \
 		systemd \
+		systemd-sysv udev \
+	&& apt-mark hold systemd \
+	&& rm -rf /etc/apt/sources.list.d/jessie-backports.list \
 	&& rm -rf /var/lib/apt/lists/*
 
 ENV container docker
 
-# We never want these to run in a container
-RUN systemctl mask \
-    dev-hugepages.mount \
-    sys-fs-fuse-connections.mount \
-    sys-kernel-config.mount \
+# We only want few core services run in the container.
+RUN find /etc/systemd/system \
+		/lib/systemd/system \
+		-path '*.wants/*' \
+		-not -name '*journald*' \
+		-not -name '*udevd*' \
+		-not -name '*systemd-tmpfiles*' \
+		-not -name '*systemd-user-sessions*' \
+		-exec rm \{} \;
 
-    display-manager.service \
-    getty@.service \
-    systemd-logind.service \
-    systemd-remount-fs.service \
-
-    getty.target \
-    graphical.target  
-
-COPY entry.sh /usr/bin/entry.sh    
+COPY entry.sh /usr/bin/entry.sh
 COPY launch.service /etc/systemd/system/launch.service
 
 RUN systemctl enable /etc/systemd/system/launch.service
 
 STOPSIGNAL 37
-VOLUME ["/sys/fs/cgroup"]
 ENTRYPOINT ["/usr/bin/entry.sh"]

--- a/debian/amd64/stretch/Dockerfile
+++ b/debian/amd64/stretch/Dockerfile
@@ -41,31 +41,33 @@ COPY 01_buildconfig /etc/apt/apt.conf.d/
 RUN mkdir -p /usr/share/man/man1
 # Install Systemd
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN echo 'deb http://deb.debian.org/debian jessie-backports main' >> /etc/apt/sources.list.d/jessie-backports.list \
+	&& apt-get remove -y --allow-remove-essential systemd libsystemd0 udev libudev1 \
+	&& apt autoremove -y \
+	&& apt-get update \
+	&& apt-get -t jessie-backports install -y --no-install-recommends \
 		systemd \
+		systemd-sysv udev \
+	&& apt-mark hold systemd \
+	&& rm -rf /etc/apt/sources.list.d/jessie-backports.list \
 	&& rm -rf /var/lib/apt/lists/*
 
 ENV container docker
 
-# We never want these to run in a container
-RUN systemctl mask \
-    dev-hugepages.mount \
-    sys-fs-fuse-connections.mount \
-    sys-kernel-config.mount \
+# We only want few core services run in the container.
+RUN find /etc/systemd/system \
+		/lib/systemd/system \
+		-path '*.wants/*' \
+		-not -name '*journald*' \
+		-not -name '*udevd*' \
+		-not -name '*systemd-tmpfiles*' \
+		-not -name '*systemd-user-sessions*' \
+		-exec rm \{} \;
 
-    display-manager.service \
-    getty@.service \
-    systemd-logind.service \
-    systemd-remount-fs.service \
-
-    getty.target \
-    graphical.target  
-
-COPY entry.sh /usr/bin/entry.sh    
+COPY entry.sh /usr/bin/entry.sh
 COPY launch.service /etc/systemd/system/launch.service
 
 RUN systemctl enable /etc/systemd/system/launch.service
 
 STOPSIGNAL 37
-VOLUME ["/sys/fs/cgroup"]
 ENTRYPOINT ["/usr/bin/entry.sh"]

--- a/debian/armel/stretch/Dockerfile
+++ b/debian/armel/stretch/Dockerfile
@@ -41,31 +41,33 @@ COPY 01_buildconfig /etc/apt/apt.conf.d/
 RUN mkdir -p /usr/share/man/man1
 # Install Systemd
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN echo 'deb http://deb.debian.org/debian jessie-backports main' >> /etc/apt/sources.list.d/jessie-backports.list \
+	&& apt-get remove -y --allow-remove-essential systemd libsystemd0 udev libudev1 \
+	&& apt autoremove -y \
+	&& apt-get update \
+	&& apt-get -t jessie-backports install -y --no-install-recommends \
 		systemd \
+		systemd-sysv udev \
+	&& apt-mark hold systemd \
+	&& rm -rf /etc/apt/sources.list.d/jessie-backports.list \
 	&& rm -rf /var/lib/apt/lists/*
 
 ENV container docker
 
-# We never want these to run in a container
-RUN systemctl mask \
-    dev-hugepages.mount \
-    sys-fs-fuse-connections.mount \
-    sys-kernel-config.mount \
+# We only want few core services run in the container.
+RUN find /etc/systemd/system \
+		/lib/systemd/system \
+		-path '*.wants/*' \
+		-not -name '*journald*' \
+		-not -name '*udevd*' \
+		-not -name '*systemd-tmpfiles*' \
+		-not -name '*systemd-user-sessions*' \
+		-exec rm \{} \;
 
-    display-manager.service \
-    getty@.service \
-    systemd-logind.service \
-    systemd-remount-fs.service \
-
-    getty.target \
-    graphical.target  
-
-COPY entry.sh /usr/bin/entry.sh    
+COPY entry.sh /usr/bin/entry.sh
 COPY launch.service /etc/systemd/system/launch.service
 
 RUN systemctl enable /etc/systemd/system/launch.service
 
 STOPSIGNAL 37
-VOLUME ["/sys/fs/cgroup"]
 ENTRYPOINT ["/usr/bin/entry.sh"]

--- a/debian/armv7hf/stretch/Dockerfile
+++ b/debian/armv7hf/stretch/Dockerfile
@@ -41,31 +41,33 @@ COPY 01_buildconfig /etc/apt/apt.conf.d/
 RUN mkdir -p /usr/share/man/man1
 # Install Systemd
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN echo 'deb http://deb.debian.org/debian jessie-backports main' >> /etc/apt/sources.list.d/jessie-backports.list \
+	&& apt-get remove -y --allow-remove-essential systemd libsystemd0 udev libudev1 \
+	&& apt autoremove -y \
+	&& apt-get update \
+	&& apt-get -t jessie-backports install -y --no-install-recommends \
 		systemd \
+		systemd-sysv udev \
+	&& apt-mark hold systemd \
+	&& rm -rf /etc/apt/sources.list.d/jessie-backports.list \
 	&& rm -rf /var/lib/apt/lists/*
 
 ENV container docker
 
-# We never want these to run in a container
-RUN systemctl mask \
-    dev-hugepages.mount \
-    sys-fs-fuse-connections.mount \
-    sys-kernel-config.mount \
+# We only want few core services run in the container.
+RUN find /etc/systemd/system \
+		/lib/systemd/system \
+		-path '*.wants/*' \
+		-not -name '*journald*' \
+		-not -name '*udevd*' \
+		-not -name '*systemd-tmpfiles*' \
+		-not -name '*systemd-user-sessions*' \
+		-exec rm \{} \;
 
-    display-manager.service \
-    getty@.service \
-    systemd-logind.service \
-    systemd-remount-fs.service \
-
-    getty.target \
-    graphical.target  
-
-COPY entry.sh /usr/bin/entry.sh    
+COPY entry.sh /usr/bin/entry.sh
 COPY launch.service /etc/systemd/system/launch.service
 
 RUN systemctl enable /etc/systemd/system/launch.service
 
 STOPSIGNAL 37
-VOLUME ["/sys/fs/cgroup"]
 ENTRYPOINT ["/usr/bin/entry.sh"]

--- a/debian/generate-dockerfile.sh
+++ b/debian/generate-dockerfile.sh
@@ -104,7 +104,11 @@ for arch in $archs; do
 			cat Dockerfile.no-systemd.partial >> $dockerfilePath/Dockerfile
 			cp entry-nosystemd.sh $dockerfilePath/entry.sh
 		else
-			cat Dockerfile.systemd.partial >> $dockerfilePath/Dockerfile
+			if [ $suite == 'stretch' ]; then
+				cat Dockerfile.systemd.stretch.partial >> $dockerfilePath/Dockerfile
+			else
+				cat Dockerfile.systemd.partial >> $dockerfilePath/Dockerfile	
+			fi
 			cp entry.sh launch.service $dockerfilePath/
 		fi
 	done

--- a/debian/i386/stretch/Dockerfile
+++ b/debian/i386/stretch/Dockerfile
@@ -41,31 +41,33 @@ COPY 01_buildconfig /etc/apt/apt.conf.d/
 RUN mkdir -p /usr/share/man/man1
 # Install Systemd
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN echo 'deb http://deb.debian.org/debian jessie-backports main' >> /etc/apt/sources.list.d/jessie-backports.list \
+	&& apt-get remove -y --allow-remove-essential systemd libsystemd0 udev libudev1 \
+	&& apt autoremove -y \
+	&& apt-get update \
+	&& apt-get -t jessie-backports install -y --no-install-recommends \
 		systemd \
+		systemd-sysv udev \
+	&& apt-mark hold systemd \
+	&& rm -rf /etc/apt/sources.list.d/jessie-backports.list \
 	&& rm -rf /var/lib/apt/lists/*
 
 ENV container docker
 
-# We never want these to run in a container
-RUN systemctl mask \
-    dev-hugepages.mount \
-    sys-fs-fuse-connections.mount \
-    sys-kernel-config.mount \
+# We only want few core services run in the container.
+RUN find /etc/systemd/system \
+		/lib/systemd/system \
+		-path '*.wants/*' \
+		-not -name '*journald*' \
+		-not -name '*udevd*' \
+		-not -name '*systemd-tmpfiles*' \
+		-not -name '*systemd-user-sessions*' \
+		-exec rm \{} \;
 
-    display-manager.service \
-    getty@.service \
-    systemd-logind.service \
-    systemd-remount-fs.service \
-
-    getty.target \
-    graphical.target  
-
-COPY entry.sh /usr/bin/entry.sh    
+COPY entry.sh /usr/bin/entry.sh
 COPY launch.service /etc/systemd/system/launch.service
 
 RUN systemctl enable /etc/systemd/system/launch.service
 
 STOPSIGNAL 37
-VOLUME ["/sys/fs/cgroup"]
 ENTRYPOINT ["/usr/bin/entry.sh"]


### PR DESCRIPTION
Fix #319 and #323. Details mentioned in issue #323.
Downgrade systemd to v230-7(jessie-backports) to make it works again.

This PR only fixes systemd on Debian Stretch. On Fedora 25, I'm able to downgrade systemd to v229 (Fedora 24) but it doesn't work properly yet so the fix for Fedora will be submitted later.