### PR TITLE
Add gawk dependency

### DIFF
--- a/debian/Dockerfile.tpl
+++ b/debian/Dockerfile.tpl
@@ -24,6 +24,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		netbase \
 		curl \
 		udev \
+		gawk \
 	&& rm -rf /var/lib/apt/lists/*
 
 # Tini


### PR DESCRIPTION
awk is required by `/usr/bin/entry.sh` entrypoint:
https://github.com/resin-io-library/base-images/blob/master/debian/entry.sh#L108

This should fix my "awk: command not found" issue when using `resin/armv7hf-debian:jessie` image:
```
root@hlnew:~# balena logs resin_supervisor
/usr/bin/entry.sh: line 108: awk: command not found
```
