### PR TITLE
Fix library generating script to make sure there will be no duplicate tag.

### DIFF
--- a/golang/generate-stackbrew-library.sh
+++ b/golang/generate-stackbrew-library.sh
@@ -87,15 +87,15 @@ for device in "${devices[@]}"; do
 	for distro in "${distros[@]}"; do
 		# Debian
 		if [ $distro == 'debian' ]; then
-			generate_library "$device" "$distro" "wheezy slim onbuild"
+			generate_library "$device" "$distro" "slim onbuild"
 		fi
 		# Alpine
 		if [ $distro == 'alpine' ]; then
-			generate_library "$device" "$distro" "3.5 slim onbuild"
+			generate_library "$device" "$distro" "slim onbuild"
 		fi
 		# Fedora
 		if [ $distro == 'fedora' ]; then
-			generate_library "$device" "$distro" "23 slim onbuild"
+			generate_library "$device" "$distro" "slim onbuild"
 		fi
 	done
 done

--- a/node/generate-stackbrew-library.sh
+++ b/node/generate-stackbrew-library.sh
@@ -92,15 +92,15 @@ for device in "${devices[@]}"; do
 	for distro in "${distros[@]}"; do
 		# Debian
 		if [ $distro == 'debian' ]; then
-			generate_library "$device" "$distro" "onbuild wheezy slim"
+			generate_library "$device" "$distro" "onbuild slim"
 		fi
 		# Alpine
 		if [ $distro == 'alpine' ]; then
-			generate_library "$device" "$distro" "onbuild 3.5 slim"
+			generate_library "$device" "$distro" "onbuild slim"
 		fi
 		# Fedora
 		if [ $distro == 'fedora' ]; then
-			generate_library "$device" "$distro" "onbuild 23 slim"
+			generate_library "$device" "$distro" "onbuild slim"
 		fi
 	done
 done

--- a/python/generate-stackbrew-library.sh
+++ b/python/generate-stackbrew-library.sh
@@ -76,15 +76,15 @@ for device in "${devices[@]}"; do
 	for distro in "${distros[@]}"; do
 		# Debian
 		if [ $distro == 'debian' ]; then
-			generate_library "$device" "$distro" "onbuild wheezy slim"
+			generate_library "$device" "$distro" "onbuild slim"
 		fi
 		# Alpine
 		if [ $distro == 'alpine' ]; then
-			generate_library "$device" "$distro" "onbuild 3.5 slim"
+			generate_library "$device" "$distro" "onbuild slim"
 		fi
 		# Fedora
 		if [ $distro == 'fedora' ]; then
-			generate_library "$device" "$distro" "onbuild 23 slim"
+			generate_library "$device" "$distro" "onbuild slim"
 		fi
 	done
 done


### PR DESCRIPTION
Connects to https://github.com/resin-io-library/base-images/issues/345.

An example of tag duplication is Python version 3.5.x and Alpine Linux 3.5, so tag `3.5` can point to an image with Python version 3.5.x on Alpine 3.6 or Python version 2.7.x on Alpine 3.5 since `2.7.x` is the latest version and `3.5` is a variant of all Alpine Linux Python images.

This PR will make sure that there is no duplication and language version will be prioritized, so tag `3.5` will point to Python version 3.5.x on Alpine 3.6.