### PR TITLE
Remove unnecessary runtime deps for python dbus. 

### DIFF
--- a/python/Dockerfile.alpine.python3.slim.tpl
+++ b/python/Dockerfile.alpine.python3.slim.tpl
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/Dockerfile.alpine.slim.tpl
+++ b/python/Dockerfile.alpine.slim.tpl
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/deployment/dockerfile"]

--- a/python/Dockerfile.python3.slim.tpl
+++ b/python/Dockerfile.python3.slim.tpl
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/Dockerfile.slim.tpl
+++ b/python/Dockerfile.slim.tpl
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/deployment/dockerfile"]

--- a/python/aarch64/alpine/2.7/slim/Dockerfile
+++ b/python/aarch64/alpine/2.7/slim/Dockerfile
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/deployment/dockerfile"]

--- a/python/aarch64/alpine/3.3/slim/Dockerfile
+++ b/python/aarch64/alpine/3.3/slim/Dockerfile
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/aarch64/alpine/3.4/slim/Dockerfile
+++ b/python/aarch64/alpine/3.4/slim/Dockerfile
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/aarch64/alpine/3.5/slim/Dockerfile
+++ b/python/aarch64/alpine/3.5/slim/Dockerfile
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/aarch64/alpine/3.6/slim/Dockerfile
+++ b/python/aarch64/alpine/3.6/slim/Dockerfile
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/aarch64/debian/2.7/slim/Dockerfile
+++ b/python/aarch64/debian/2.7/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/deployment/dockerfile"]

--- a/python/aarch64/debian/3.3/slim/Dockerfile
+++ b/python/aarch64/debian/3.3/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/aarch64/debian/3.4/slim/Dockerfile
+++ b/python/aarch64/debian/3.4/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/aarch64/debian/3.5/slim/Dockerfile
+++ b/python/aarch64/debian/3.5/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/aarch64/debian/3.6/slim/Dockerfile
+++ b/python/aarch64/debian/3.6/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/am571x-evm/alpine/2.7/slim/Dockerfile
+++ b/python/am571x-evm/alpine/2.7/slim/Dockerfile
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/deployment/dockerfile"]

--- a/python/am571x-evm/alpine/3.3/slim/Dockerfile
+++ b/python/am571x-evm/alpine/3.3/slim/Dockerfile
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/am571x-evm/alpine/3.4/slim/Dockerfile
+++ b/python/am571x-evm/alpine/3.4/slim/Dockerfile
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/am571x-evm/alpine/3.5/slim/Dockerfile
+++ b/python/am571x-evm/alpine/3.5/slim/Dockerfile
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/am571x-evm/alpine/3.6/slim/Dockerfile
+++ b/python/am571x-evm/alpine/3.6/slim/Dockerfile
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/am571x-evm/debian/2.7/slim/Dockerfile
+++ b/python/am571x-evm/debian/2.7/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/deployment/dockerfile"]

--- a/python/am571x-evm/debian/3.3/slim/Dockerfile
+++ b/python/am571x-evm/debian/3.3/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/am571x-evm/debian/3.4/slim/Dockerfile
+++ b/python/am571x-evm/debian/3.4/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/am571x-evm/debian/3.5/slim/Dockerfile
+++ b/python/am571x-evm/debian/3.5/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/am571x-evm/debian/3.6/slim/Dockerfile
+++ b/python/am571x-evm/debian/3.6/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/amd64/alpine/2.7/slim/Dockerfile
+++ b/python/amd64/alpine/2.7/slim/Dockerfile
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/deployment/dockerfile"]

--- a/python/amd64/alpine/3.3/slim/Dockerfile
+++ b/python/amd64/alpine/3.3/slim/Dockerfile
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/amd64/alpine/3.4/slim/Dockerfile
+++ b/python/amd64/alpine/3.4/slim/Dockerfile
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/amd64/alpine/3.5/slim/Dockerfile
+++ b/python/amd64/alpine/3.5/slim/Dockerfile
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/amd64/alpine/3.6/slim/Dockerfile
+++ b/python/amd64/alpine/3.6/slim/Dockerfile
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/amd64/debian/2.7/slim/Dockerfile
+++ b/python/amd64/debian/2.7/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/deployment/dockerfile"]

--- a/python/amd64/debian/3.3/slim/Dockerfile
+++ b/python/amd64/debian/3.3/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/amd64/debian/3.4/slim/Dockerfile
+++ b/python/amd64/debian/3.4/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/amd64/debian/3.5/slim/Dockerfile
+++ b/python/amd64/debian/3.5/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/amd64/debian/3.6/slim/Dockerfile
+++ b/python/amd64/debian/3.6/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/apalis-imx6q/alpine/2.7/slim/Dockerfile
+++ b/python/apalis-imx6q/alpine/2.7/slim/Dockerfile
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/deployment/dockerfile"]

--- a/python/apalis-imx6q/alpine/3.3/slim/Dockerfile
+++ b/python/apalis-imx6q/alpine/3.3/slim/Dockerfile
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/apalis-imx6q/alpine/3.4/slim/Dockerfile
+++ b/python/apalis-imx6q/alpine/3.4/slim/Dockerfile
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/apalis-imx6q/alpine/3.5/slim/Dockerfile
+++ b/python/apalis-imx6q/alpine/3.5/slim/Dockerfile
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/apalis-imx6q/alpine/3.6/slim/Dockerfile
+++ b/python/apalis-imx6q/alpine/3.6/slim/Dockerfile
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/apalis-imx6q/debian/2.7/slim/Dockerfile
+++ b/python/apalis-imx6q/debian/2.7/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/deployment/dockerfile"]

--- a/python/apalis-imx6q/debian/3.3/slim/Dockerfile
+++ b/python/apalis-imx6q/debian/3.3/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/apalis-imx6q/debian/3.4/slim/Dockerfile
+++ b/python/apalis-imx6q/debian/3.4/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/apalis-imx6q/debian/3.5/slim/Dockerfile
+++ b/python/apalis-imx6q/debian/3.5/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/apalis-imx6q/debian/3.6/slim/Dockerfile
+++ b/python/apalis-imx6q/debian/3.6/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/armel/debian/2.7/slim/Dockerfile
+++ b/python/armel/debian/2.7/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/deployment/dockerfile"]

--- a/python/armel/debian/3.3/slim/Dockerfile
+++ b/python/armel/debian/3.3/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/armel/debian/3.4/slim/Dockerfile
+++ b/python/armel/debian/3.4/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/armel/debian/3.5/slim/Dockerfile
+++ b/python/armel/debian/3.5/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/armel/debian/3.6/slim/Dockerfile
+++ b/python/armel/debian/3.6/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/armhf/alpine/2.7/slim/Dockerfile
+++ b/python/armhf/alpine/2.7/slim/Dockerfile
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/deployment/dockerfile"]

--- a/python/armhf/alpine/3.3/slim/Dockerfile
+++ b/python/armhf/alpine/3.3/slim/Dockerfile
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/armhf/alpine/3.4/slim/Dockerfile
+++ b/python/armhf/alpine/3.4/slim/Dockerfile
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/armhf/alpine/3.5/slim/Dockerfile
+++ b/python/armhf/alpine/3.5/slim/Dockerfile
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/armhf/alpine/3.6/slim/Dockerfile
+++ b/python/armhf/alpine/3.6/slim/Dockerfile
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/armhf/debian/3.3/slim/Dockerfile
+++ b/python/armhf/debian/3.3/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/armhf/debian/3.4/slim/Dockerfile
+++ b/python/armhf/debian/3.4/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/armhf/debian/3.5/slim/Dockerfile
+++ b/python/armhf/debian/3.5/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/armhf/debian/3.6/slim/Dockerfile
+++ b/python/armhf/debian/3.6/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/armv7hf/debian/2.7/slim/Dockerfile
+++ b/python/armv7hf/debian/2.7/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/deployment/dockerfile"]

--- a/python/artik10/alpine/2.7/slim/Dockerfile
+++ b/python/artik10/alpine/2.7/slim/Dockerfile
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/deployment/dockerfile"]

--- a/python/artik10/alpine/3.3/slim/Dockerfile
+++ b/python/artik10/alpine/3.3/slim/Dockerfile
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/artik10/alpine/3.4/slim/Dockerfile
+++ b/python/artik10/alpine/3.4/slim/Dockerfile
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/artik10/alpine/3.5/slim/Dockerfile
+++ b/python/artik10/alpine/3.5/slim/Dockerfile
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/artik10/alpine/3.6/slim/Dockerfile
+++ b/python/artik10/alpine/3.6/slim/Dockerfile
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/artik10/debian/2.7/slim/Dockerfile
+++ b/python/artik10/debian/2.7/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/deployment/dockerfile"]

--- a/python/artik10/debian/3.3/slim/Dockerfile
+++ b/python/artik10/debian/3.3/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/artik10/debian/3.4/slim/Dockerfile
+++ b/python/artik10/debian/3.4/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/artik10/debian/3.5/slim/Dockerfile
+++ b/python/artik10/debian/3.5/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/artik10/debian/3.6/slim/Dockerfile
+++ b/python/artik10/debian/3.6/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/artik5/alpine/2.7/slim/Dockerfile
+++ b/python/artik5/alpine/2.7/slim/Dockerfile
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/deployment/dockerfile"]

--- a/python/artik5/alpine/3.3/slim/Dockerfile
+++ b/python/artik5/alpine/3.3/slim/Dockerfile
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/artik5/alpine/3.4/slim/Dockerfile
+++ b/python/artik5/alpine/3.4/slim/Dockerfile
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/artik5/alpine/3.5/slim/Dockerfile
+++ b/python/artik5/alpine/3.5/slim/Dockerfile
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/artik5/alpine/3.6/slim/Dockerfile
+++ b/python/artik5/alpine/3.6/slim/Dockerfile
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/artik5/debian/2.7/slim/Dockerfile
+++ b/python/artik5/debian/2.7/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/deployment/dockerfile"]

--- a/python/artik5/debian/3.3/slim/Dockerfile
+++ b/python/artik5/debian/3.3/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/artik5/debian/3.4/slim/Dockerfile
+++ b/python/artik5/debian/3.4/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/artik5/debian/3.5/slim/Dockerfile
+++ b/python/artik5/debian/3.5/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/artik5/debian/3.6/slim/Dockerfile
+++ b/python/artik5/debian/3.6/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/artik710/alpine/2.7/slim/Dockerfile
+++ b/python/artik710/alpine/2.7/slim/Dockerfile
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/deployment/dockerfile"]

--- a/python/artik710/alpine/3.3/slim/Dockerfile
+++ b/python/artik710/alpine/3.3/slim/Dockerfile
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/artik710/alpine/3.4/slim/Dockerfile
+++ b/python/artik710/alpine/3.4/slim/Dockerfile
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/artik710/alpine/3.5/slim/Dockerfile
+++ b/python/artik710/alpine/3.5/slim/Dockerfile
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/artik710/alpine/3.6/slim/Dockerfile
+++ b/python/artik710/alpine/3.6/slim/Dockerfile
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/artik710/debian/2.7/slim/Dockerfile
+++ b/python/artik710/debian/2.7/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/deployment/dockerfile"]

--- a/python/artik710/debian/3.3/slim/Dockerfile
+++ b/python/artik710/debian/3.3/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/artik710/debian/3.4/slim/Dockerfile
+++ b/python/artik710/debian/3.4/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/artik710/debian/3.5/slim/Dockerfile
+++ b/python/artik710/debian/3.5/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/artik710/debian/3.6/slim/Dockerfile
+++ b/python/artik710/debian/3.6/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/beaglebone-black/alpine/2.7/slim/Dockerfile
+++ b/python/beaglebone-black/alpine/2.7/slim/Dockerfile
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/deployment/dockerfile"]

--- a/python/beaglebone-black/alpine/3.3/slim/Dockerfile
+++ b/python/beaglebone-black/alpine/3.3/slim/Dockerfile
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/beaglebone-black/alpine/3.4/slim/Dockerfile
+++ b/python/beaglebone-black/alpine/3.4/slim/Dockerfile
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/beaglebone-black/alpine/3.5/slim/Dockerfile
+++ b/python/beaglebone-black/alpine/3.5/slim/Dockerfile
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/beaglebone-black/alpine/3.6/slim/Dockerfile
+++ b/python/beaglebone-black/alpine/3.6/slim/Dockerfile
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/beaglebone-black/debian/2.7/slim/Dockerfile
+++ b/python/beaglebone-black/debian/2.7/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/deployment/dockerfile"]

--- a/python/beaglebone-black/debian/3.3/slim/Dockerfile
+++ b/python/beaglebone-black/debian/3.3/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/beaglebone-black/debian/3.4/slim/Dockerfile
+++ b/python/beaglebone-black/debian/3.4/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/beaglebone-black/debian/3.5/slim/Dockerfile
+++ b/python/beaglebone-black/debian/3.5/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/beaglebone-black/debian/3.6/slim/Dockerfile
+++ b/python/beaglebone-black/debian/3.6/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/beaglebone-green-wifi/alpine/2.7/slim/Dockerfile
+++ b/python/beaglebone-green-wifi/alpine/2.7/slim/Dockerfile
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/deployment/dockerfile"]

--- a/python/beaglebone-green-wifi/alpine/3.3/slim/Dockerfile
+++ b/python/beaglebone-green-wifi/alpine/3.3/slim/Dockerfile
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/beaglebone-green-wifi/alpine/3.4/slim/Dockerfile
+++ b/python/beaglebone-green-wifi/alpine/3.4/slim/Dockerfile
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/beaglebone-green-wifi/alpine/3.5/slim/Dockerfile
+++ b/python/beaglebone-green-wifi/alpine/3.5/slim/Dockerfile
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/beaglebone-green-wifi/alpine/3.6/slim/Dockerfile
+++ b/python/beaglebone-green-wifi/alpine/3.6/slim/Dockerfile
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/beaglebone-green-wifi/debian/2.7/slim/Dockerfile
+++ b/python/beaglebone-green-wifi/debian/2.7/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/deployment/dockerfile"]

--- a/python/beaglebone-green-wifi/debian/3.3/slim/Dockerfile
+++ b/python/beaglebone-green-wifi/debian/3.3/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/beaglebone-green-wifi/debian/3.4/slim/Dockerfile
+++ b/python/beaglebone-green-wifi/debian/3.4/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/beaglebone-green-wifi/debian/3.5/slim/Dockerfile
+++ b/python/beaglebone-green-wifi/debian/3.5/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/beaglebone-green-wifi/debian/3.6/slim/Dockerfile
+++ b/python/beaglebone-green-wifi/debian/3.6/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/beaglebone-green/alpine/2.7/slim/Dockerfile
+++ b/python/beaglebone-green/alpine/2.7/slim/Dockerfile
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/deployment/dockerfile"]

--- a/python/beaglebone-green/alpine/3.3/slim/Dockerfile
+++ b/python/beaglebone-green/alpine/3.3/slim/Dockerfile
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/beaglebone-green/alpine/3.4/slim/Dockerfile
+++ b/python/beaglebone-green/alpine/3.4/slim/Dockerfile
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/beaglebone-green/alpine/3.5/slim/Dockerfile
+++ b/python/beaglebone-green/alpine/3.5/slim/Dockerfile
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/beaglebone-green/alpine/3.6/slim/Dockerfile
+++ b/python/beaglebone-green/alpine/3.6/slim/Dockerfile
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/beaglebone-green/debian/2.7/slim/Dockerfile
+++ b/python/beaglebone-green/debian/2.7/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/deployment/dockerfile"]

--- a/python/beaglebone-green/debian/3.3/slim/Dockerfile
+++ b/python/beaglebone-green/debian/3.3/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/beaglebone-green/debian/3.4/slim/Dockerfile
+++ b/python/beaglebone-green/debian/3.4/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/beaglebone-green/debian/3.5/slim/Dockerfile
+++ b/python/beaglebone-green/debian/3.5/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/beaglebone-green/debian/3.6/slim/Dockerfile
+++ b/python/beaglebone-green/debian/3.6/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/colibri-imx6dl/alpine/2.7/slim/Dockerfile
+++ b/python/colibri-imx6dl/alpine/2.7/slim/Dockerfile
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/deployment/dockerfile"]

--- a/python/colibri-imx6dl/alpine/3.3/slim/Dockerfile
+++ b/python/colibri-imx6dl/alpine/3.3/slim/Dockerfile
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/colibri-imx6dl/alpine/3.4/slim/Dockerfile
+++ b/python/colibri-imx6dl/alpine/3.4/slim/Dockerfile
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/colibri-imx6dl/alpine/3.5/slim/Dockerfile
+++ b/python/colibri-imx6dl/alpine/3.5/slim/Dockerfile
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/colibri-imx6dl/alpine/3.6/slim/Dockerfile
+++ b/python/colibri-imx6dl/alpine/3.6/slim/Dockerfile
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/colibri-imx6dl/debian/2.7/slim/Dockerfile
+++ b/python/colibri-imx6dl/debian/2.7/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/deployment/dockerfile"]

--- a/python/colibri-imx6dl/debian/3.3/slim/Dockerfile
+++ b/python/colibri-imx6dl/debian/3.3/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/colibri-imx6dl/debian/3.4/slim/Dockerfile
+++ b/python/colibri-imx6dl/debian/3.4/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/colibri-imx6dl/debian/3.5/slim/Dockerfile
+++ b/python/colibri-imx6dl/debian/3.5/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/colibri-imx6dl/debian/3.6/slim/Dockerfile
+++ b/python/colibri-imx6dl/debian/3.6/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/cybertan-ze250/alpine/2.7/slim/Dockerfile
+++ b/python/cybertan-ze250/alpine/2.7/slim/Dockerfile
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/deployment/dockerfile"]

--- a/python/cybertan-ze250/alpine/3.3/slim/Dockerfile
+++ b/python/cybertan-ze250/alpine/3.3/slim/Dockerfile
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/cybertan-ze250/alpine/3.4/slim/Dockerfile
+++ b/python/cybertan-ze250/alpine/3.4/slim/Dockerfile
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/cybertan-ze250/alpine/3.5/slim/Dockerfile
+++ b/python/cybertan-ze250/alpine/3.5/slim/Dockerfile
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/cybertan-ze250/alpine/3.6/slim/Dockerfile
+++ b/python/cybertan-ze250/alpine/3.6/slim/Dockerfile
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/cybertan-ze250/debian/2.7/slim/Dockerfile
+++ b/python/cybertan-ze250/debian/2.7/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/deployment/dockerfile"]

--- a/python/cybertan-ze250/debian/3.3/slim/Dockerfile
+++ b/python/cybertan-ze250/debian/3.3/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/cybertan-ze250/debian/3.4/slim/Dockerfile
+++ b/python/cybertan-ze250/debian/3.4/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/cybertan-ze250/debian/3.5/slim/Dockerfile
+++ b/python/cybertan-ze250/debian/3.5/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/cybertan-ze250/debian/3.6/slim/Dockerfile
+++ b/python/cybertan-ze250/debian/3.6/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/hummingboard/alpine/2.7/slim/Dockerfile
+++ b/python/hummingboard/alpine/2.7/slim/Dockerfile
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/deployment/dockerfile"]

--- a/python/hummingboard/alpine/3.3/slim/Dockerfile
+++ b/python/hummingboard/alpine/3.3/slim/Dockerfile
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/hummingboard/alpine/3.4/slim/Dockerfile
+++ b/python/hummingboard/alpine/3.4/slim/Dockerfile
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/hummingboard/alpine/3.5/slim/Dockerfile
+++ b/python/hummingboard/alpine/3.5/slim/Dockerfile
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/hummingboard/alpine/3.6/slim/Dockerfile
+++ b/python/hummingboard/alpine/3.6/slim/Dockerfile
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/hummingboard/debian/2.7/slim/Dockerfile
+++ b/python/hummingboard/debian/2.7/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/deployment/dockerfile"]

--- a/python/hummingboard/debian/3.3/slim/Dockerfile
+++ b/python/hummingboard/debian/3.3/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/hummingboard/debian/3.4/slim/Dockerfile
+++ b/python/hummingboard/debian/3.4/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/hummingboard/debian/3.5/slim/Dockerfile
+++ b/python/hummingboard/debian/3.5/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/hummingboard/debian/3.6/slim/Dockerfile
+++ b/python/hummingboard/debian/3.6/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/i386/alpine/2.7/slim/Dockerfile
+++ b/python/i386/alpine/2.7/slim/Dockerfile
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/deployment/dockerfile"]

--- a/python/i386/alpine/3.3/slim/Dockerfile
+++ b/python/i386/alpine/3.3/slim/Dockerfile
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/i386/alpine/3.4/slim/Dockerfile
+++ b/python/i386/alpine/3.4/slim/Dockerfile
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/i386/alpine/3.5/slim/Dockerfile
+++ b/python/i386/alpine/3.5/slim/Dockerfile
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/i386/alpine/3.6/slim/Dockerfile
+++ b/python/i386/alpine/3.6/slim/Dockerfile
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/i386/debian/2.7/slim/Dockerfile
+++ b/python/i386/debian/2.7/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/deployment/dockerfile"]

--- a/python/i386/debian/3.3/slim/Dockerfile
+++ b/python/i386/debian/3.3/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/i386/debian/3.4/slim/Dockerfile
+++ b/python/i386/debian/3.4/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/i386/debian/3.5/slim/Dockerfile
+++ b/python/i386/debian/3.5/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/i386/debian/3.6/slim/Dockerfile
+++ b/python/i386/debian/3.6/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/imx6ul-var-dart/alpine/2.7/slim/Dockerfile
+++ b/python/imx6ul-var-dart/alpine/2.7/slim/Dockerfile
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/deployment/dockerfile"]

--- a/python/imx6ul-var-dart/alpine/3.3/slim/Dockerfile
+++ b/python/imx6ul-var-dart/alpine/3.3/slim/Dockerfile
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/imx6ul-var-dart/alpine/3.4/slim/Dockerfile
+++ b/python/imx6ul-var-dart/alpine/3.4/slim/Dockerfile
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/imx6ul-var-dart/alpine/3.5/slim/Dockerfile
+++ b/python/imx6ul-var-dart/alpine/3.5/slim/Dockerfile
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/imx6ul-var-dart/alpine/3.6/slim/Dockerfile
+++ b/python/imx6ul-var-dart/alpine/3.6/slim/Dockerfile
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/imx6ul-var-dart/debian/2.7/slim/Dockerfile
+++ b/python/imx6ul-var-dart/debian/2.7/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/deployment/dockerfile"]

--- a/python/imx6ul-var-dart/debian/3.3/slim/Dockerfile
+++ b/python/imx6ul-var-dart/debian/3.3/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/imx6ul-var-dart/debian/3.4/slim/Dockerfile
+++ b/python/imx6ul-var-dart/debian/3.4/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/imx6ul-var-dart/debian/3.5/slim/Dockerfile
+++ b/python/imx6ul-var-dart/debian/3.5/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/imx6ul-var-dart/debian/3.6/slim/Dockerfile
+++ b/python/imx6ul-var-dart/debian/3.6/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/intel-edison/alpine/2.7/slim/Dockerfile
+++ b/python/intel-edison/alpine/2.7/slim/Dockerfile
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/deployment/dockerfile"]

--- a/python/intel-edison/alpine/3.3/slim/Dockerfile
+++ b/python/intel-edison/alpine/3.3/slim/Dockerfile
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/intel-edison/alpine/3.4/slim/Dockerfile
+++ b/python/intel-edison/alpine/3.4/slim/Dockerfile
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/intel-edison/alpine/3.5/slim/Dockerfile
+++ b/python/intel-edison/alpine/3.5/slim/Dockerfile
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/intel-edison/alpine/3.6/slim/Dockerfile
+++ b/python/intel-edison/alpine/3.6/slim/Dockerfile
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/intel-edison/debian/2.7/slim/Dockerfile
+++ b/python/intel-edison/debian/2.7/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/deployment/dockerfile"]

--- a/python/intel-edison/debian/3.3/slim/Dockerfile
+++ b/python/intel-edison/debian/3.3/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/intel-edison/debian/3.4/slim/Dockerfile
+++ b/python/intel-edison/debian/3.4/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/intel-edison/debian/3.5/slim/Dockerfile
+++ b/python/intel-edison/debian/3.5/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/intel-edison/debian/3.6/slim/Dockerfile
+++ b/python/intel-edison/debian/3.6/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/intel-nuc/alpine/2.7/slim/Dockerfile
+++ b/python/intel-nuc/alpine/2.7/slim/Dockerfile
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/deployment/dockerfile"]

--- a/python/intel-nuc/alpine/3.3/slim/Dockerfile
+++ b/python/intel-nuc/alpine/3.3/slim/Dockerfile
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/intel-nuc/alpine/3.4/slim/Dockerfile
+++ b/python/intel-nuc/alpine/3.4/slim/Dockerfile
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/intel-nuc/alpine/3.5/slim/Dockerfile
+++ b/python/intel-nuc/alpine/3.5/slim/Dockerfile
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/intel-nuc/alpine/3.6/slim/Dockerfile
+++ b/python/intel-nuc/alpine/3.6/slim/Dockerfile
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/intel-nuc/debian/2.7/slim/Dockerfile
+++ b/python/intel-nuc/debian/2.7/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/deployment/dockerfile"]

--- a/python/intel-nuc/debian/3.3/slim/Dockerfile
+++ b/python/intel-nuc/debian/3.3/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/intel-nuc/debian/3.4/slim/Dockerfile
+++ b/python/intel-nuc/debian/3.4/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/intel-nuc/debian/3.5/slim/Dockerfile
+++ b/python/intel-nuc/debian/3.5/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/intel-nuc/debian/3.6/slim/Dockerfile
+++ b/python/intel-nuc/debian/3.6/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/jetson-tx2/alpine/2.7/slim/Dockerfile
+++ b/python/jetson-tx2/alpine/2.7/slim/Dockerfile
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/deployment/dockerfile"]

--- a/python/jetson-tx2/alpine/3.3/slim/Dockerfile
+++ b/python/jetson-tx2/alpine/3.3/slim/Dockerfile
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/jetson-tx2/alpine/3.4/slim/Dockerfile
+++ b/python/jetson-tx2/alpine/3.4/slim/Dockerfile
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/jetson-tx2/alpine/3.5/slim/Dockerfile
+++ b/python/jetson-tx2/alpine/3.5/slim/Dockerfile
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/jetson-tx2/alpine/3.6/slim/Dockerfile
+++ b/python/jetson-tx2/alpine/3.6/slim/Dockerfile
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/jetson-tx2/debian/2.7/slim/Dockerfile
+++ b/python/jetson-tx2/debian/2.7/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/deployment/dockerfile"]

--- a/python/jetson-tx2/debian/3.3/slim/Dockerfile
+++ b/python/jetson-tx2/debian/3.3/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/jetson-tx2/debian/3.4/slim/Dockerfile
+++ b/python/jetson-tx2/debian/3.4/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/jetson-tx2/debian/3.5/slim/Dockerfile
+++ b/python/jetson-tx2/debian/3.5/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/jetson-tx2/debian/3.6/slim/Dockerfile
+++ b/python/jetson-tx2/debian/3.6/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/kitra520/alpine/2.7/slim/Dockerfile
+++ b/python/kitra520/alpine/2.7/slim/Dockerfile
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/deployment/dockerfile"]

--- a/python/kitra520/alpine/3.3/slim/Dockerfile
+++ b/python/kitra520/alpine/3.3/slim/Dockerfile
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/kitra520/alpine/3.4/slim/Dockerfile
+++ b/python/kitra520/alpine/3.4/slim/Dockerfile
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/kitra520/alpine/3.5/slim/Dockerfile
+++ b/python/kitra520/alpine/3.5/slim/Dockerfile
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/kitra520/alpine/3.6/slim/Dockerfile
+++ b/python/kitra520/alpine/3.6/slim/Dockerfile
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/kitra520/debian/2.7/slim/Dockerfile
+++ b/python/kitra520/debian/2.7/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/deployment/dockerfile"]

--- a/python/kitra520/debian/3.3/slim/Dockerfile
+++ b/python/kitra520/debian/3.3/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/kitra520/debian/3.4/slim/Dockerfile
+++ b/python/kitra520/debian/3.4/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/kitra520/debian/3.5/slim/Dockerfile
+++ b/python/kitra520/debian/3.5/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/kitra520/debian/3.6/slim/Dockerfile
+++ b/python/kitra520/debian/3.6/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/kitra710/alpine/2.7/slim/Dockerfile
+++ b/python/kitra710/alpine/2.7/slim/Dockerfile
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/deployment/dockerfile"]

--- a/python/kitra710/alpine/3.3/slim/Dockerfile
+++ b/python/kitra710/alpine/3.3/slim/Dockerfile
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/kitra710/alpine/3.4/slim/Dockerfile
+++ b/python/kitra710/alpine/3.4/slim/Dockerfile
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/kitra710/alpine/3.5/slim/Dockerfile
+++ b/python/kitra710/alpine/3.5/slim/Dockerfile
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/kitra710/alpine/3.6/slim/Dockerfile
+++ b/python/kitra710/alpine/3.6/slim/Dockerfile
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/kitra710/debian/2.7/slim/Dockerfile
+++ b/python/kitra710/debian/2.7/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/deployment/dockerfile"]

--- a/python/kitra710/debian/3.3/slim/Dockerfile
+++ b/python/kitra710/debian/3.3/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/kitra710/debian/3.4/slim/Dockerfile
+++ b/python/kitra710/debian/3.4/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/kitra710/debian/3.5/slim/Dockerfile
+++ b/python/kitra710/debian/3.5/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/kitra710/debian/3.6/slim/Dockerfile
+++ b/python/kitra710/debian/3.6/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/nitrogen6x/alpine/2.7/slim/Dockerfile
+++ b/python/nitrogen6x/alpine/2.7/slim/Dockerfile
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/deployment/dockerfile"]

--- a/python/nitrogen6x/alpine/3.3/slim/Dockerfile
+++ b/python/nitrogen6x/alpine/3.3/slim/Dockerfile
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/nitrogen6x/alpine/3.4/slim/Dockerfile
+++ b/python/nitrogen6x/alpine/3.4/slim/Dockerfile
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/nitrogen6x/alpine/3.5/slim/Dockerfile
+++ b/python/nitrogen6x/alpine/3.5/slim/Dockerfile
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/nitrogen6x/alpine/3.6/slim/Dockerfile
+++ b/python/nitrogen6x/alpine/3.6/slim/Dockerfile
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/nitrogen6x/debian/2.7/slim/Dockerfile
+++ b/python/nitrogen6x/debian/2.7/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/deployment/dockerfile"]

--- a/python/nitrogen6x/debian/3.3/slim/Dockerfile
+++ b/python/nitrogen6x/debian/3.3/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/nitrogen6x/debian/3.4/slim/Dockerfile
+++ b/python/nitrogen6x/debian/3.4/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/nitrogen6x/debian/3.5/slim/Dockerfile
+++ b/python/nitrogen6x/debian/3.5/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/nitrogen6x/debian/3.6/slim/Dockerfile
+++ b/python/nitrogen6x/debian/3.6/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/odroid-c1/alpine/2.7/slim/Dockerfile
+++ b/python/odroid-c1/alpine/2.7/slim/Dockerfile
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/deployment/dockerfile"]

--- a/python/odroid-c1/alpine/3.3/slim/Dockerfile
+++ b/python/odroid-c1/alpine/3.3/slim/Dockerfile
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/odroid-c1/alpine/3.4/slim/Dockerfile
+++ b/python/odroid-c1/alpine/3.4/slim/Dockerfile
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/odroid-c1/alpine/3.5/slim/Dockerfile
+++ b/python/odroid-c1/alpine/3.5/slim/Dockerfile
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/odroid-c1/alpine/3.6/slim/Dockerfile
+++ b/python/odroid-c1/alpine/3.6/slim/Dockerfile
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/odroid-c1/debian/2.7/slim/Dockerfile
+++ b/python/odroid-c1/debian/2.7/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/deployment/dockerfile"]

--- a/python/odroid-c1/debian/3.3/slim/Dockerfile
+++ b/python/odroid-c1/debian/3.3/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/odroid-c1/debian/3.4/slim/Dockerfile
+++ b/python/odroid-c1/debian/3.4/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/odroid-c1/debian/3.5/slim/Dockerfile
+++ b/python/odroid-c1/debian/3.5/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/odroid-c1/debian/3.6/slim/Dockerfile
+++ b/python/odroid-c1/debian/3.6/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/odroid-xu4/alpine/2.7/slim/Dockerfile
+++ b/python/odroid-xu4/alpine/2.7/slim/Dockerfile
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/deployment/dockerfile"]

--- a/python/odroid-xu4/alpine/3.3/slim/Dockerfile
+++ b/python/odroid-xu4/alpine/3.3/slim/Dockerfile
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/odroid-xu4/alpine/3.4/slim/Dockerfile
+++ b/python/odroid-xu4/alpine/3.4/slim/Dockerfile
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/odroid-xu4/alpine/3.5/slim/Dockerfile
+++ b/python/odroid-xu4/alpine/3.5/slim/Dockerfile
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/odroid-xu4/alpine/3.6/slim/Dockerfile
+++ b/python/odroid-xu4/alpine/3.6/slim/Dockerfile
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/odroid-xu4/debian/2.7/slim/Dockerfile
+++ b/python/odroid-xu4/debian/2.7/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/deployment/dockerfile"]

--- a/python/odroid-xu4/debian/3.3/slim/Dockerfile
+++ b/python/odroid-xu4/debian/3.3/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/odroid-xu4/debian/3.4/slim/Dockerfile
+++ b/python/odroid-xu4/debian/3.4/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/odroid-xu4/debian/3.5/slim/Dockerfile
+++ b/python/odroid-xu4/debian/3.5/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/odroid-xu4/debian/3.6/slim/Dockerfile
+++ b/python/odroid-xu4/debian/3.6/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/parallella/alpine/2.7/slim/Dockerfile
+++ b/python/parallella/alpine/2.7/slim/Dockerfile
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/deployment/dockerfile"]

--- a/python/parallella/alpine/3.3/slim/Dockerfile
+++ b/python/parallella/alpine/3.3/slim/Dockerfile
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/parallella/alpine/3.4/slim/Dockerfile
+++ b/python/parallella/alpine/3.4/slim/Dockerfile
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/parallella/alpine/3.5/slim/Dockerfile
+++ b/python/parallella/alpine/3.5/slim/Dockerfile
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/parallella/alpine/3.6/slim/Dockerfile
+++ b/python/parallella/alpine/3.6/slim/Dockerfile
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/parallella/debian/2.7/slim/Dockerfile
+++ b/python/parallella/debian/2.7/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/deployment/dockerfile"]

--- a/python/parallella/debian/3.3/slim/Dockerfile
+++ b/python/parallella/debian/3.3/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/parallella/debian/3.4/slim/Dockerfile
+++ b/python/parallella/debian/3.4/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/parallella/debian/3.5/slim/Dockerfile
+++ b/python/parallella/debian/3.5/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/parallella/debian/3.6/slim/Dockerfile
+++ b/python/parallella/debian/3.6/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/qemux86-64/alpine/2.7/slim/Dockerfile
+++ b/python/qemux86-64/alpine/2.7/slim/Dockerfile
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/deployment/dockerfile"]

--- a/python/qemux86-64/alpine/3.3/slim/Dockerfile
+++ b/python/qemux86-64/alpine/3.3/slim/Dockerfile
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/qemux86-64/alpine/3.4/slim/Dockerfile
+++ b/python/qemux86-64/alpine/3.4/slim/Dockerfile
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/qemux86-64/alpine/3.5/slim/Dockerfile
+++ b/python/qemux86-64/alpine/3.5/slim/Dockerfile
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/qemux86-64/alpine/3.6/slim/Dockerfile
+++ b/python/qemux86-64/alpine/3.6/slim/Dockerfile
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/qemux86-64/debian/2.7/slim/Dockerfile
+++ b/python/qemux86-64/debian/2.7/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/deployment/dockerfile"]

--- a/python/qemux86-64/debian/3.3/slim/Dockerfile
+++ b/python/qemux86-64/debian/3.3/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/qemux86-64/debian/3.4/slim/Dockerfile
+++ b/python/qemux86-64/debian/3.4/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/qemux86-64/debian/3.5/slim/Dockerfile
+++ b/python/qemux86-64/debian/3.5/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/qemux86-64/debian/3.6/slim/Dockerfile
+++ b/python/qemux86-64/debian/3.6/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/qemux86/alpine/2.7/slim/Dockerfile
+++ b/python/qemux86/alpine/2.7/slim/Dockerfile
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/deployment/dockerfile"]

--- a/python/qemux86/alpine/3.3/slim/Dockerfile
+++ b/python/qemux86/alpine/3.3/slim/Dockerfile
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/qemux86/alpine/3.4/slim/Dockerfile
+++ b/python/qemux86/alpine/3.4/slim/Dockerfile
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/qemux86/alpine/3.5/slim/Dockerfile
+++ b/python/qemux86/alpine/3.5/slim/Dockerfile
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/qemux86/alpine/3.6/slim/Dockerfile
+++ b/python/qemux86/alpine/3.6/slim/Dockerfile
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/qemux86/debian/2.7/slim/Dockerfile
+++ b/python/qemux86/debian/2.7/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/deployment/dockerfile"]

--- a/python/qemux86/debian/3.3/slim/Dockerfile
+++ b/python/qemux86/debian/3.3/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/qemux86/debian/3.4/slim/Dockerfile
+++ b/python/qemux86/debian/3.4/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/qemux86/debian/3.5/slim/Dockerfile
+++ b/python/qemux86/debian/3.5/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/qemux86/debian/3.6/slim/Dockerfile
+++ b/python/qemux86/debian/3.6/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/raspberry-pi/alpine/2.7/slim/Dockerfile
+++ b/python/raspberry-pi/alpine/2.7/slim/Dockerfile
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/deployment/dockerfile"]

--- a/python/raspberry-pi/alpine/3.3/slim/Dockerfile
+++ b/python/raspberry-pi/alpine/3.3/slim/Dockerfile
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/raspberry-pi/alpine/3.4/slim/Dockerfile
+++ b/python/raspberry-pi/alpine/3.4/slim/Dockerfile
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/raspberry-pi/alpine/3.5/slim/Dockerfile
+++ b/python/raspberry-pi/alpine/3.5/slim/Dockerfile
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/raspberry-pi/alpine/3.6/slim/Dockerfile
+++ b/python/raspberry-pi/alpine/3.6/slim/Dockerfile
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/raspberry-pi/debian/2.7/slim/Dockerfile
+++ b/python/raspberry-pi/debian/2.7/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/deployment/dockerfile"]

--- a/python/raspberry-pi/debian/3.3/slim/Dockerfile
+++ b/python/raspberry-pi/debian/3.3/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/raspberry-pi/debian/3.4/slim/Dockerfile
+++ b/python/raspberry-pi/debian/3.4/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/raspberry-pi/debian/3.5/slim/Dockerfile
+++ b/python/raspberry-pi/debian/3.5/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/raspberry-pi/debian/3.6/slim/Dockerfile
+++ b/python/raspberry-pi/debian/3.6/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/raspberry-pi2/alpine/2.7/slim/Dockerfile
+++ b/python/raspberry-pi2/alpine/2.7/slim/Dockerfile
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/deployment/dockerfile"]

--- a/python/raspberry-pi2/alpine/3.3/slim/Dockerfile
+++ b/python/raspberry-pi2/alpine/3.3/slim/Dockerfile
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/raspberry-pi2/alpine/3.4/slim/Dockerfile
+++ b/python/raspberry-pi2/alpine/3.4/slim/Dockerfile
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/raspberry-pi2/alpine/3.5/slim/Dockerfile
+++ b/python/raspberry-pi2/alpine/3.5/slim/Dockerfile
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/raspberry-pi2/alpine/3.6/slim/Dockerfile
+++ b/python/raspberry-pi2/alpine/3.6/slim/Dockerfile
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/raspberry-pi2/debian/2.7/slim/Dockerfile
+++ b/python/raspberry-pi2/debian/2.7/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/deployment/dockerfile"]

--- a/python/raspberry-pi2/debian/3.3/slim/Dockerfile
+++ b/python/raspberry-pi2/debian/3.3/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/raspberry-pi2/debian/3.4/slim/Dockerfile
+++ b/python/raspberry-pi2/debian/3.4/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/raspberry-pi2/debian/3.5/slim/Dockerfile
+++ b/python/raspberry-pi2/debian/3.5/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/raspberry-pi2/debian/3.6/slim/Dockerfile
+++ b/python/raspberry-pi2/debian/3.6/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/raspberrypi3/alpine/2.7/slim/Dockerfile
+++ b/python/raspberrypi3/alpine/2.7/slim/Dockerfile
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/deployment/dockerfile"]

--- a/python/raspberrypi3/alpine/3.3/slim/Dockerfile
+++ b/python/raspberrypi3/alpine/3.3/slim/Dockerfile
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/raspberrypi3/alpine/3.4/slim/Dockerfile
+++ b/python/raspberrypi3/alpine/3.4/slim/Dockerfile
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/raspberrypi3/alpine/3.5/slim/Dockerfile
+++ b/python/raspberrypi3/alpine/3.5/slim/Dockerfile
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/raspberrypi3/alpine/3.6/slim/Dockerfile
+++ b/python/raspberrypi3/alpine/3.6/slim/Dockerfile
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/raspberrypi3/debian/2.7/slim/Dockerfile
+++ b/python/raspberrypi3/debian/2.7/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/deployment/dockerfile"]

--- a/python/raspberrypi3/debian/3.3/slim/Dockerfile
+++ b/python/raspberrypi3/debian/3.3/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/raspberrypi3/debian/3.4/slim/Dockerfile
+++ b/python/raspberrypi3/debian/3.4/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/raspberrypi3/debian/3.5/slim/Dockerfile
+++ b/python/raspberrypi3/debian/3.5/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/raspberrypi3/debian/3.6/slim/Dockerfile
+++ b/python/raspberrypi3/debian/3.6/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/ts4900/alpine/2.7/slim/Dockerfile
+++ b/python/ts4900/alpine/2.7/slim/Dockerfile
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/deployment/dockerfile"]

--- a/python/ts4900/alpine/3.3/slim/Dockerfile
+++ b/python/ts4900/alpine/3.3/slim/Dockerfile
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/ts4900/alpine/3.4/slim/Dockerfile
+++ b/python/ts4900/alpine/3.4/slim/Dockerfile
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/ts4900/alpine/3.5/slim/Dockerfile
+++ b/python/ts4900/alpine/3.5/slim/Dockerfile
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/ts4900/alpine/3.6/slim/Dockerfile
+++ b/python/ts4900/alpine/3.6/slim/Dockerfile
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/ts4900/debian/2.7/slim/Dockerfile
+++ b/python/ts4900/debian/2.7/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/deployment/dockerfile"]

--- a/python/ts4900/debian/3.3/slim/Dockerfile
+++ b/python/ts4900/debian/3.3/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/ts4900/debian/3.4/slim/Dockerfile
+++ b/python/ts4900/debian/3.4/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/ts4900/debian/3.5/slim/Dockerfile
+++ b/python/ts4900/debian/3.5/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/ts4900/debian/3.6/slim/Dockerfile
+++ b/python/ts4900/debian/3.6/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/ts7700/debian/2.7/slim/Dockerfile
+++ b/python/ts7700/debian/2.7/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/deployment/dockerfile"]

--- a/python/ts7700/debian/3.3/slim/Dockerfile
+++ b/python/ts7700/debian/3.3/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/ts7700/debian/3.4/slim/Dockerfile
+++ b/python/ts7700/debian/3.4/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/ts7700/debian/3.5/slim/Dockerfile
+++ b/python/ts7700/debian/3.5/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/ts7700/debian/3.6/slim/Dockerfile
+++ b/python/ts7700/debian/3.6/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/up-board/alpine/2.7/slim/Dockerfile
+++ b/python/up-board/alpine/2.7/slim/Dockerfile
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/deployment/dockerfile"]

--- a/python/up-board/alpine/3.3/slim/Dockerfile
+++ b/python/up-board/alpine/3.3/slim/Dockerfile
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/up-board/alpine/3.4/slim/Dockerfile
+++ b/python/up-board/alpine/3.4/slim/Dockerfile
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/up-board/alpine/3.5/slim/Dockerfile
+++ b/python/up-board/alpine/3.5/slim/Dockerfile
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/up-board/alpine/3.6/slim/Dockerfile
+++ b/python/up-board/alpine/3.6/slim/Dockerfile
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/up-board/debian/2.7/slim/Dockerfile
+++ b/python/up-board/debian/2.7/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/deployment/dockerfile"]

--- a/python/up-board/debian/3.3/slim/Dockerfile
+++ b/python/up-board/debian/3.3/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/up-board/debian/3.4/slim/Dockerfile
+++ b/python/up-board/debian/3.4/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/up-board/debian/3.5/slim/Dockerfile
+++ b/python/up-board/debian/3.5/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/up-board/debian/3.6/slim/Dockerfile
+++ b/python/up-board/debian/3.6/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/via-via-vab820-quad/alpine/2.7/slim/Dockerfile
+++ b/python/via-via-vab820-quad/alpine/2.7/slim/Dockerfile
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/deployment/dockerfile"]

--- a/python/via-via-vab820-quad/alpine/3.3/slim/Dockerfile
+++ b/python/via-via-vab820-quad/alpine/3.3/slim/Dockerfile
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/via-via-vab820-quad/alpine/3.4/slim/Dockerfile
+++ b/python/via-via-vab820-quad/alpine/3.4/slim/Dockerfile
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/via-via-vab820-quad/alpine/3.5/slim/Dockerfile
+++ b/python/via-via-vab820-quad/alpine/3.5/slim/Dockerfile
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/via-via-vab820-quad/alpine/3.6/slim/Dockerfile
+++ b/python/via-via-vab820-quad/alpine/3.6/slim/Dockerfile
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/via-via-vab820-quad/debian/2.7/slim/Dockerfile
+++ b/python/via-via-vab820-quad/debian/2.7/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/deployment/dockerfile"]

--- a/python/via-via-vab820-quad/debian/3.3/slim/Dockerfile
+++ b/python/via-via-vab820-quad/debian/3.3/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/via-via-vab820-quad/debian/3.4/slim/Dockerfile
+++ b/python/via-via-vab820-quad/debian/3.4/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/via-via-vab820-quad/debian/3.5/slim/Dockerfile
+++ b/python/via-via-vab820-quad/debian/3.5/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/via-via-vab820-quad/debian/3.6/slim/Dockerfile
+++ b/python/via-via-vab820-quad/debian/3.6/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/zynq-xz702/alpine/2.7/slim/Dockerfile
+++ b/python/zynq-xz702/alpine/2.7/slim/Dockerfile
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/deployment/dockerfile"]

--- a/python/zynq-xz702/alpine/3.3/slim/Dockerfile
+++ b/python/zynq-xz702/alpine/3.3/slim/Dockerfile
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/zynq-xz702/alpine/3.4/slim/Dockerfile
+++ b/python/zynq-xz702/alpine/3.4/slim/Dockerfile
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/zynq-xz702/alpine/3.5/slim/Dockerfile
+++ b/python/zynq-xz702/alpine/3.5/slim/Dockerfile
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/zynq-xz702/alpine/3.6/slim/Dockerfile
+++ b/python/zynq-xz702/alpine/3.6/slim/Dockerfile
@@ -60,11 +60,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apk add --no-cache \
-		dbus-dev \
-		dbus-glib-dev
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -72,6 +67,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-base \
+		dbus-dev \
+		dbus-glib-dev \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& mkdir -p /usr/src/dbus-python \
@@ -86,6 +83,7 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apk del .build-deps \
+	&& apk add --no-cache dbus dbus-glib \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/zynq-xz702/debian/2.7/slim/Dockerfile
+++ b/python/zynq-xz702/debian/2.7/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 CMD ["echo","'No CMD command was set in Dockerfile! Details about CMD command could be found in Dockerfile Guide section in our Docs. Here's the link: http://docs.resin.io/deployment/dockerfile"]

--- a/python/zynq-xz702/debian/3.3/slim/Dockerfile
+++ b/python/zynq-xz702/debian/3.3/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/zynq-xz702/debian/3.4/slim/Dockerfile
+++ b/python/zynq-xz702/debian/3.4/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/zynq-xz702/debian/3.5/slim/Dockerfile
+++ b/python/zynq-xz702/debian/3.5/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist

--- a/python/zynq-xz702/debian/3.6/slim/Dockerfile
+++ b/python/zynq-xz702/debian/3.6/slim/Dockerfile
@@ -56,12 +56,6 @@ RUN set -x \
 # install "virtualenv", since the vast majority of users of this image will want it
 RUN pip3 install --no-cache-dir virtualenv
 
-# install dbus-python dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libdbus-1-dev \
-		libdbus-glib-1-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV PYTHON_DBUS_VERSION 1.2.4
 
 # install dbus-python
@@ -69,6 +63,8 @@ RUN set -x \
 	&& buildDeps=' \
 		curl \
 		build-essential \
+		libdbus-1-dev \
+		libdbus-glib-1-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/dbus-python \
@@ -83,6 +79,8 @@ RUN set -x \
 	&& make install -j$(nproc) \
 	&& cd / \
 	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get update && apt-get install -y libdbus-1-3 libdbus-glib-1-2 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /usr/src/dbus-python
 
 # make some useful symlinks that are expected to exist


### PR DESCRIPTION
The dbus dev packages are only needed to build the lib so can be removed after building, this change will significantly reduce the image size