### PR TITLE
Update launch.Service to restart the service.

### DIFF
--- a/debian/launch.service
+++ b/debian/launch.service
@@ -7,7 +7,7 @@ ExecStart=/etc/resinApp.sh
 StandardOutput=tty
 StandardError=tty
 TTYPath=/dev/console
-
+Restart=always
 
 [Install]
 WantedBy=basic.target


### PR DESCRIPTION
Without this - if the binary exits and you're running a systemd init system, it will just hang - not getting restarted by docker or systemd.