### PR TITLE
 Update sources.list for RPI base images.

### DIFF
--- a/device-base/generate-dockerfile.sh
+++ b/device-base/generate-dockerfile.sh
@@ -7,7 +7,7 @@ rpi_sourcelist='echo "deb http://archive.raspbian.org/raspbian #{SUITE} main con
 	\&\& echo "deb http://archive.raspberrypi.org/debian #{SUITE} main" >>  /etc/apt/sources.list.d/raspi.list \\\
 	\&\& apt-key adv --keyserver pgp.mit.edu  --recv-key 0x82B129927FA3303E'
 
-rpi_sourcelist_stretch='echo "deb http://archive.raspbian.org/raspbian #{SUITE} main contrib non-free rpi firmware" >>  /etc/apt/sources.list \\\
+rpi_sourcelist_buster='echo "deb http://archive.raspbian.org/raspbian #{SUITE} main contrib non-free rpi firmware" >>  /etc/apt/sources.list \\\
 	\&\& apt-key adv --keyserver pgp.mit.edu  --recv-key 0x9165938D90FDDD2E'
 
 # for beaglebone
@@ -305,9 +305,9 @@ for device in $devices; do
 			;;
 			"raspberry"*)
 				case "$suite" in
-				'stretch')
-					# raspberrypi foundation doesn't have stretch yet.
-					sourcelist=$rpi_sourcelist_stretch
+				'buster')
+					# raspberrypi foundation doesn't have buster yet.
+					sourcelist=$rpi_sourcelist_buster
 				;;
 				*)
 					# jessie and wheezy

--- a/device-base/raspberry-pi2/debian/buster/Dockerfile
+++ b/device-base/raspberry-pi2/debian/buster/Dockerfile
@@ -3,9 +3,7 @@ FROM resin/armv7hf-debian:buster
 LABEL io.resin.device-type="raspberry-pi2"
 
 RUN echo "deb http://archive.raspbian.org/raspbian buster main contrib non-free rpi firmware" >>  /etc/apt/sources.list \
-	&& apt-key adv --keyserver pgp.mit.edu  --recv-key 0x9165938D90FDDD2E \
-	&& echo "deb http://archive.raspberrypi.org/debian buster main" >>  /etc/apt/sources.list.d/raspi.list \
-	&& apt-key adv --keyserver pgp.mit.edu  --recv-key 0x82B129927FA3303E
+	&& apt-key adv --keyserver pgp.mit.edu  --recv-key 0x9165938D90FDDD2E
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
 		less \

--- a/device-base/raspberry-pi2/debian/stretch/Dockerfile
+++ b/device-base/raspberry-pi2/debian/stretch/Dockerfile
@@ -3,7 +3,9 @@ FROM resin/armv7hf-debian:stretch
 LABEL io.resin.device-type="raspberry-pi2"
 
 RUN echo "deb http://archive.raspbian.org/raspbian stretch main contrib non-free rpi firmware" >>  /etc/apt/sources.list \
-	&& apt-key adv --keyserver pgp.mit.edu  --recv-key 0x9165938D90FDDD2E
+	&& apt-key adv --keyserver pgp.mit.edu  --recv-key 0x9165938D90FDDD2E \
+	&& echo "deb http://archive.raspberrypi.org/debian stretch main" >>  /etc/apt/sources.list.d/raspi.list \
+	&& apt-key adv --keyserver pgp.mit.edu  --recv-key 0x82B129927FA3303E
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
 		less \

--- a/device-base/raspberrypi3/debian/buster/Dockerfile
+++ b/device-base/raspberrypi3/debian/buster/Dockerfile
@@ -3,9 +3,7 @@ FROM resin/armv7hf-debian:buster
 LABEL io.resin.device-type="raspberrypi3"
 
 RUN echo "deb http://archive.raspbian.org/raspbian buster main contrib non-free rpi firmware" >>  /etc/apt/sources.list \
-	&& apt-key adv --keyserver pgp.mit.edu  --recv-key 0x9165938D90FDDD2E \
-	&& echo "deb http://archive.raspberrypi.org/debian buster main" >>  /etc/apt/sources.list.d/raspi.list \
-	&& apt-key adv --keyserver pgp.mit.edu  --recv-key 0x82B129927FA3303E
+	&& apt-key adv --keyserver pgp.mit.edu  --recv-key 0x9165938D90FDDD2E
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
 		less \

--- a/device-base/raspberrypi3/debian/stretch/Dockerfile
+++ b/device-base/raspberrypi3/debian/stretch/Dockerfile
@@ -3,7 +3,9 @@ FROM resin/armv7hf-debian:stretch
 LABEL io.resin.device-type="raspberrypi3"
 
 RUN echo "deb http://archive.raspbian.org/raspbian stretch main contrib non-free rpi firmware" >>  /etc/apt/sources.list \
-	&& apt-key adv --keyserver pgp.mit.edu  --recv-key 0x9165938D90FDDD2E
+	&& apt-key adv --keyserver pgp.mit.edu  --recv-key 0x9165938D90FDDD2E \
+	&& echo "deb http://archive.raspberrypi.org/debian stretch main" >>  /etc/apt/sources.list.d/raspi.list \
+	&& apt-key adv --keyserver pgp.mit.edu  --recv-key 0x82B129927FA3303E
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
 		less \


### PR DESCRIPTION
- Add Raspberrypi foundation to Stretch sources.list.
- Remove Raspberrypi foundation from Buster sources.list since its not available yet.