### PR TITLE
Fix issue with service is not properly cleaned up on Alpine Linux images

### DIFF
--- a/alpine/aarch64/3.5/entry.sh
+++ b/alpine/aarch64/3.5/entry.sh
@@ -44,6 +44,11 @@ function init_openrc()
 	printf '%q ' "$@" >> /etc/resinApp.sh
 	chmod +x /etc/resinApp.sh
 
+	# Make sure there is no pidfile before starting.
+	if [ -f "/var/run/resinapp.pid" ]; then
+		rm -f /var/run/resinapp.pid &> /dev/null
+	fi
+
 	sed -i -e s~#{DIR}~"$(pwd)"~g /etc/init.d/resin
 
 	exec /sbin/init quiet

--- a/alpine/aarch64/3.6/entry.sh
+++ b/alpine/aarch64/3.6/entry.sh
@@ -44,6 +44,11 @@ function init_openrc()
 	printf '%q ' "$@" >> /etc/resinApp.sh
 	chmod +x /etc/resinApp.sh
 
+	# Make sure there is no pidfile before starting.
+	if [ -f "/var/run/resinapp.pid" ]; then
+		rm -f /var/run/resinapp.pid &> /dev/null
+	fi
+
 	sed -i -e s~#{DIR}~"$(pwd)"~g /etc/init.d/resin
 
 	exec /sbin/init quiet

--- a/alpine/amd64/3.5/entry.sh
+++ b/alpine/amd64/3.5/entry.sh
@@ -44,6 +44,11 @@ function init_openrc()
 	printf '%q ' "$@" >> /etc/resinApp.sh
 	chmod +x /etc/resinApp.sh
 
+	# Make sure there is no pidfile before starting.
+	if [ -f "/var/run/resinapp.pid" ]; then
+		rm -f /var/run/resinapp.pid &> /dev/null
+	fi
+
 	sed -i -e s~#{DIR}~"$(pwd)"~g /etc/init.d/resin
 
 	exec /sbin/init quiet

--- a/alpine/amd64/3.6/entry.sh
+++ b/alpine/amd64/3.6/entry.sh
@@ -44,6 +44,11 @@ function init_openrc()
 	printf '%q ' "$@" >> /etc/resinApp.sh
 	chmod +x /etc/resinApp.sh
 
+	# Make sure there is no pidfile before starting.
+	if [ -f "/var/run/resinapp.pid" ]; then
+		rm -f /var/run/resinapp.pid &> /dev/null
+	fi
+
 	sed -i -e s~#{DIR}~"$(pwd)"~g /etc/init.d/resin
 
 	exec /sbin/init quiet

--- a/alpine/armhf/3.5/entry.sh
+++ b/alpine/armhf/3.5/entry.sh
@@ -44,6 +44,11 @@ function init_openrc()
 	printf '%q ' "$@" >> /etc/resinApp.sh
 	chmod +x /etc/resinApp.sh
 
+	# Make sure there is no pidfile before starting.
+	if [ -f "/var/run/resinapp.pid" ]; then
+		rm -f /var/run/resinapp.pid &> /dev/null
+	fi
+
 	sed -i -e s~#{DIR}~"$(pwd)"~g /etc/init.d/resin
 
 	exec /sbin/init quiet

--- a/alpine/armhf/3.6/entry.sh
+++ b/alpine/armhf/3.6/entry.sh
@@ -44,6 +44,11 @@ function init_openrc()
 	printf '%q ' "$@" >> /etc/resinApp.sh
 	chmod +x /etc/resinApp.sh
 
+	# Make sure there is no pidfile before starting.
+	if [ -f "/var/run/resinapp.pid" ]; then
+		rm -f /var/run/resinapp.pid &> /dev/null
+	fi
+
 	sed -i -e s~#{DIR}~"$(pwd)"~g /etc/init.d/resin
 
 	exec /sbin/init quiet

--- a/alpine/entry.sh
+++ b/alpine/entry.sh
@@ -44,6 +44,11 @@ function init_openrc()
 	printf '%q ' "$@" >> /etc/resinApp.sh
 	chmod +x /etc/resinApp.sh
 
+	# Make sure there is no pidfile before starting.
+	if [ -f "/var/run/resinapp.pid" ]; then
+		rm -f /var/run/resinapp.pid &> /dev/null
+	fi
+
 	sed -i -e s~#{DIR}~"$(pwd)"~g /etc/init.d/resin
 
 	exec /sbin/init quiet

--- a/alpine/i386/3.5/entry.sh
+++ b/alpine/i386/3.5/entry.sh
@@ -44,6 +44,11 @@ function init_openrc()
 	printf '%q ' "$@" >> /etc/resinApp.sh
 	chmod +x /etc/resinApp.sh
 
+	# Make sure there is no pidfile before starting.
+	if [ -f "/var/run/resinapp.pid" ]; then
+		rm -f /var/run/resinapp.pid &> /dev/null
+	fi
+
 	sed -i -e s~#{DIR}~"$(pwd)"~g /etc/init.d/resin
 
 	exec /sbin/init quiet

--- a/alpine/i386/3.6/entry.sh
+++ b/alpine/i386/3.6/entry.sh
@@ -44,6 +44,11 @@ function init_openrc()
 	printf '%q ' "$@" >> /etc/resinApp.sh
 	chmod +x /etc/resinApp.sh
 
+	# Make sure there is no pidfile before starting.
+	if [ -f "/var/run/resinapp.pid" ]; then
+		rm -f /var/run/resinapp.pid &> /dev/null
+	fi
+
 	sed -i -e s~#{DIR}~"$(pwd)"~g /etc/init.d/resin
 
 	exec /sbin/init quiet


### PR DESCRIPTION
Connects to https://github.com/resin-io/hq/issues/987.
After checking user's log and Dockerfile, this issue happens when container starts and can only be reproduced by creating a process and echoing its PID to `/var/run/resinapp.pid` before starting OpenRC. 

When OpenRC starts resin service, it will  first check whether the process with PID in `/var/run/resinapp.pid` is running or not (if that file exists) and the error will be thrown in case it's running. It seems weird that the issue can happen right after the container starts so I think the possible fix here is to make sure that the pidfile and process don't exist.