### PR TITLE
Add UDEV env var to enable/disable udev for base images

### DIFF
--- a/alpine/Dockerfile.tpl
+++ b/alpine/Dockerfile.tpl
@@ -2,6 +2,9 @@ FROM #{FROM}
 
 #{LABEL}
 
+# For backward compatibility, udev is enabled by default
+ENV UDEV on
+
 #{QEMU}
 COPY resin-xbuild /usr/bin/
 RUN ln -s resin-xbuild /usr/bin/cross-build-start \

--- a/alpine/aarch64/3.5/Dockerfile
+++ b/alpine/aarch64/3.5/Dockerfile
@@ -2,6 +2,9 @@ FROM arm64v8/alpine:3.5
 
 LABEL io.resin.architecture="aarch64" io.resin.qemu.version="2.9.0.resin1-arm"
 
+# For backward compatibility, udev is enabled by default
+ENV UDEV on
+
 COPY qemu-aarch64-static /usr/bin/qemu-aarch64-static
 COPY resin-xbuild /usr/bin/
 RUN ln -s resin-xbuild /usr/bin/cross-build-start \

--- a/alpine/aarch64/3.6/Dockerfile
+++ b/alpine/aarch64/3.6/Dockerfile
@@ -2,6 +2,9 @@ FROM arm64v8/alpine:3.6
 
 LABEL io.resin.architecture="aarch64" io.resin.qemu.version="2.9.0.resin1-arm"
 
+# For backward compatibility, udev is enabled by default
+ENV UDEV on
+
 COPY qemu-aarch64-static /usr/bin/qemu-aarch64-static
 COPY resin-xbuild /usr/bin/
 RUN ln -s resin-xbuild /usr/bin/cross-build-start \

--- a/alpine/aarch64/3.7/Dockerfile
+++ b/alpine/aarch64/3.7/Dockerfile
@@ -2,6 +2,9 @@ FROM arm64v8/alpine:3.7
 
 LABEL io.resin.architecture="aarch64" io.resin.qemu.version="2.9.0.resin1-arm"
 
+# For backward compatibility, udev is enabled by default
+ENV UDEV on
+
 COPY qemu-aarch64-static /usr/bin/qemu-aarch64-static
 COPY resin-xbuild /usr/bin/
 RUN ln -s resin-xbuild /usr/bin/cross-build-start \

--- a/alpine/aarch64/edge/Dockerfile
+++ b/alpine/aarch64/edge/Dockerfile
@@ -2,6 +2,9 @@ FROM arm64v8/alpine:edge
 
 LABEL io.resin.architecture="aarch64" io.resin.qemu.version="2.9.0.resin1-arm"
 
+# For backward compatibility, udev is enabled by default
+ENV UDEV on
+
 COPY qemu-aarch64-static /usr/bin/qemu-aarch64-static
 COPY resin-xbuild /usr/bin/
 RUN ln -s resin-xbuild /usr/bin/cross-build-start \

--- a/alpine/amd64/3.5/Dockerfile
+++ b/alpine/amd64/3.5/Dockerfile
@@ -2,6 +2,9 @@ FROM alpine:3.5
 
 LABEL io.resin.architecture="amd64"
 
+# For backward compatibility, udev is enabled by default
+ENV UDEV on
+
 
 COPY resin-xbuild /usr/bin/
 RUN ln -s resin-xbuild /usr/bin/cross-build-start \

--- a/alpine/amd64/3.6/Dockerfile
+++ b/alpine/amd64/3.6/Dockerfile
@@ -2,6 +2,9 @@ FROM alpine:3.6
 
 LABEL io.resin.architecture="amd64"
 
+# For backward compatibility, udev is enabled by default
+ENV UDEV on
+
 
 COPY resin-xbuild /usr/bin/
 RUN ln -s resin-xbuild /usr/bin/cross-build-start \

--- a/alpine/amd64/3.7/Dockerfile
+++ b/alpine/amd64/3.7/Dockerfile
@@ -2,6 +2,9 @@ FROM alpine:3.7
 
 LABEL io.resin.architecture="amd64"
 
+# For backward compatibility, udev is enabled by default
+ENV UDEV on
+
 
 COPY resin-xbuild /usr/bin/
 RUN ln -s resin-xbuild /usr/bin/cross-build-start \

--- a/alpine/amd64/edge/Dockerfile
+++ b/alpine/amd64/edge/Dockerfile
@@ -2,6 +2,9 @@ FROM alpine:edge
 
 LABEL io.resin.architecture="amd64"
 
+# For backward compatibility, udev is enabled by default
+ENV UDEV on
+
 
 COPY resin-xbuild /usr/bin/
 RUN ln -s resin-xbuild /usr/bin/cross-build-start \

--- a/alpine/armhf/3.5/Dockerfile
+++ b/alpine/armhf/3.5/Dockerfile
@@ -2,6 +2,9 @@ FROM arm32v6/alpine:3.5
 
 LABEL io.resin.architecture="armhf" io.resin.qemu.version="2.9.0.resin1-arm"
 
+# For backward compatibility, udev is enabled by default
+ENV UDEV on
+
 COPY qemu-arm-static /usr/bin/qemu-arm-static
 COPY resin-xbuild /usr/bin/
 RUN ln -s resin-xbuild /usr/bin/cross-build-start \

--- a/alpine/armhf/3.6/Dockerfile
+++ b/alpine/armhf/3.6/Dockerfile
@@ -2,6 +2,9 @@ FROM arm32v6/alpine:3.6
 
 LABEL io.resin.architecture="armhf" io.resin.qemu.version="2.9.0.resin1-arm"
 
+# For backward compatibility, udev is enabled by default
+ENV UDEV on
+
 COPY qemu-arm-static /usr/bin/qemu-arm-static
 COPY resin-xbuild /usr/bin/
 RUN ln -s resin-xbuild /usr/bin/cross-build-start \

--- a/alpine/armhf/3.7/Dockerfile
+++ b/alpine/armhf/3.7/Dockerfile
@@ -2,6 +2,9 @@ FROM arm32v6/alpine:3.7
 
 LABEL io.resin.architecture="armhf" io.resin.qemu.version="2.9.0.resin1-arm"
 
+# For backward compatibility, udev is enabled by default
+ENV UDEV on
+
 COPY qemu-arm-static /usr/bin/qemu-arm-static
 COPY resin-xbuild /usr/bin/
 RUN ln -s resin-xbuild /usr/bin/cross-build-start \

--- a/alpine/armhf/edge/Dockerfile
+++ b/alpine/armhf/edge/Dockerfile
@@ -2,6 +2,9 @@ FROM arm32v6/alpine:edge
 
 LABEL io.resin.architecture="armhf" io.resin.qemu.version="2.9.0.resin1-arm"
 
+# For backward compatibility, udev is enabled by default
+ENV UDEV on
+
 COPY qemu-arm-static /usr/bin/qemu-arm-static
 COPY resin-xbuild /usr/bin/
 RUN ln -s resin-xbuild /usr/bin/cross-build-start \

--- a/alpine/i386/3.5/Dockerfile
+++ b/alpine/i386/3.5/Dockerfile
@@ -2,6 +2,9 @@ FROM i386/alpine:3.5
 
 LABEL io.resin.architecture="i386"
 
+# For backward compatibility, udev is enabled by default
+ENV UDEV on
+
 
 COPY resin-xbuild /usr/bin/
 RUN ln -s resin-xbuild /usr/bin/cross-build-start \

--- a/alpine/i386/3.6/Dockerfile
+++ b/alpine/i386/3.6/Dockerfile
@@ -2,6 +2,9 @@ FROM i386/alpine:3.6
 
 LABEL io.resin.architecture="i386"
 
+# For backward compatibility, udev is enabled by default
+ENV UDEV on
+
 
 COPY resin-xbuild /usr/bin/
 RUN ln -s resin-xbuild /usr/bin/cross-build-start \

--- a/alpine/i386/3.7/Dockerfile
+++ b/alpine/i386/3.7/Dockerfile
@@ -2,6 +2,9 @@ FROM i386/alpine:3.7
 
 LABEL io.resin.architecture="i386"
 
+# For backward compatibility, udev is enabled by default
+ENV UDEV on
+
 
 COPY resin-xbuild /usr/bin/
 RUN ln -s resin-xbuild /usr/bin/cross-build-start \

--- a/alpine/i386/edge/Dockerfile
+++ b/alpine/i386/edge/Dockerfile
@@ -2,6 +2,9 @@ FROM i386/alpine:edge
 
 LABEL io.resin.architecture="i386"
 
+# For backward compatibility, udev is enabled by default
+ENV UDEV on
+
 
 COPY resin-xbuild /usr/bin/
 RUN ln -s resin-xbuild /usr/bin/cross-build-start \

--- a/debian/Dockerfile.tpl
+++ b/debian/Dockerfile.tpl
@@ -4,6 +4,8 @@ LABEL #{LABEL}
 
 ENV LC_ALL C.UTF-8
 ENV DEBIAN_FRONTEND noninteractive
+# For backward compatibility, udev is enabled by default
+ENV UDEV on
 
 #{QEMU}
 #{QEMU_CPU}

--- a/debian/aarch64/buster/Dockerfile
+++ b/debian/aarch64/buster/Dockerfile
@@ -4,6 +4,8 @@ LABEL io.resin.architecture="aarch64" io.resin.qemu.version="2.9.0.resin1-aarch6
 
 ENV LC_ALL C.UTF-8
 ENV DEBIAN_FRONTEND noninteractive
+# For backward compatibility, udev is enabled by default
+ENV UDEV on
 
 COPY qemu-aarch64-static /usr/bin/
 

--- a/debian/aarch64/buster/entry.sh
+++ b/debian/aarch64/buster/entry.sh
@@ -4,13 +4,21 @@ set -m
 
 function start_udev()
 {
-	which udevd
-	if [ $? == '0' ]; then
-		udevd --daemon &> /dev/null
+	if [ "$UDEV" == "on" ]; then
+		if [ "$INITSYSTEM" != "on" ]; then
+			which udevd
+			if [ $? == '0' ]; then
+				udevd --daemon &> /dev/null
+			else
+				/lib/systemd/systemd-udevd --daemon &> /dev/null
+			fi
+			udevadm trigger &> /dev/null
+		fi
 	else
-		/lib/systemd/systemd-udevd --daemon &> /dev/null
+		if [ "$INITSYSTEM" == "on" ]; then
+			systemctl mask systemd-udevd
+		fi
 	fi
-	udevadm trigger &> /dev/null
 }
 
 function remove_buildtime_env_var()
@@ -90,10 +98,6 @@ function init_non_systemd()
 	# echo error message, when executable file doesn't exist.
 	if [ $? == '0' ]; then
 		shift
-		if [ ! -z "$RESIN" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
-			# run this on resin device only
-			start_udev
-		fi
 		tini -sg -- "$CMD" "$@" &
 		pid=$!
 		wait "$pid"
@@ -113,10 +117,19 @@ case "$INITSYSTEM" in
 	;;
 esac
 
+UDEV=$(echo "$UDEV" | awk '{print tolower($0)}')
+
+case "$UDEV" in
+	'1' | 'true')
+		UDEV='on'
+	;;
+esac
+
 if [ ! -z "$RESIN" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 	# run this on resin device only
 	update_hostname
 	mount_dev
+	start_udev
 fi 
 
 if [ "$INITSYSTEM" = "on" ]; then

--- a/debian/aarch64/jessie/Dockerfile
+++ b/debian/aarch64/jessie/Dockerfile
@@ -4,6 +4,8 @@ LABEL io.resin.architecture="aarch64" io.resin.qemu.version="2.9.0.resin1-aarch6
 
 ENV LC_ALL C.UTF-8
 ENV DEBIAN_FRONTEND noninteractive
+# For backward compatibility, udev is enabled by default
+ENV UDEV on
 
 COPY qemu-aarch64-static /usr/bin/
 

--- a/debian/aarch64/jessie/entry.sh
+++ b/debian/aarch64/jessie/entry.sh
@@ -4,13 +4,21 @@ set -m
 
 function start_udev()
 {
-	which udevd
-	if [ $? == '0' ]; then
-		udevd --daemon &> /dev/null
+	if [ "$UDEV" == "on" ]; then
+		if [ "$INITSYSTEM" != "on" ]; then
+			which udevd
+			if [ $? == '0' ]; then
+				udevd --daemon &> /dev/null
+			else
+				/lib/systemd/systemd-udevd --daemon &> /dev/null
+			fi
+			udevadm trigger &> /dev/null
+		fi
 	else
-		/lib/systemd/systemd-udevd --daemon &> /dev/null
+		if [ "$INITSYSTEM" == "on" ]; then
+			systemctl mask systemd-udevd
+		fi
 	fi
-	udevadm trigger &> /dev/null
 }
 
 function remove_buildtime_env_var()
@@ -90,10 +98,6 @@ function init_non_systemd()
 	# echo error message, when executable file doesn't exist.
 	if [ $? == '0' ]; then
 		shift
-		if [ ! -z "$RESIN" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
-			# run this on resin device only
-			start_udev
-		fi
 		tini -sg -- "$CMD" "$@" &
 		pid=$!
 		wait "$pid"
@@ -113,10 +117,19 @@ case "$INITSYSTEM" in
 	;;
 esac
 
+UDEV=$(echo "$UDEV" | awk '{print tolower($0)}')
+
+case "$UDEV" in
+	'1' | 'true')
+		UDEV='on'
+	;;
+esac
+
 if [ ! -z "$RESIN" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 	# run this on resin device only
 	update_hostname
 	mount_dev
+	start_udev
 fi 
 
 if [ "$INITSYSTEM" = "on" ]; then

--- a/debian/aarch64/stretch/Dockerfile
+++ b/debian/aarch64/stretch/Dockerfile
@@ -4,6 +4,8 @@ LABEL io.resin.architecture="aarch64" io.resin.qemu.version="2.9.0.resin1-aarch6
 
 ENV LC_ALL C.UTF-8
 ENV DEBIAN_FRONTEND noninteractive
+# For backward compatibility, udev is enabled by default
+ENV UDEV on
 
 COPY qemu-aarch64-static /usr/bin/
 

--- a/debian/aarch64/stretch/entry.sh
+++ b/debian/aarch64/stretch/entry.sh
@@ -4,13 +4,21 @@ set -m
 
 function start_udev()
 {
-	which udevd
-	if [ $? == '0' ]; then
-		udevd --daemon &> /dev/null
+	if [ "$UDEV" == "on" ]; then
+		if [ "$INITSYSTEM" != "on" ]; then
+			which udevd
+			if [ $? == '0' ]; then
+				udevd --daemon &> /dev/null
+			else
+				/lib/systemd/systemd-udevd --daemon &> /dev/null
+			fi
+			udevadm trigger &> /dev/null
+		fi
 	else
-		/lib/systemd/systemd-udevd --daemon &> /dev/null
+		if [ "$INITSYSTEM" == "on" ]; then
+			systemctl mask systemd-udevd
+		fi
 	fi
-	udevadm trigger &> /dev/null
 }
 
 function remove_buildtime_env_var()
@@ -90,10 +98,6 @@ function init_non_systemd()
 	# echo error message, when executable file doesn't exist.
 	if [ $? == '0' ]; then
 		shift
-		if [ ! -z "$RESIN" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
-			# run this on resin device only
-			start_udev
-		fi
 		tini -sg -- "$CMD" "$@" &
 		pid=$!
 		wait "$pid"
@@ -113,10 +117,19 @@ case "$INITSYSTEM" in
 	;;
 esac
 
+UDEV=$(echo "$UDEV" | awk '{print tolower($0)}')
+
+case "$UDEV" in
+	'1' | 'true')
+		UDEV='on'
+	;;
+esac
+
 if [ ! -z "$RESIN" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 	# run this on resin device only
 	update_hostname
 	mount_dev
+	start_udev
 fi 
 
 if [ "$INITSYSTEM" = "on" ]; then

--- a/debian/amd64/buster/Dockerfile
+++ b/debian/amd64/buster/Dockerfile
@@ -4,6 +4,8 @@ LABEL io.resin.architecture="amd64"
 
 ENV LC_ALL C.UTF-8
 ENV DEBIAN_FRONTEND noninteractive
+# For backward compatibility, udev is enabled by default
+ENV UDEV on
 
 
 

--- a/debian/amd64/buster/entry.sh
+++ b/debian/amd64/buster/entry.sh
@@ -4,13 +4,21 @@ set -m
 
 function start_udev()
 {
-	which udevd
-	if [ $? == '0' ]; then
-		udevd --daemon &> /dev/null
+	if [ "$UDEV" == "on" ]; then
+		if [ "$INITSYSTEM" != "on" ]; then
+			which udevd
+			if [ $? == '0' ]; then
+				udevd --daemon &> /dev/null
+			else
+				/lib/systemd/systemd-udevd --daemon &> /dev/null
+			fi
+			udevadm trigger &> /dev/null
+		fi
 	else
-		/lib/systemd/systemd-udevd --daemon &> /dev/null
+		if [ "$INITSYSTEM" == "on" ]; then
+			systemctl mask systemd-udevd
+		fi
 	fi
-	udevadm trigger &> /dev/null
 }
 
 function remove_buildtime_env_var()
@@ -90,10 +98,6 @@ function init_non_systemd()
 	# echo error message, when executable file doesn't exist.
 	if [ $? == '0' ]; then
 		shift
-		if [ ! -z "$RESIN" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
-			# run this on resin device only
-			start_udev
-		fi
 		tini -sg -- "$CMD" "$@" &
 		pid=$!
 		wait "$pid"
@@ -113,10 +117,19 @@ case "$INITSYSTEM" in
 	;;
 esac
 
+UDEV=$(echo "$UDEV" | awk '{print tolower($0)}')
+
+case "$UDEV" in
+	'1' | 'true')
+		UDEV='on'
+	;;
+esac
+
 if [ ! -z "$RESIN" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 	# run this on resin device only
 	update_hostname
 	mount_dev
+	start_udev
 fi 
 
 if [ "$INITSYSTEM" = "on" ]; then

--- a/debian/amd64/jessie/Dockerfile
+++ b/debian/amd64/jessie/Dockerfile
@@ -4,6 +4,8 @@ LABEL io.resin.architecture="amd64"
 
 ENV LC_ALL C.UTF-8
 ENV DEBIAN_FRONTEND noninteractive
+# For backward compatibility, udev is enabled by default
+ENV UDEV on
 
 
 

--- a/debian/amd64/jessie/entry.sh
+++ b/debian/amd64/jessie/entry.sh
@@ -4,13 +4,21 @@ set -m
 
 function start_udev()
 {
-	which udevd
-	if [ $? == '0' ]; then
-		udevd --daemon &> /dev/null
+	if [ "$UDEV" == "on" ]; then
+		if [ "$INITSYSTEM" != "on" ]; then
+			which udevd
+			if [ $? == '0' ]; then
+				udevd --daemon &> /dev/null
+			else
+				/lib/systemd/systemd-udevd --daemon &> /dev/null
+			fi
+			udevadm trigger &> /dev/null
+		fi
 	else
-		/lib/systemd/systemd-udevd --daemon &> /dev/null
+		if [ "$INITSYSTEM" == "on" ]; then
+			systemctl mask systemd-udevd
+		fi
 	fi
-	udevadm trigger &> /dev/null
 }
 
 function remove_buildtime_env_var()
@@ -90,10 +98,6 @@ function init_non_systemd()
 	# echo error message, when executable file doesn't exist.
 	if [ $? == '0' ]; then
 		shift
-		if [ ! -z "$RESIN" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
-			# run this on resin device only
-			start_udev
-		fi
 		tini -sg -- "$CMD" "$@" &
 		pid=$!
 		wait "$pid"
@@ -113,10 +117,19 @@ case "$INITSYSTEM" in
 	;;
 esac
 
+UDEV=$(echo "$UDEV" | awk '{print tolower($0)}')
+
+case "$UDEV" in
+	'1' | 'true')
+		UDEV='on'
+	;;
+esac
+
 if [ ! -z "$RESIN" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 	# run this on resin device only
 	update_hostname
 	mount_dev
+	start_udev
 fi 
 
 if [ "$INITSYSTEM" = "on" ]; then

--- a/debian/amd64/stretch/Dockerfile
+++ b/debian/amd64/stretch/Dockerfile
@@ -4,6 +4,8 @@ LABEL io.resin.architecture="amd64"
 
 ENV LC_ALL C.UTF-8
 ENV DEBIAN_FRONTEND noninteractive
+# For backward compatibility, udev is enabled by default
+ENV UDEV on
 
 
 

--- a/debian/amd64/stretch/entry.sh
+++ b/debian/amd64/stretch/entry.sh
@@ -4,13 +4,21 @@ set -m
 
 function start_udev()
 {
-	which udevd
-	if [ $? == '0' ]; then
-		udevd --daemon &> /dev/null
+	if [ "$UDEV" == "on" ]; then
+		if [ "$INITSYSTEM" != "on" ]; then
+			which udevd
+			if [ $? == '0' ]; then
+				udevd --daemon &> /dev/null
+			else
+				/lib/systemd/systemd-udevd --daemon &> /dev/null
+			fi
+			udevadm trigger &> /dev/null
+		fi
 	else
-		/lib/systemd/systemd-udevd --daemon &> /dev/null
+		if [ "$INITSYSTEM" == "on" ]; then
+			systemctl mask systemd-udevd
+		fi
 	fi
-	udevadm trigger &> /dev/null
 }
 
 function remove_buildtime_env_var()
@@ -90,10 +98,6 @@ function init_non_systemd()
 	# echo error message, when executable file doesn't exist.
 	if [ $? == '0' ]; then
 		shift
-		if [ ! -z "$RESIN" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
-			# run this on resin device only
-			start_udev
-		fi
 		tini -sg -- "$CMD" "$@" &
 		pid=$!
 		wait "$pid"
@@ -113,10 +117,19 @@ case "$INITSYSTEM" in
 	;;
 esac
 
+UDEV=$(echo "$UDEV" | awk '{print tolower($0)}')
+
+case "$UDEV" in
+	'1' | 'true')
+		UDEV='on'
+	;;
+esac
+
 if [ ! -z "$RESIN" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 	# run this on resin device only
 	update_hostname
 	mount_dev
+	start_udev
 fi 
 
 if [ "$INITSYSTEM" = "on" ]; then

--- a/debian/amd64/wheezy/Dockerfile
+++ b/debian/amd64/wheezy/Dockerfile
@@ -4,6 +4,8 @@ LABEL io.resin.architecture="amd64"
 
 ENV LC_ALL C.UTF-8
 ENV DEBIAN_FRONTEND noninteractive
+# For backward compatibility, udev is enabled by default
+ENV UDEV on
 
 
 

--- a/debian/armel/buster/Dockerfile
+++ b/debian/armel/buster/Dockerfile
@@ -4,6 +4,8 @@ LABEL io.resin.architecture="armv5e" io.resin.qemu.version="2.9.0.resin1-arm"
 
 ENV LC_ALL C.UTF-8
 ENV DEBIAN_FRONTEND noninteractive
+# For backward compatibility, udev is enabled by default
+ENV UDEV on
 
 COPY qemu-arm-static /usr/bin/
 ENV QEMU_CPU arm1026

--- a/debian/armel/buster/entry.sh
+++ b/debian/armel/buster/entry.sh
@@ -4,13 +4,21 @@ set -m
 
 function start_udev()
 {
-	which udevd
-	if [ $? == '0' ]; then
-		udevd --daemon &> /dev/null
+	if [ "$UDEV" == "on" ]; then
+		if [ "$INITSYSTEM" != "on" ]; then
+			which udevd
+			if [ $? == '0' ]; then
+				udevd --daemon &> /dev/null
+			else
+				/lib/systemd/systemd-udevd --daemon &> /dev/null
+			fi
+			udevadm trigger &> /dev/null
+		fi
 	else
-		/lib/systemd/systemd-udevd --daemon &> /dev/null
+		if [ "$INITSYSTEM" == "on" ]; then
+			systemctl mask systemd-udevd
+		fi
 	fi
-	udevadm trigger &> /dev/null
 }
 
 function remove_buildtime_env_var()
@@ -90,10 +98,6 @@ function init_non_systemd()
 	# echo error message, when executable file doesn't exist.
 	if [ $? == '0' ]; then
 		shift
-		if [ ! -z "$RESIN" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
-			# run this on resin device only
-			start_udev
-		fi
 		tini -sg -- "$CMD" "$@" &
 		pid=$!
 		wait "$pid"
@@ -113,10 +117,19 @@ case "$INITSYSTEM" in
 	;;
 esac
 
+UDEV=$(echo "$UDEV" | awk '{print tolower($0)}')
+
+case "$UDEV" in
+	'1' | 'true')
+		UDEV='on'
+	;;
+esac
+
 if [ ! -z "$RESIN" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 	# run this on resin device only
 	update_hostname
 	mount_dev
+	start_udev
 fi 
 
 if [ "$INITSYSTEM" = "on" ]; then

--- a/debian/armel/jessie/Dockerfile
+++ b/debian/armel/jessie/Dockerfile
@@ -4,6 +4,8 @@ LABEL io.resin.architecture="armv5e" io.resin.qemu.version="2.9.0.resin1-arm"
 
 ENV LC_ALL C.UTF-8
 ENV DEBIAN_FRONTEND noninteractive
+# For backward compatibility, udev is enabled by default
+ENV UDEV on
 
 COPY qemu-arm-static /usr/bin/
 ENV QEMU_CPU arm1026

--- a/debian/armel/jessie/entry.sh
+++ b/debian/armel/jessie/entry.sh
@@ -4,13 +4,21 @@ set -m
 
 function start_udev()
 {
-	which udevd
-	if [ $? == '0' ]; then
-		udevd --daemon &> /dev/null
+	if [ "$UDEV" == "on" ]; then
+		if [ "$INITSYSTEM" != "on" ]; then
+			which udevd
+			if [ $? == '0' ]; then
+				udevd --daemon &> /dev/null
+			else
+				/lib/systemd/systemd-udevd --daemon &> /dev/null
+			fi
+			udevadm trigger &> /dev/null
+		fi
 	else
-		/lib/systemd/systemd-udevd --daemon &> /dev/null
+		if [ "$INITSYSTEM" == "on" ]; then
+			systemctl mask systemd-udevd
+		fi
 	fi
-	udevadm trigger &> /dev/null
 }
 
 function remove_buildtime_env_var()
@@ -90,10 +98,6 @@ function init_non_systemd()
 	# echo error message, when executable file doesn't exist.
 	if [ $? == '0' ]; then
 		shift
-		if [ ! -z "$RESIN" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
-			# run this on resin device only
-			start_udev
-		fi
 		tini -sg -- "$CMD" "$@" &
 		pid=$!
 		wait "$pid"
@@ -113,10 +117,19 @@ case "$INITSYSTEM" in
 	;;
 esac
 
+UDEV=$(echo "$UDEV" | awk '{print tolower($0)}')
+
+case "$UDEV" in
+	'1' | 'true')
+		UDEV='on'
+	;;
+esac
+
 if [ ! -z "$RESIN" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 	# run this on resin device only
 	update_hostname
 	mount_dev
+	start_udev
 fi 
 
 if [ "$INITSYSTEM" = "on" ]; then

--- a/debian/armel/stretch/Dockerfile
+++ b/debian/armel/stretch/Dockerfile
@@ -4,6 +4,8 @@ LABEL io.resin.architecture="armv5e" io.resin.qemu.version="2.9.0.resin1-arm"
 
 ENV LC_ALL C.UTF-8
 ENV DEBIAN_FRONTEND noninteractive
+# For backward compatibility, udev is enabled by default
+ENV UDEV on
 
 COPY qemu-arm-static /usr/bin/
 ENV QEMU_CPU arm1026

--- a/debian/armel/stretch/entry.sh
+++ b/debian/armel/stretch/entry.sh
@@ -4,13 +4,21 @@ set -m
 
 function start_udev()
 {
-	which udevd
-	if [ $? == '0' ]; then
-		udevd --daemon &> /dev/null
+	if [ "$UDEV" == "on" ]; then
+		if [ "$INITSYSTEM" != "on" ]; then
+			which udevd
+			if [ $? == '0' ]; then
+				udevd --daemon &> /dev/null
+			else
+				/lib/systemd/systemd-udevd --daemon &> /dev/null
+			fi
+			udevadm trigger &> /dev/null
+		fi
 	else
-		/lib/systemd/systemd-udevd --daemon &> /dev/null
+		if [ "$INITSYSTEM" == "on" ]; then
+			systemctl mask systemd-udevd
+		fi
 	fi
-	udevadm trigger &> /dev/null
 }
 
 function remove_buildtime_env_var()
@@ -90,10 +98,6 @@ function init_non_systemd()
 	# echo error message, when executable file doesn't exist.
 	if [ $? == '0' ]; then
 		shift
-		if [ ! -z "$RESIN" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
-			# run this on resin device only
-			start_udev
-		fi
 		tini -sg -- "$CMD" "$@" &
 		pid=$!
 		wait "$pid"
@@ -113,10 +117,19 @@ case "$INITSYSTEM" in
 	;;
 esac
 
+UDEV=$(echo "$UDEV" | awk '{print tolower($0)}')
+
+case "$UDEV" in
+	'1' | 'true')
+		UDEV='on'
+	;;
+esac
+
 if [ ! -z "$RESIN" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 	# run this on resin device only
 	update_hostname
 	mount_dev
+	start_udev
 fi 
 
 if [ "$INITSYSTEM" = "on" ]; then

--- a/debian/armel/wheezy/Dockerfile
+++ b/debian/armel/wheezy/Dockerfile
@@ -4,6 +4,8 @@ LABEL io.resin.architecture="armv5e" io.resin.qemu.version="2.9.0.resin1-arm"
 
 ENV LC_ALL C.UTF-8
 ENV DEBIAN_FRONTEND noninteractive
+# For backward compatibility, udev is enabled by default
+ENV UDEV on
 
 COPY qemu-arm-static /usr/bin/
 ENV QEMU_CPU arm1026

--- a/debian/armv7hf/buster/Dockerfile
+++ b/debian/armv7hf/buster/Dockerfile
@@ -4,6 +4,8 @@ LABEL io.resin.architecture="armv7hf" io.resin.qemu.version="2.9.0.resin1-arm"
 
 ENV LC_ALL C.UTF-8
 ENV DEBIAN_FRONTEND noninteractive
+# For backward compatibility, udev is enabled by default
+ENV UDEV on
 
 COPY qemu-arm-static /usr/bin/
 

--- a/debian/armv7hf/buster/entry.sh
+++ b/debian/armv7hf/buster/entry.sh
@@ -4,13 +4,21 @@ set -m
 
 function start_udev()
 {
-	which udevd
-	if [ $? == '0' ]; then
-		udevd --daemon &> /dev/null
+	if [ "$UDEV" == "on" ]; then
+		if [ "$INITSYSTEM" != "on" ]; then
+			which udevd
+			if [ $? == '0' ]; then
+				udevd --daemon &> /dev/null
+			else
+				/lib/systemd/systemd-udevd --daemon &> /dev/null
+			fi
+			udevadm trigger &> /dev/null
+		fi
 	else
-		/lib/systemd/systemd-udevd --daemon &> /dev/null
+		if [ "$INITSYSTEM" == "on" ]; then
+			systemctl mask systemd-udevd
+		fi
 	fi
-	udevadm trigger &> /dev/null
 }
 
 function remove_buildtime_env_var()
@@ -90,10 +98,6 @@ function init_non_systemd()
 	# echo error message, when executable file doesn't exist.
 	if [ $? == '0' ]; then
 		shift
-		if [ ! -z "$RESIN" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
-			# run this on resin device only
-			start_udev
-		fi
 		tini -sg -- "$CMD" "$@" &
 		pid=$!
 		wait "$pid"
@@ -113,10 +117,19 @@ case "$INITSYSTEM" in
 	;;
 esac
 
+UDEV=$(echo "$UDEV" | awk '{print tolower($0)}')
+
+case "$UDEV" in
+	'1' | 'true')
+		UDEV='on'
+	;;
+esac
+
 if [ ! -z "$RESIN" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 	# run this on resin device only
 	update_hostname
 	mount_dev
+	start_udev
 fi 
 
 if [ "$INITSYSTEM" = "on" ]; then

--- a/debian/armv7hf/jessie/Dockerfile
+++ b/debian/armv7hf/jessie/Dockerfile
@@ -4,6 +4,8 @@ LABEL io.resin.architecture="armv7hf" io.resin.qemu.version="2.9.0.resin1-arm"
 
 ENV LC_ALL C.UTF-8
 ENV DEBIAN_FRONTEND noninteractive
+# For backward compatibility, udev is enabled by default
+ENV UDEV on
 
 COPY qemu-arm-static /usr/bin/
 

--- a/debian/armv7hf/jessie/entry.sh
+++ b/debian/armv7hf/jessie/entry.sh
@@ -4,13 +4,21 @@ set -m
 
 function start_udev()
 {
-	which udevd
-	if [ $? == '0' ]; then
-		udevd --daemon &> /dev/null
+	if [ "$UDEV" == "on" ]; then
+		if [ "$INITSYSTEM" != "on" ]; then
+			which udevd
+			if [ $? == '0' ]; then
+				udevd --daemon &> /dev/null
+			else
+				/lib/systemd/systemd-udevd --daemon &> /dev/null
+			fi
+			udevadm trigger &> /dev/null
+		fi
 	else
-		/lib/systemd/systemd-udevd --daemon &> /dev/null
+		if [ "$INITSYSTEM" == "on" ]; then
+			systemctl mask systemd-udevd
+		fi
 	fi
-	udevadm trigger &> /dev/null
 }
 
 function remove_buildtime_env_var()
@@ -90,10 +98,6 @@ function init_non_systemd()
 	# echo error message, when executable file doesn't exist.
 	if [ $? == '0' ]; then
 		shift
-		if [ ! -z "$RESIN" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
-			# run this on resin device only
-			start_udev
-		fi
 		tini -sg -- "$CMD" "$@" &
 		pid=$!
 		wait "$pid"
@@ -113,10 +117,19 @@ case "$INITSYSTEM" in
 	;;
 esac
 
+UDEV=$(echo "$UDEV" | awk '{print tolower($0)}')
+
+case "$UDEV" in
+	'1' | 'true')
+		UDEV='on'
+	;;
+esac
+
 if [ ! -z "$RESIN" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 	# run this on resin device only
 	update_hostname
 	mount_dev
+	start_udev
 fi 
 
 if [ "$INITSYSTEM" = "on" ]; then

--- a/debian/armv7hf/sid/Dockerfile
+++ b/debian/armv7hf/sid/Dockerfile
@@ -4,6 +4,8 @@ LABEL io.resin.architecture="armv7hf" io.resin.qemu.version="2.9.0.resin1-arm"
 
 ENV LC_ALL C.UTF-8
 ENV DEBIAN_FRONTEND noninteractive
+# For backward compatibility, udev is enabled by default
+ENV UDEV on
 
 COPY qemu-arm-static /usr/bin/
 

--- a/debian/armv7hf/sid/entry.sh
+++ b/debian/armv7hf/sid/entry.sh
@@ -4,13 +4,21 @@ set -m
 
 function start_udev()
 {
-	which udevd
-	if [ $? == '0' ]; then
-		udevd --daemon &> /dev/null
+	if [ "$UDEV" == "on" ]; then
+		if [ "$INITSYSTEM" != "on" ]; then
+			which udevd
+			if [ $? == '0' ]; then
+				udevd --daemon &> /dev/null
+			else
+				/lib/systemd/systemd-udevd --daemon &> /dev/null
+			fi
+			udevadm trigger &> /dev/null
+		fi
 	else
-		/lib/systemd/systemd-udevd --daemon &> /dev/null
+		if [ "$INITSYSTEM" == "on" ]; then
+			systemctl mask systemd-udevd
+		fi
 	fi
-	udevadm trigger &> /dev/null
 }
 
 function remove_buildtime_env_var()
@@ -90,10 +98,6 @@ function init_non_systemd()
 	# echo error message, when executable file doesn't exist.
 	if [ $? == '0' ]; then
 		shift
-		if [ ! -z "$RESIN" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
-			# run this on resin device only
-			start_udev
-		fi
 		tini -sg -- "$CMD" "$@" &
 		pid=$!
 		wait "$pid"
@@ -113,10 +117,19 @@ case "$INITSYSTEM" in
 	;;
 esac
 
+UDEV=$(echo "$UDEV" | awk '{print tolower($0)}')
+
+case "$UDEV" in
+	'1' | 'true')
+		UDEV='on'
+	;;
+esac
+
 if [ ! -z "$RESIN" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 	# run this on resin device only
 	update_hostname
 	mount_dev
+	start_udev
 fi 
 
 if [ "$INITSYSTEM" = "on" ]; then

--- a/debian/armv7hf/stretch/Dockerfile
+++ b/debian/armv7hf/stretch/Dockerfile
@@ -4,6 +4,8 @@ LABEL io.resin.architecture="armv7hf" io.resin.qemu.version="2.9.0.resin1-arm"
 
 ENV LC_ALL C.UTF-8
 ENV DEBIAN_FRONTEND noninteractive
+# For backward compatibility, udev is enabled by default
+ENV UDEV on
 
 COPY qemu-arm-static /usr/bin/
 

--- a/debian/armv7hf/stretch/entry.sh
+++ b/debian/armv7hf/stretch/entry.sh
@@ -4,13 +4,21 @@ set -m
 
 function start_udev()
 {
-	which udevd
-	if [ $? == '0' ]; then
-		udevd --daemon &> /dev/null
+	if [ "$UDEV" == "on" ]; then
+		if [ "$INITSYSTEM" != "on" ]; then
+			which udevd
+			if [ $? == '0' ]; then
+				udevd --daemon &> /dev/null
+			else
+				/lib/systemd/systemd-udevd --daemon &> /dev/null
+			fi
+			udevadm trigger &> /dev/null
+		fi
 	else
-		/lib/systemd/systemd-udevd --daemon &> /dev/null
+		if [ "$INITSYSTEM" == "on" ]; then
+			systemctl mask systemd-udevd
+		fi
 	fi
-	udevadm trigger &> /dev/null
 }
 
 function remove_buildtime_env_var()
@@ -90,10 +98,6 @@ function init_non_systemd()
 	# echo error message, when executable file doesn't exist.
 	if [ $? == '0' ]; then
 		shift
-		if [ ! -z "$RESIN" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
-			# run this on resin device only
-			start_udev
-		fi
 		tini -sg -- "$CMD" "$@" &
 		pid=$!
 		wait "$pid"
@@ -113,10 +117,19 @@ case "$INITSYSTEM" in
 	;;
 esac
 
+UDEV=$(echo "$UDEV" | awk '{print tolower($0)}')
+
+case "$UDEV" in
+	'1' | 'true')
+		UDEV='on'
+	;;
+esac
+
 if [ ! -z "$RESIN" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 	# run this on resin device only
 	update_hostname
 	mount_dev
+	start_udev
 fi 
 
 if [ "$INITSYSTEM" = "on" ]; then

--- a/debian/armv7hf/wheezy/Dockerfile
+++ b/debian/armv7hf/wheezy/Dockerfile
@@ -4,6 +4,8 @@ LABEL io.resin.architecture="armv7hf" io.resin.qemu.version="2.9.0.resin1-arm"
 
 ENV LC_ALL C.UTF-8
 ENV DEBIAN_FRONTEND noninteractive
+# For backward compatibility, udev is enabled by default
+ENV UDEV on
 
 COPY qemu-arm-static /usr/bin/
 

--- a/debian/entry.sh
+++ b/debian/entry.sh
@@ -4,13 +4,21 @@ set -m
 
 function start_udev()
 {
-	which udevd
-	if [ $? == '0' ]; then
-		udevd --daemon &> /dev/null
+	if [ "$UDEV" == "on" ]; then
+		if [ "$INITSYSTEM" != "on" ]; then
+			which udevd
+			if [ $? == '0' ]; then
+				udevd --daemon &> /dev/null
+			else
+				/lib/systemd/systemd-udevd --daemon &> /dev/null
+			fi
+			udevadm trigger &> /dev/null
+		fi
 	else
-		/lib/systemd/systemd-udevd --daemon &> /dev/null
+		if [ "$INITSYSTEM" == "on" ]; then
+			systemctl mask systemd-udevd
+		fi
 	fi
-	udevadm trigger &> /dev/null
 }
 
 function remove_buildtime_env_var()
@@ -90,10 +98,6 @@ function init_non_systemd()
 	# echo error message, when executable file doesn't exist.
 	if [ $? == '0' ]; then
 		shift
-		if [ ! -z "$RESIN" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
-			# run this on resin device only
-			start_udev
-		fi
 		tini -sg -- "$CMD" "$@" &
 		pid=$!
 		wait "$pid"
@@ -113,10 +117,19 @@ case "$INITSYSTEM" in
 	;;
 esac
 
+UDEV=$(echo "$UDEV" | awk '{print tolower($0)}')
+
+case "$UDEV" in
+	'1' | 'true')
+		UDEV='on'
+	;;
+esac
+
 if [ ! -z "$RESIN" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 	# run this on resin device only
 	update_hostname
 	mount_dev
+	start_udev
 fi 
 
 if [ "$INITSYSTEM" = "on" ]; then

--- a/debian/i386/buster/Dockerfile
+++ b/debian/i386/buster/Dockerfile
@@ -4,6 +4,8 @@ LABEL io.resin.architecture="i386"
 
 ENV LC_ALL C.UTF-8
 ENV DEBIAN_FRONTEND noninteractive
+# For backward compatibility, udev is enabled by default
+ENV UDEV on
 
 
 

--- a/debian/i386/buster/entry.sh
+++ b/debian/i386/buster/entry.sh
@@ -4,13 +4,21 @@ set -m
 
 function start_udev()
 {
-	which udevd
-	if [ $? == '0' ]; then
-		udevd --daemon &> /dev/null
+	if [ "$UDEV" == "on" ]; then
+		if [ "$INITSYSTEM" != "on" ]; then
+			which udevd
+			if [ $? == '0' ]; then
+				udevd --daemon &> /dev/null
+			else
+				/lib/systemd/systemd-udevd --daemon &> /dev/null
+			fi
+			udevadm trigger &> /dev/null
+		fi
 	else
-		/lib/systemd/systemd-udevd --daemon &> /dev/null
+		if [ "$INITSYSTEM" == "on" ]; then
+			systemctl mask systemd-udevd
+		fi
 	fi
-	udevadm trigger &> /dev/null
 }
 
 function remove_buildtime_env_var()
@@ -90,10 +98,6 @@ function init_non_systemd()
 	# echo error message, when executable file doesn't exist.
 	if [ $? == '0' ]; then
 		shift
-		if [ ! -z "$RESIN" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
-			# run this on resin device only
-			start_udev
-		fi
 		tini -sg -- "$CMD" "$@" &
 		pid=$!
 		wait "$pid"
@@ -113,10 +117,19 @@ case "$INITSYSTEM" in
 	;;
 esac
 
+UDEV=$(echo "$UDEV" | awk '{print tolower($0)}')
+
+case "$UDEV" in
+	'1' | 'true')
+		UDEV='on'
+	;;
+esac
+
 if [ ! -z "$RESIN" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 	# run this on resin device only
 	update_hostname
 	mount_dev
+	start_udev
 fi 
 
 if [ "$INITSYSTEM" = "on" ]; then

--- a/debian/i386/jessie/Dockerfile
+++ b/debian/i386/jessie/Dockerfile
@@ -4,6 +4,8 @@ LABEL io.resin.architecture="i386"
 
 ENV LC_ALL C.UTF-8
 ENV DEBIAN_FRONTEND noninteractive
+# For backward compatibility, udev is enabled by default
+ENV UDEV on
 
 
 

--- a/debian/i386/jessie/entry.sh
+++ b/debian/i386/jessie/entry.sh
@@ -4,13 +4,21 @@ set -m
 
 function start_udev()
 {
-	which udevd
-	if [ $? == '0' ]; then
-		udevd --daemon &> /dev/null
+	if [ "$UDEV" == "on" ]; then
+		if [ "$INITSYSTEM" != "on" ]; then
+			which udevd
+			if [ $? == '0' ]; then
+				udevd --daemon &> /dev/null
+			else
+				/lib/systemd/systemd-udevd --daemon &> /dev/null
+			fi
+			udevadm trigger &> /dev/null
+		fi
 	else
-		/lib/systemd/systemd-udevd --daemon &> /dev/null
+		if [ "$INITSYSTEM" == "on" ]; then
+			systemctl mask systemd-udevd
+		fi
 	fi
-	udevadm trigger &> /dev/null
 }
 
 function remove_buildtime_env_var()
@@ -90,10 +98,6 @@ function init_non_systemd()
 	# echo error message, when executable file doesn't exist.
 	if [ $? == '0' ]; then
 		shift
-		if [ ! -z "$RESIN" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
-			# run this on resin device only
-			start_udev
-		fi
 		tini -sg -- "$CMD" "$@" &
 		pid=$!
 		wait "$pid"
@@ -113,10 +117,19 @@ case "$INITSYSTEM" in
 	;;
 esac
 
+UDEV=$(echo "$UDEV" | awk '{print tolower($0)}')
+
+case "$UDEV" in
+	'1' | 'true')
+		UDEV='on'
+	;;
+esac
+
 if [ ! -z "$RESIN" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 	# run this on resin device only
 	update_hostname
 	mount_dev
+	start_udev
 fi 
 
 if [ "$INITSYSTEM" = "on" ]; then

--- a/debian/i386/stretch/Dockerfile
+++ b/debian/i386/stretch/Dockerfile
@@ -4,6 +4,8 @@ LABEL io.resin.architecture="i386"
 
 ENV LC_ALL C.UTF-8
 ENV DEBIAN_FRONTEND noninteractive
+# For backward compatibility, udev is enabled by default
+ENV UDEV on
 
 
 

--- a/debian/i386/stretch/entry.sh
+++ b/debian/i386/stretch/entry.sh
@@ -4,13 +4,21 @@ set -m
 
 function start_udev()
 {
-	which udevd
-	if [ $? == '0' ]; then
-		udevd --daemon &> /dev/null
+	if [ "$UDEV" == "on" ]; then
+		if [ "$INITSYSTEM" != "on" ]; then
+			which udevd
+			if [ $? == '0' ]; then
+				udevd --daemon &> /dev/null
+			else
+				/lib/systemd/systemd-udevd --daemon &> /dev/null
+			fi
+			udevadm trigger &> /dev/null
+		fi
 	else
-		/lib/systemd/systemd-udevd --daemon &> /dev/null
+		if [ "$INITSYSTEM" == "on" ]; then
+			systemctl mask systemd-udevd
+		fi
 	fi
-	udevadm trigger &> /dev/null
 }
 
 function remove_buildtime_env_var()
@@ -90,10 +98,6 @@ function init_non_systemd()
 	# echo error message, when executable file doesn't exist.
 	if [ $? == '0' ]; then
 		shift
-		if [ ! -z "$RESIN" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
-			# run this on resin device only
-			start_udev
-		fi
 		tini -sg -- "$CMD" "$@" &
 		pid=$!
 		wait "$pid"
@@ -113,10 +117,19 @@ case "$INITSYSTEM" in
 	;;
 esac
 
+UDEV=$(echo "$UDEV" | awk '{print tolower($0)}')
+
+case "$UDEV" in
+	'1' | 'true')
+		UDEV='on'
+	;;
+esac
+
 if [ ! -z "$RESIN" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 	# run this on resin device only
 	update_hostname
 	mount_dev
+	start_udev
 fi 
 
 if [ "$INITSYSTEM" = "on" ]; then

--- a/debian/i386/wheezy/Dockerfile
+++ b/debian/i386/wheezy/Dockerfile
@@ -4,6 +4,8 @@ LABEL io.resin.architecture="i386"
 
 ENV LC_ALL C.UTF-8
 ENV DEBIAN_FRONTEND noninteractive
+# For backward compatibility, udev is enabled by default
+ENV UDEV on
 
 
 

--- a/fedora/Dockerfile.armv7hf.tpl
+++ b/fedora/Dockerfile.armv7hf.tpl
@@ -7,6 +7,9 @@ COPY resin-xbuild /usr/bin/
 RUN ln -s resin-xbuild /usr/bin/cross-build-start \
     && ln -s resin-xbuild /usr/bin/cross-build-end
 
+# For backward compatibility, udev is enabled by default
+ENV UDEV on
+
 # Few tweaks for Fedora base image
 RUN mkdir -p /etc/dnf/vars \
     && echo "armhfp" > /etc/dnf/vars/basearch \

--- a/fedora/Dockerfile.tpl
+++ b/fedora/Dockerfile.tpl
@@ -7,6 +7,9 @@ COPY resin-xbuild /usr/bin/
 RUN ln -s resin-xbuild /usr/bin/cross-build-start \
     && ln -s resin-xbuild /usr/bin/cross-build-end
 
+# For backward compatibility, udev is enabled by default
+ENV UDEV on
+
 RUN dnf update -y \
     && dnf install -y \
         ca-certificates \

--- a/fedora/aarch64/24/Dockerfile
+++ b/fedora/aarch64/24/Dockerfile
@@ -7,6 +7,9 @@ COPY resin-xbuild /usr/bin/
 RUN ln -s resin-xbuild /usr/bin/cross-build-start \
     && ln -s resin-xbuild /usr/bin/cross-build-end
 
+# For backward compatibility, udev is enabled by default
+ENV UDEV on
+
 RUN dnf update -y \
     && dnf install -y \
         ca-certificates \

--- a/fedora/aarch64/25/Dockerfile
+++ b/fedora/aarch64/25/Dockerfile
@@ -7,6 +7,9 @@ COPY resin-xbuild /usr/bin/
 RUN ln -s resin-xbuild /usr/bin/cross-build-start \
     && ln -s resin-xbuild /usr/bin/cross-build-end
 
+# For backward compatibility, udev is enabled by default
+ENV UDEV on
+
 RUN dnf update -y \
     && dnf install -y \
         ca-certificates \

--- a/fedora/aarch64/26/Dockerfile
+++ b/fedora/aarch64/26/Dockerfile
@@ -7,6 +7,9 @@ COPY resin-xbuild /usr/bin/
 RUN ln -s resin-xbuild /usr/bin/cross-build-start \
     && ln -s resin-xbuild /usr/bin/cross-build-end
 
+# For backward compatibility, udev is enabled by default
+ENV UDEV on
+
 RUN dnf update -y \
     && dnf install -y \
         ca-certificates \

--- a/fedora/amd64/24/Dockerfile
+++ b/fedora/amd64/24/Dockerfile
@@ -7,6 +7,9 @@ COPY resin-xbuild /usr/bin/
 RUN ln -s resin-xbuild /usr/bin/cross-build-start \
     && ln -s resin-xbuild /usr/bin/cross-build-end
 
+# For backward compatibility, udev is enabled by default
+ENV UDEV on
+
 RUN dnf update -y \
     && dnf install -y \
         ca-certificates \

--- a/fedora/amd64/25/Dockerfile
+++ b/fedora/amd64/25/Dockerfile
@@ -7,6 +7,9 @@ COPY resin-xbuild /usr/bin/
 RUN ln -s resin-xbuild /usr/bin/cross-build-start \
     && ln -s resin-xbuild /usr/bin/cross-build-end
 
+# For backward compatibility, udev is enabled by default
+ENV UDEV on
+
 RUN dnf update -y \
     && dnf install -y \
         ca-certificates \

--- a/fedora/amd64/26/Dockerfile
+++ b/fedora/amd64/26/Dockerfile
@@ -7,6 +7,9 @@ COPY resin-xbuild /usr/bin/
 RUN ln -s resin-xbuild /usr/bin/cross-build-start \
     && ln -s resin-xbuild /usr/bin/cross-build-end
 
+# For backward compatibility, udev is enabled by default
+ENV UDEV on
+
 RUN dnf update -y \
     && dnf install -y \
         ca-certificates \

--- a/fedora/armv7hf/24/Dockerfile
+++ b/fedora/armv7hf/24/Dockerfile
@@ -7,6 +7,9 @@ COPY resin-xbuild /usr/bin/
 RUN ln -s resin-xbuild /usr/bin/cross-build-start \
     && ln -s resin-xbuild /usr/bin/cross-build-end
 
+# For backward compatibility, udev is enabled by default
+ENV UDEV on
+
 # Few tweaks for Fedora base image
 RUN mkdir -p /etc/dnf/vars \
     && echo "armhfp" > /etc/dnf/vars/basearch \

--- a/fedora/armv7hf/25/Dockerfile
+++ b/fedora/armv7hf/25/Dockerfile
@@ -7,6 +7,9 @@ COPY resin-xbuild /usr/bin/
 RUN ln -s resin-xbuild /usr/bin/cross-build-start \
     && ln -s resin-xbuild /usr/bin/cross-build-end
 
+# For backward compatibility, udev is enabled by default
+ENV UDEV on
+
 # Few tweaks for Fedora base image
 RUN mkdir -p /etc/dnf/vars \
     && echo "armhfp" > /etc/dnf/vars/basearch \

--- a/fedora/armv7hf/26/Dockerfile
+++ b/fedora/armv7hf/26/Dockerfile
@@ -7,6 +7,9 @@ COPY resin-xbuild /usr/bin/
 RUN ln -s resin-xbuild /usr/bin/cross-build-start \
     && ln -s resin-xbuild /usr/bin/cross-build-end
 
+# For backward compatibility, udev is enabled by default
+ENV UDEV on
+
 # Few tweaks for Fedora base image
 RUN mkdir -p /etc/dnf/vars \
     && echo "armhfp" > /etc/dnf/vars/basearch \


### PR DESCRIPTION
Fixes https://github.com/resin-io-library/base-images/issues/385.
This PR will introduce a new base images env var `UDEV` (default to `on`) which will be used to enable/disable udev.

Notice: in case systemd is enabled and udev is disabled, the systemd udev service `systemd-udevd` will be masked (since it's a dependency for other services so disabling it won't work) so we need to mention in our docs if users want to enable it, they will need to unmask the service.