### PR TITLE
 Change the base images for kitra710 and artik710 to aarch64

### DIFF
--- a/device-base/artik710/alpine/3.5/Dockerfile
+++ b/device-base/artik710/alpine/3.5/Dockerfile
@@ -1,4 +1,4 @@
-FROM resin/armhf-alpine:3.5
+FROM resin/aarch64-alpine:3.5
 
 LABEL io.resin.device-type="artik710"
 

--- a/device-base/artik710/alpine/3.6/Dockerfile
+++ b/device-base/artik710/alpine/3.6/Dockerfile
@@ -1,4 +1,4 @@
-FROM resin/armhf-alpine:3.6
+FROM resin/aarch64-alpine:3.6
 
 LABEL io.resin.device-type="artik710"
 

--- a/device-base/artik710/alpine/3.7/Dockerfile
+++ b/device-base/artik710/alpine/3.7/Dockerfile
@@ -1,4 +1,4 @@
-FROM resin/armhf-alpine:3.7
+FROM resin/aarch64-alpine:3.7
 
 LABEL io.resin.device-type="artik710"
 

--- a/device-base/artik710/alpine/edge/Dockerfile
+++ b/device-base/artik710/alpine/edge/Dockerfile
@@ -1,4 +1,4 @@
-FROM resin/armhf-alpine:edge
+FROM resin/aarch64-alpine:edge
 
 LABEL io.resin.device-type="artik710"
 

--- a/device-base/artik710/debian/buster/Dockerfile
+++ b/device-base/artik710/debian/buster/Dockerfile
@@ -1,4 +1,4 @@
-FROM resin/armv7hf-debian:buster
+FROM resin/aarch64-debian:buster
 
 LABEL io.resin.device-type="artik710"
 

--- a/device-base/artik710/debian/jessie/Dockerfile
+++ b/device-base/artik710/debian/jessie/Dockerfile
@@ -1,4 +1,4 @@
-FROM resin/armv7hf-debian:jessie
+FROM resin/aarch64-debian:jessie
 
 LABEL io.resin.device-type="artik710"
 

--- a/device-base/artik710/debian/stretch/Dockerfile
+++ b/device-base/artik710/debian/stretch/Dockerfile
@@ -1,4 +1,4 @@
-FROM resin/armv7hf-debian:stretch
+FROM resin/aarch64-debian:stretch
 
 LABEL io.resin.device-type="artik710"
 

--- a/device-base/artik710/debian/wheezy/Dockerfile
+++ b/device-base/artik710/debian/wheezy/Dockerfile
@@ -1,4 +1,4 @@
-FROM resin/armv7hf-debian:wheezy
+FROM resin/aarch64-debian:wheezy
 
 LABEL io.resin.device-type="artik710"
 

--- a/device-base/artik710/fedora/24/Dockerfile
+++ b/device-base/artik710/fedora/24/Dockerfile
@@ -1,4 +1,4 @@
-FROM resin/armv7hf-fedora:24
+FROM resin/aarch64-fedora:24
 
 LABEL io.resin.device-type="artik710"
 

--- a/device-base/artik710/fedora/25/Dockerfile
+++ b/device-base/artik710/fedora/25/Dockerfile
@@ -1,4 +1,4 @@
-FROM resin/armv7hf-fedora:25
+FROM resin/aarch64-fedora:25
 
 LABEL io.resin.device-type="artik710"
 

--- a/device-base/artik710/fedora/26/Dockerfile
+++ b/device-base/artik710/fedora/26/Dockerfile
@@ -1,4 +1,4 @@
-FROM resin/armv7hf-fedora:26
+FROM resin/aarch64-fedora:26
 
 LABEL io.resin.device-type="artik710"
 

--- a/device-base/generate-dockerfile.sh
+++ b/device-base/generate-dockerfile.sh
@@ -217,22 +217,6 @@ for device in $devices; do
 		alpine_baseImage='armhf-alpine'
 		fedora_baseImage='armv7hf-fedora'
 	;;
-	'artik710')
-		template='Dockerfile.tpl'
-		baseImage='armv7hf-debian'
-		alpine_template='Dockerfile.alpine.tpl'
-		alpine_baseImage='armhf-alpine'
-		fedora_template='Dockerfile.fedora.tpl'
-		fedora_baseImage='armv7hf-fedora'
-	;;
-	'kitra710')
-		template='Dockerfile.tpl'
-		baseImage='armv7hf-debian'
-		alpine_template='Dockerfile.alpine.tpl'
-		alpine_baseImage='armhf-alpine'
-		fedora_template='Dockerfile.fedora.tpl'
-		fedora_baseImage='armv7hf-fedora'
-	;;
 	'kitra520')
 		template='Dockerfile.tpl'
 		baseImage='armv7hf-debian'
@@ -257,7 +241,7 @@ for device in $devices; do
 		fedora_template='Dockerfile.fedora.tpl'
 		fedora_baseImage='armv7hf-fedora'
 	;;
-	'jetson-tx2'|'jetson-tx1')
+	'jetson-tx2'|'jetson-tx1'|'artik710'|'kitra710')
 		template='Dockerfile.tpl'
 		baseImage='aarch64-debian'
 		alpine_template='Dockerfile.alpine.tpl'

--- a/device-base/kitra710/alpine/3.5/Dockerfile
+++ b/device-base/kitra710/alpine/3.5/Dockerfile
@@ -1,4 +1,4 @@
-FROM resin/armhf-alpine:3.5
+FROM resin/aarch64-alpine:3.5
 
 LABEL io.resin.device-type="kitra710"
 

--- a/device-base/kitra710/alpine/3.6/Dockerfile
+++ b/device-base/kitra710/alpine/3.6/Dockerfile
@@ -1,4 +1,4 @@
-FROM resin/armhf-alpine:3.6
+FROM resin/aarch64-alpine:3.6
 
 LABEL io.resin.device-type="kitra710"
 

--- a/device-base/kitra710/alpine/3.7/Dockerfile
+++ b/device-base/kitra710/alpine/3.7/Dockerfile
@@ -1,4 +1,4 @@
-FROM resin/armhf-alpine:3.7
+FROM resin/aarch64-alpine:3.7
 
 LABEL io.resin.device-type="kitra710"
 

--- a/device-base/kitra710/alpine/edge/Dockerfile
+++ b/device-base/kitra710/alpine/edge/Dockerfile
@@ -1,4 +1,4 @@
-FROM resin/armhf-alpine:edge
+FROM resin/aarch64-alpine:edge
 
 LABEL io.resin.device-type="kitra710"
 

--- a/device-base/kitra710/debian/buster/Dockerfile
+++ b/device-base/kitra710/debian/buster/Dockerfile
@@ -1,4 +1,4 @@
-FROM resin/armv7hf-debian:buster
+FROM resin/aarch64-debian:buster
 
 LABEL io.resin.device-type="kitra710"
 

--- a/device-base/kitra710/debian/jessie/Dockerfile
+++ b/device-base/kitra710/debian/jessie/Dockerfile
@@ -1,4 +1,4 @@
-FROM resin/armv7hf-debian:jessie
+FROM resin/aarch64-debian:jessie
 
 LABEL io.resin.device-type="kitra710"
 

--- a/device-base/kitra710/debian/stretch/Dockerfile
+++ b/device-base/kitra710/debian/stretch/Dockerfile
@@ -1,4 +1,4 @@
-FROM resin/armv7hf-debian:stretch
+FROM resin/aarch64-debian:stretch
 
 LABEL io.resin.device-type="kitra710"
 

--- a/device-base/kitra710/debian/wheezy/Dockerfile
+++ b/device-base/kitra710/debian/wheezy/Dockerfile
@@ -1,4 +1,4 @@
-FROM resin/armv7hf-debian:wheezy
+FROM resin/aarch64-debian:wheezy
 
 LABEL io.resin.device-type="kitra710"
 

--- a/device-base/kitra710/fedora/24/Dockerfile
+++ b/device-base/kitra710/fedora/24/Dockerfile
@@ -1,4 +1,4 @@
-FROM resin/armv7hf-fedora:24
+FROM resin/aarch64-fedora:24
 
 LABEL io.resin.device-type="kitra710"
 

--- a/device-base/kitra710/fedora/25/Dockerfile
+++ b/device-base/kitra710/fedora/25/Dockerfile
@@ -1,4 +1,4 @@
-FROM resin/armv7hf-fedora:25
+FROM resin/aarch64-fedora:25
 
 LABEL io.resin.device-type="kitra710"
 

--- a/device-base/kitra710/fedora/26/Dockerfile
+++ b/device-base/kitra710/fedora/26/Dockerfile
@@ -1,4 +1,4 @@
-FROM resin/armv7hf-fedora:26
+FROM resin/aarch64-fedora:26
 
 LABEL io.resin.device-type="kitra710"
 

--- a/golang/artik710/alpine/1.6/Dockerfile
+++ b/golang/artik710/alpine/1.6/Dockerfile
@@ -3,10 +3,10 @@ FROM resin/artik710-alpine-buildpack-deps:latest
 ENV GO_VERSION 1.6.4
 
 RUN mkdir -p /usr/local/go \
-	&& curl -SLO "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/go$GO_VERSION.linux-alpine-armhf.tar.gz" \
-	&& echo "0771bc6209ab359df2dc73ceb0bd06e6d2751b016dd7165dfb3512b86620bfaf  go1.6.4.linux-alpine-armhf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "go$GO_VERSION.linux-alpine-armhf.tar.gz" -C /usr/local/go --strip-components=1 \
-	&& rm -f go$GO_VERSION.linux-alpine-armhf.tar.gz
+	&& curl -SLO "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/go$GO_VERSION.linux-alpine-aarch64.tar.gz" \
+	&& echo "ece8a5076e7c02233c78b7ddf9f370f3f86fe0626231138f61895aa4b2fd7c71  go1.6.4.linux-alpine-aarch64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "go$GO_VERSION.linux-alpine-aarch64.tar.gz" -C /usr/local/go --strip-components=1 \
+	&& rm -f go$GO_VERSION.linux-alpine-aarch64.tar.gz
 
 ENV GOROOT /usr/local/go
 ENV GOPATH /go

--- a/golang/artik710/alpine/1.6/edge/Dockerfile
+++ b/golang/artik710/alpine/1.6/edge/Dockerfile
@@ -3,10 +3,10 @@ FROM resin/artik710-alpine-buildpack-deps:edge
 ENV GO_VERSION 1.6.4
 
 RUN mkdir -p /usr/local/go \
-	&& curl -SLO "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/go$GO_VERSION.linux-alpine-armhf.tar.gz" \
-	&& echo "0771bc6209ab359df2dc73ceb0bd06e6d2751b016dd7165dfb3512b86620bfaf  go1.6.4.linux-alpine-armhf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "go$GO_VERSION.linux-alpine-armhf.tar.gz" -C /usr/local/go --strip-components=1 \
-	&& rm -f go$GO_VERSION.linux-alpine-armhf.tar.gz
+	&& curl -SLO "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/go$GO_VERSION.linux-alpine-aarch64.tar.gz" \
+	&& echo "ece8a5076e7c02233c78b7ddf9f370f3f86fe0626231138f61895aa4b2fd7c71  go1.6.4.linux-alpine-aarch64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "go$GO_VERSION.linux-alpine-aarch64.tar.gz" -C /usr/local/go --strip-components=1 \
+	&& rm -f go$GO_VERSION.linux-alpine-aarch64.tar.gz
 
 ENV GOROOT /usr/local/go
 ENV GOPATH /go

--- a/golang/artik710/alpine/1.6/slim/Dockerfile
+++ b/golang/artik710/alpine/1.6/slim/Dockerfile
@@ -8,10 +8,10 @@ RUN buildDeps='curl' \
 	&& set -x \
 	&& apk add --no-cache $buildDeps \
 	&& mkdir -p /usr/local/go \
-	&& curl -SLO "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/go$GO_VERSION.linux-alpine-armhf.tar.gz" \
-	&& echo "0771bc6209ab359df2dc73ceb0bd06e6d2751b016dd7165dfb3512b86620bfaf  go1.6.4.linux-alpine-armhf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "go$GO_VERSION.linux-alpine-armhf.tar.gz" -C /usr/local/go --strip-components=1 \
-	&& rm -f go$GO_VERSION.linux-alpine-armhf.tar.gz \
+	&& curl -SLO "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/go$GO_VERSION.linux-alpine-aarch64.tar.gz" \
+	&& echo "ece8a5076e7c02233c78b7ddf9f370f3f86fe0626231138f61895aa4b2fd7c71  go1.6.4.linux-alpine-aarch64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "go$GO_VERSION.linux-alpine-aarch64.tar.gz" -C /usr/local/go --strip-components=1 \
+	&& rm -f go$GO_VERSION.linux-alpine-aarch64.tar.gz \
 	&& apk del $buildDeps
 
 ENV GOROOT /usr/local/go

--- a/golang/artik710/alpine/1.7/Dockerfile
+++ b/golang/artik710/alpine/1.7/Dockerfile
@@ -3,10 +3,10 @@ FROM resin/artik710-alpine-buildpack-deps:latest
 ENV GO_VERSION 1.7.5
 
 RUN mkdir -p /usr/local/go \
-	&& curl -SLO "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/go$GO_VERSION.linux-alpine-armhf.tar.gz" \
-	&& echo "445b61cd7fbb8246769bf394a9e930cc6fc90c14bd90dbf49d41127af23759d2  go1.7.5.linux-alpine-armhf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "go$GO_VERSION.linux-alpine-armhf.tar.gz" -C /usr/local/go --strip-components=1 \
-	&& rm -f go$GO_VERSION.linux-alpine-armhf.tar.gz
+	&& curl -SLO "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/go$GO_VERSION.linux-alpine-aarch64.tar.gz" \
+	&& echo "eadfd8bfa92147b9792c95ab324faa1e55a9fd75aecf49d493394f5a86e60dc6  go1.7.5.linux-alpine-aarch64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "go$GO_VERSION.linux-alpine-aarch64.tar.gz" -C /usr/local/go --strip-components=1 \
+	&& rm -f go$GO_VERSION.linux-alpine-aarch64.tar.gz
 
 ENV GOROOT /usr/local/go
 ENV GOPATH /go

--- a/golang/artik710/alpine/1.7/edge/Dockerfile
+++ b/golang/artik710/alpine/1.7/edge/Dockerfile
@@ -3,10 +3,10 @@ FROM resin/artik710-alpine-buildpack-deps:edge
 ENV GO_VERSION 1.7.5
 
 RUN mkdir -p /usr/local/go \
-	&& curl -SLO "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/go$GO_VERSION.linux-alpine-armhf.tar.gz" \
-	&& echo "445b61cd7fbb8246769bf394a9e930cc6fc90c14bd90dbf49d41127af23759d2  go1.7.5.linux-alpine-armhf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "go$GO_VERSION.linux-alpine-armhf.tar.gz" -C /usr/local/go --strip-components=1 \
-	&& rm -f go$GO_VERSION.linux-alpine-armhf.tar.gz
+	&& curl -SLO "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/go$GO_VERSION.linux-alpine-aarch64.tar.gz" \
+	&& echo "eadfd8bfa92147b9792c95ab324faa1e55a9fd75aecf49d493394f5a86e60dc6  go1.7.5.linux-alpine-aarch64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "go$GO_VERSION.linux-alpine-aarch64.tar.gz" -C /usr/local/go --strip-components=1 \
+	&& rm -f go$GO_VERSION.linux-alpine-aarch64.tar.gz
 
 ENV GOROOT /usr/local/go
 ENV GOPATH /go

--- a/golang/artik710/alpine/1.7/slim/Dockerfile
+++ b/golang/artik710/alpine/1.7/slim/Dockerfile
@@ -8,10 +8,10 @@ RUN buildDeps='curl' \
 	&& set -x \
 	&& apk add --no-cache $buildDeps \
 	&& mkdir -p /usr/local/go \
-	&& curl -SLO "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/go$GO_VERSION.linux-alpine-armhf.tar.gz" \
-	&& echo "445b61cd7fbb8246769bf394a9e930cc6fc90c14bd90dbf49d41127af23759d2  go1.7.5.linux-alpine-armhf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "go$GO_VERSION.linux-alpine-armhf.tar.gz" -C /usr/local/go --strip-components=1 \
-	&& rm -f go$GO_VERSION.linux-alpine-armhf.tar.gz \
+	&& curl -SLO "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/go$GO_VERSION.linux-alpine-aarch64.tar.gz" \
+	&& echo "eadfd8bfa92147b9792c95ab324faa1e55a9fd75aecf49d493394f5a86e60dc6  go1.7.5.linux-alpine-aarch64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "go$GO_VERSION.linux-alpine-aarch64.tar.gz" -C /usr/local/go --strip-components=1 \
+	&& rm -f go$GO_VERSION.linux-alpine-aarch64.tar.gz \
 	&& apk del $buildDeps
 
 ENV GOROOT /usr/local/go

--- a/golang/artik710/alpine/1.8/Dockerfile
+++ b/golang/artik710/alpine/1.8/Dockerfile
@@ -3,10 +3,10 @@ FROM resin/artik710-alpine-buildpack-deps:latest
 ENV GO_VERSION 1.8.7
 
 RUN mkdir -p /usr/local/go \
-	&& curl -SLO "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/go$GO_VERSION.linux-alpine-armhf.tar.gz" \
-	&& echo "a77b103fdc390214c4d1da4fea88d72e93cb2a67a0ece9ab117ef9d6718b0296  go1.8.7.linux-alpine-armhf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "go$GO_VERSION.linux-alpine-armhf.tar.gz" -C /usr/local/go --strip-components=1 \
-	&& rm -f go$GO_VERSION.linux-alpine-armhf.tar.gz
+	&& curl -SLO "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/go$GO_VERSION.linux-alpine-aarch64.tar.gz" \
+	&& echo "3412b8ec0fc011b868a253368a4cf6cda6a23d5cb70a717e196825479a15c55c  go1.8.7.linux-alpine-aarch64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "go$GO_VERSION.linux-alpine-aarch64.tar.gz" -C /usr/local/go --strip-components=1 \
+	&& rm -f go$GO_VERSION.linux-alpine-aarch64.tar.gz
 
 ENV GOROOT /usr/local/go
 ENV GOPATH /go

--- a/golang/artik710/alpine/1.8/edge/Dockerfile
+++ b/golang/artik710/alpine/1.8/edge/Dockerfile
@@ -3,10 +3,10 @@ FROM resin/artik710-alpine-buildpack-deps:edge
 ENV GO_VERSION 1.8.7
 
 RUN mkdir -p /usr/local/go \
-	&& curl -SLO "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/go$GO_VERSION.linux-alpine-armhf.tar.gz" \
-	&& echo "a77b103fdc390214c4d1da4fea88d72e93cb2a67a0ece9ab117ef9d6718b0296  go1.8.7.linux-alpine-armhf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "go$GO_VERSION.linux-alpine-armhf.tar.gz" -C /usr/local/go --strip-components=1 \
-	&& rm -f go$GO_VERSION.linux-alpine-armhf.tar.gz
+	&& curl -SLO "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/go$GO_VERSION.linux-alpine-aarch64.tar.gz" \
+	&& echo "3412b8ec0fc011b868a253368a4cf6cda6a23d5cb70a717e196825479a15c55c  go1.8.7.linux-alpine-aarch64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "go$GO_VERSION.linux-alpine-aarch64.tar.gz" -C /usr/local/go --strip-components=1 \
+	&& rm -f go$GO_VERSION.linux-alpine-aarch64.tar.gz
 
 ENV GOROOT /usr/local/go
 ENV GOPATH /go

--- a/golang/artik710/alpine/1.8/slim/Dockerfile
+++ b/golang/artik710/alpine/1.8/slim/Dockerfile
@@ -8,10 +8,10 @@ RUN buildDeps='curl' \
 	&& set -x \
 	&& apk add --no-cache $buildDeps \
 	&& mkdir -p /usr/local/go \
-	&& curl -SLO "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/go$GO_VERSION.linux-alpine-armhf.tar.gz" \
-	&& echo "a77b103fdc390214c4d1da4fea88d72e93cb2a67a0ece9ab117ef9d6718b0296  go1.8.7.linux-alpine-armhf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "go$GO_VERSION.linux-alpine-armhf.tar.gz" -C /usr/local/go --strip-components=1 \
-	&& rm -f go$GO_VERSION.linux-alpine-armhf.tar.gz \
+	&& curl -SLO "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/go$GO_VERSION.linux-alpine-aarch64.tar.gz" \
+	&& echo "3412b8ec0fc011b868a253368a4cf6cda6a23d5cb70a717e196825479a15c55c  go1.8.7.linux-alpine-aarch64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "go$GO_VERSION.linux-alpine-aarch64.tar.gz" -C /usr/local/go --strip-components=1 \
+	&& rm -f go$GO_VERSION.linux-alpine-aarch64.tar.gz \
 	&& apk del $buildDeps
 
 ENV GOROOT /usr/local/go

--- a/golang/artik710/alpine/1.9/Dockerfile
+++ b/golang/artik710/alpine/1.9/Dockerfile
@@ -3,10 +3,10 @@ FROM resin/artik710-alpine-buildpack-deps:latest
 ENV GO_VERSION 1.9.4
 
 RUN mkdir -p /usr/local/go \
-	&& curl -SLO "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/go$GO_VERSION.linux-alpine-armhf.tar.gz" \
-	&& echo "01ce5ea71b05cb0e61facea4f992b8695938cb23bbb46a6558203989a9ee3661  go1.9.4.linux-alpine-armhf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "go$GO_VERSION.linux-alpine-armhf.tar.gz" -C /usr/local/go --strip-components=1 \
-	&& rm -f go$GO_VERSION.linux-alpine-armhf.tar.gz
+	&& curl -SLO "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/go$GO_VERSION.linux-alpine-aarch64.tar.gz" \
+	&& echo "85452c2bf5e213db51ea29cbb6cd58bcb6dc7704da5eb526136fdd4911567e57  go1.9.4.linux-alpine-aarch64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "go$GO_VERSION.linux-alpine-aarch64.tar.gz" -C /usr/local/go --strip-components=1 \
+	&& rm -f go$GO_VERSION.linux-alpine-aarch64.tar.gz
 
 ENV GOROOT /usr/local/go
 ENV GOPATH /go

--- a/golang/artik710/alpine/1.9/edge/Dockerfile
+++ b/golang/artik710/alpine/1.9/edge/Dockerfile
@@ -3,10 +3,10 @@ FROM resin/artik710-alpine-buildpack-deps:edge
 ENV GO_VERSION 1.9.4
 
 RUN mkdir -p /usr/local/go \
-	&& curl -SLO "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/go$GO_VERSION.linux-alpine-armhf.tar.gz" \
-	&& echo "01ce5ea71b05cb0e61facea4f992b8695938cb23bbb46a6558203989a9ee3661  go1.9.4.linux-alpine-armhf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "go$GO_VERSION.linux-alpine-armhf.tar.gz" -C /usr/local/go --strip-components=1 \
-	&& rm -f go$GO_VERSION.linux-alpine-armhf.tar.gz
+	&& curl -SLO "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/go$GO_VERSION.linux-alpine-aarch64.tar.gz" \
+	&& echo "85452c2bf5e213db51ea29cbb6cd58bcb6dc7704da5eb526136fdd4911567e57  go1.9.4.linux-alpine-aarch64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "go$GO_VERSION.linux-alpine-aarch64.tar.gz" -C /usr/local/go --strip-components=1 \
+	&& rm -f go$GO_VERSION.linux-alpine-aarch64.tar.gz
 
 ENV GOROOT /usr/local/go
 ENV GOPATH /go

--- a/golang/artik710/alpine/1.9/slim/Dockerfile
+++ b/golang/artik710/alpine/1.9/slim/Dockerfile
@@ -8,10 +8,10 @@ RUN buildDeps='curl' \
 	&& set -x \
 	&& apk add --no-cache $buildDeps \
 	&& mkdir -p /usr/local/go \
-	&& curl -SLO "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/go$GO_VERSION.linux-alpine-armhf.tar.gz" \
-	&& echo "01ce5ea71b05cb0e61facea4f992b8695938cb23bbb46a6558203989a9ee3661  go1.9.4.linux-alpine-armhf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "go$GO_VERSION.linux-alpine-armhf.tar.gz" -C /usr/local/go --strip-components=1 \
-	&& rm -f go$GO_VERSION.linux-alpine-armhf.tar.gz \
+	&& curl -SLO "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/go$GO_VERSION.linux-alpine-aarch64.tar.gz" \
+	&& echo "85452c2bf5e213db51ea29cbb6cd58bcb6dc7704da5eb526136fdd4911567e57  go1.9.4.linux-alpine-aarch64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "go$GO_VERSION.linux-alpine-aarch64.tar.gz" -C /usr/local/go --strip-components=1 \
+	&& rm -f go$GO_VERSION.linux-alpine-aarch64.tar.gz \
 	&& apk del $buildDeps
 
 ENV GOROOT /usr/local/go

--- a/golang/artik710/debian/1.6/Dockerfile
+++ b/golang/artik710/debian/1.6/Dockerfile
@@ -3,10 +3,10 @@ FROM resin/artik710-buildpack-deps:jessie
 ENV GO_VERSION 1.6.4
 
 RUN mkdir -p /usr/local/go \
-	&& curl -SLO "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/go$GO_VERSION.linux-armv7hf.tar.gz" \
-	&& echo "2e1041466b9bdffb1c07c691c2cfd6346ee3ce122f57fdf92710f24a400dc4e6  go1.6.4.linux-armv7hf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "go$GO_VERSION.linux-armv7hf.tar.gz" -C /usr/local/go --strip-components=1 \
-	&& rm -f go$GO_VERSION.linux-armv7hf.tar.gz
+	&& curl -SLO "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/go$GO_VERSION.linux-aarch64.tar.gz" \
+	&& echo "83345ebe96ac57de79d6ca2676602efd62a538934c6ce5608a3fe454faf70984  go1.6.4.linux-aarch64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "go$GO_VERSION.linux-aarch64.tar.gz" -C /usr/local/go --strip-components=1 \
+	&& rm -f go$GO_VERSION.linux-aarch64.tar.gz
 
 ENV GOROOT /usr/local/go
 ENV GOPATH /go

--- a/golang/artik710/debian/1.6/slim/Dockerfile
+++ b/golang/artik710/debian/1.6/slim/Dockerfile
@@ -7,10 +7,10 @@ RUN buildDeps='curl gcc g++ git' \
 	&& apt-get update && apt-get install -y $buildDeps \
 	&& rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/local/go \
-	&& curl -SLO "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/go$GO_VERSION.linux-armv7hf.tar.gz" \
-	&& echo "2e1041466b9bdffb1c07c691c2cfd6346ee3ce122f57fdf92710f24a400dc4e6  go1.6.4.linux-armv7hf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "go$GO_VERSION.linux-armv7hf.tar.gz" -C /usr/local/go --strip-components=1 \
-	&& rm -f go$GO_VERSION.linux-armv7hf.tar.gz
+	&& curl -SLO "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/go$GO_VERSION.linux-aarch64.tar.gz" \
+	&& echo "83345ebe96ac57de79d6ca2676602efd62a538934c6ce5608a3fe454faf70984  go1.6.4.linux-aarch64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "go$GO_VERSION.linux-aarch64.tar.gz" -C /usr/local/go --strip-components=1 \
+	&& rm -f go$GO_VERSION.linux-aarch64.tar.gz
 
 ENV GOROOT /usr/local/go
 ENV GOPATH /go

--- a/golang/artik710/debian/1.6/wheezy/Dockerfile
+++ b/golang/artik710/debian/1.6/wheezy/Dockerfile
@@ -3,10 +3,10 @@ FROM resin/artik710-buildpack-deps:wheezy
 ENV GO_VERSION 1.6.4
 
 RUN mkdir -p /usr/local/go \
-	&& curl -SLO "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/go$GO_VERSION.linux-armv7hf.tar.gz" \
-	&& echo "2e1041466b9bdffb1c07c691c2cfd6346ee3ce122f57fdf92710f24a400dc4e6  go1.6.4.linux-armv7hf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "go$GO_VERSION.linux-armv7hf.tar.gz" -C /usr/local/go --strip-components=1 \
-	&& rm -f go$GO_VERSION.linux-armv7hf.tar.gz
+	&& curl -SLO "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/go$GO_VERSION.linux-aarch64.tar.gz" \
+	&& echo "83345ebe96ac57de79d6ca2676602efd62a538934c6ce5608a3fe454faf70984  go1.6.4.linux-aarch64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "go$GO_VERSION.linux-aarch64.tar.gz" -C /usr/local/go --strip-components=1 \
+	&& rm -f go$GO_VERSION.linux-aarch64.tar.gz
 
 ENV GOROOT /usr/local/go
 ENV GOPATH /go

--- a/golang/artik710/debian/1.7/Dockerfile
+++ b/golang/artik710/debian/1.7/Dockerfile
@@ -3,10 +3,10 @@ FROM resin/artik710-buildpack-deps:jessie
 ENV GO_VERSION 1.7.5
 
 RUN mkdir -p /usr/local/go \
-	&& curl -SLO "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/go$GO_VERSION.linux-armv7hf.tar.gz" \
-	&& echo "4dc6e9e851bd48b92b758ff2127ffc5ac7320b35e1dd1b7aa51e74191fbee259  go1.7.5.linux-armv7hf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "go$GO_VERSION.linux-armv7hf.tar.gz" -C /usr/local/go --strip-components=1 \
-	&& rm -f go$GO_VERSION.linux-armv7hf.tar.gz
+	&& curl -SLO "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/go$GO_VERSION.linux-aarch64.tar.gz" \
+	&& echo "ad531f420f8fd2db2b506ec2683760be7a223af6e995122040526504b11a736c  go1.7.5.linux-aarch64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "go$GO_VERSION.linux-aarch64.tar.gz" -C /usr/local/go --strip-components=1 \
+	&& rm -f go$GO_VERSION.linux-aarch64.tar.gz
 
 ENV GOROOT /usr/local/go
 ENV GOPATH /go

--- a/golang/artik710/debian/1.7/slim/Dockerfile
+++ b/golang/artik710/debian/1.7/slim/Dockerfile
@@ -7,10 +7,10 @@ RUN buildDeps='curl gcc g++ git' \
 	&& apt-get update && apt-get install -y $buildDeps \
 	&& rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/local/go \
-	&& curl -SLO "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/go$GO_VERSION.linux-armv7hf.tar.gz" \
-	&& echo "4dc6e9e851bd48b92b758ff2127ffc5ac7320b35e1dd1b7aa51e74191fbee259  go1.7.5.linux-armv7hf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "go$GO_VERSION.linux-armv7hf.tar.gz" -C /usr/local/go --strip-components=1 \
-	&& rm -f go$GO_VERSION.linux-armv7hf.tar.gz
+	&& curl -SLO "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/go$GO_VERSION.linux-aarch64.tar.gz" \
+	&& echo "ad531f420f8fd2db2b506ec2683760be7a223af6e995122040526504b11a736c  go1.7.5.linux-aarch64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "go$GO_VERSION.linux-aarch64.tar.gz" -C /usr/local/go --strip-components=1 \
+	&& rm -f go$GO_VERSION.linux-aarch64.tar.gz
 
 ENV GOROOT /usr/local/go
 ENV GOPATH /go

--- a/golang/artik710/debian/1.7/wheezy/Dockerfile
+++ b/golang/artik710/debian/1.7/wheezy/Dockerfile
@@ -3,10 +3,10 @@ FROM resin/artik710-buildpack-deps:wheezy
 ENV GO_VERSION 1.7.5
 
 RUN mkdir -p /usr/local/go \
-	&& curl -SLO "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/go$GO_VERSION.linux-armv7hf.tar.gz" \
-	&& echo "4dc6e9e851bd48b92b758ff2127ffc5ac7320b35e1dd1b7aa51e74191fbee259  go1.7.5.linux-armv7hf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "go$GO_VERSION.linux-armv7hf.tar.gz" -C /usr/local/go --strip-components=1 \
-	&& rm -f go$GO_VERSION.linux-armv7hf.tar.gz
+	&& curl -SLO "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/go$GO_VERSION.linux-aarch64.tar.gz" \
+	&& echo "ad531f420f8fd2db2b506ec2683760be7a223af6e995122040526504b11a736c  go1.7.5.linux-aarch64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "go$GO_VERSION.linux-aarch64.tar.gz" -C /usr/local/go --strip-components=1 \
+	&& rm -f go$GO_VERSION.linux-aarch64.tar.gz
 
 ENV GOROOT /usr/local/go
 ENV GOPATH /go

--- a/golang/artik710/debian/1.8/Dockerfile
+++ b/golang/artik710/debian/1.8/Dockerfile
@@ -3,10 +3,10 @@ FROM resin/artik710-buildpack-deps:jessie
 ENV GO_VERSION 1.8.7
 
 RUN mkdir -p /usr/local/go \
-	&& curl -SLO "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/go$GO_VERSION.linux-armv7hf.tar.gz" \
-	&& echo "2f1485b0a6a800cd2544fe86387af93bb4c946c1978eeca36280be31bf41a73c  go1.8.7.linux-armv7hf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "go$GO_VERSION.linux-armv7hf.tar.gz" -C /usr/local/go --strip-components=1 \
-	&& rm -f go$GO_VERSION.linux-armv7hf.tar.gz
+	&& curl -SLO "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/go$GO_VERSION.linux-aarch64.tar.gz" \
+	&& echo "67ec30fded78b65175e779a0ddfdc19ab1233e51ae44818fcbada9fa3cafd72f  go1.8.7.linux-aarch64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "go$GO_VERSION.linux-aarch64.tar.gz" -C /usr/local/go --strip-components=1 \
+	&& rm -f go$GO_VERSION.linux-aarch64.tar.gz
 
 ENV GOROOT /usr/local/go
 ENV GOPATH /go

--- a/golang/artik710/debian/1.8/slim/Dockerfile
+++ b/golang/artik710/debian/1.8/slim/Dockerfile
@@ -7,10 +7,10 @@ RUN buildDeps='curl gcc g++ git' \
 	&& apt-get update && apt-get install -y $buildDeps \
 	&& rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/local/go \
-	&& curl -SLO "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/go$GO_VERSION.linux-armv7hf.tar.gz" \
-	&& echo "2f1485b0a6a800cd2544fe86387af93bb4c946c1978eeca36280be31bf41a73c  go1.8.7.linux-armv7hf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "go$GO_VERSION.linux-armv7hf.tar.gz" -C /usr/local/go --strip-components=1 \
-	&& rm -f go$GO_VERSION.linux-armv7hf.tar.gz
+	&& curl -SLO "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/go$GO_VERSION.linux-aarch64.tar.gz" \
+	&& echo "67ec30fded78b65175e779a0ddfdc19ab1233e51ae44818fcbada9fa3cafd72f  go1.8.7.linux-aarch64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "go$GO_VERSION.linux-aarch64.tar.gz" -C /usr/local/go --strip-components=1 \
+	&& rm -f go$GO_VERSION.linux-aarch64.tar.gz
 
 ENV GOROOT /usr/local/go
 ENV GOPATH /go

--- a/golang/artik710/debian/1.8/wheezy/Dockerfile
+++ b/golang/artik710/debian/1.8/wheezy/Dockerfile
@@ -3,10 +3,10 @@ FROM resin/artik710-buildpack-deps:wheezy
 ENV GO_VERSION 1.8.7
 
 RUN mkdir -p /usr/local/go \
-	&& curl -SLO "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/go$GO_VERSION.linux-armv7hf.tar.gz" \
-	&& echo "2f1485b0a6a800cd2544fe86387af93bb4c946c1978eeca36280be31bf41a73c  go1.8.7.linux-armv7hf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "go$GO_VERSION.linux-armv7hf.tar.gz" -C /usr/local/go --strip-components=1 \
-	&& rm -f go$GO_VERSION.linux-armv7hf.tar.gz
+	&& curl -SLO "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/go$GO_VERSION.linux-aarch64.tar.gz" \
+	&& echo "67ec30fded78b65175e779a0ddfdc19ab1233e51ae44818fcbada9fa3cafd72f  go1.8.7.linux-aarch64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "go$GO_VERSION.linux-aarch64.tar.gz" -C /usr/local/go --strip-components=1 \
+	&& rm -f go$GO_VERSION.linux-aarch64.tar.gz
 
 ENV GOROOT /usr/local/go
 ENV GOPATH /go

--- a/golang/artik710/debian/1.9/Dockerfile
+++ b/golang/artik710/debian/1.9/Dockerfile
@@ -3,10 +3,10 @@ FROM resin/artik710-buildpack-deps:jessie
 ENV GO_VERSION 1.9.4
 
 RUN mkdir -p /usr/local/go \
-	&& curl -SLO "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/go$GO_VERSION.linux-armv7hf.tar.gz" \
-	&& echo "7f65a8338f88d49c373f5bcbf8ec58cc1c2d5a6d3921a17d290011370f6af5b6  go1.9.4.linux-armv7hf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "go$GO_VERSION.linux-armv7hf.tar.gz" -C /usr/local/go --strip-components=1 \
-	&& rm -f go$GO_VERSION.linux-armv7hf.tar.gz
+	&& curl -SLO "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/go$GO_VERSION.linux-aarch64.tar.gz" \
+	&& echo "daec3bb8f6f36161369e5a0886ae2f95f9282a98c83b1f065dce116b3b4c3110  go1.9.4.linux-aarch64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "go$GO_VERSION.linux-aarch64.tar.gz" -C /usr/local/go --strip-components=1 \
+	&& rm -f go$GO_VERSION.linux-aarch64.tar.gz
 
 ENV GOROOT /usr/local/go
 ENV GOPATH /go

--- a/golang/artik710/debian/1.9/slim/Dockerfile
+++ b/golang/artik710/debian/1.9/slim/Dockerfile
@@ -7,10 +7,10 @@ RUN buildDeps='curl gcc g++ git' \
 	&& apt-get update && apt-get install -y $buildDeps \
 	&& rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/local/go \
-	&& curl -SLO "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/go$GO_VERSION.linux-armv7hf.tar.gz" \
-	&& echo "7f65a8338f88d49c373f5bcbf8ec58cc1c2d5a6d3921a17d290011370f6af5b6  go1.9.4.linux-armv7hf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "go$GO_VERSION.linux-armv7hf.tar.gz" -C /usr/local/go --strip-components=1 \
-	&& rm -f go$GO_VERSION.linux-armv7hf.tar.gz
+	&& curl -SLO "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/go$GO_VERSION.linux-aarch64.tar.gz" \
+	&& echo "daec3bb8f6f36161369e5a0886ae2f95f9282a98c83b1f065dce116b3b4c3110  go1.9.4.linux-aarch64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "go$GO_VERSION.linux-aarch64.tar.gz" -C /usr/local/go --strip-components=1 \
+	&& rm -f go$GO_VERSION.linux-aarch64.tar.gz
 
 ENV GOROOT /usr/local/go
 ENV GOPATH /go

--- a/golang/artik710/debian/1.9/wheezy/Dockerfile
+++ b/golang/artik710/debian/1.9/wheezy/Dockerfile
@@ -3,10 +3,10 @@ FROM resin/artik710-buildpack-deps:wheezy
 ENV GO_VERSION 1.9.4
 
 RUN mkdir -p /usr/local/go \
-	&& curl -SLO "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/go$GO_VERSION.linux-armv7hf.tar.gz" \
-	&& echo "7f65a8338f88d49c373f5bcbf8ec58cc1c2d5a6d3921a17d290011370f6af5b6  go1.9.4.linux-armv7hf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "go$GO_VERSION.linux-armv7hf.tar.gz" -C /usr/local/go --strip-components=1 \
-	&& rm -f go$GO_VERSION.linux-armv7hf.tar.gz
+	&& curl -SLO "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/go$GO_VERSION.linux-aarch64.tar.gz" \
+	&& echo "daec3bb8f6f36161369e5a0886ae2f95f9282a98c83b1f065dce116b3b4c3110  go1.9.4.linux-aarch64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "go$GO_VERSION.linux-aarch64.tar.gz" -C /usr/local/go --strip-components=1 \
+	&& rm -f go$GO_VERSION.linux-aarch64.tar.gz
 
 ENV GOROOT /usr/local/go
 ENV GOPATH /go

--- a/golang/artik710/fedora/1.6/24/Dockerfile
+++ b/golang/artik710/fedora/1.6/24/Dockerfile
@@ -3,10 +3,10 @@ FROM resin/artik710-fedora-buildpack-deps:24
 ENV GO_VERSION 1.6.4
 
 RUN mkdir -p /usr/local/go \
-	&& curl -SLO "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/go$GO_VERSION.linux-armv7hf.tar.gz" \
-	&& echo "2e1041466b9bdffb1c07c691c2cfd6346ee3ce122f57fdf92710f24a400dc4e6  go1.6.4.linux-armv7hf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "go$GO_VERSION.linux-armv7hf.tar.gz" -C /usr/local/go --strip-components=1 \
-	&& rm -f go$GO_VERSION.linux-armv7hf.tar.gz
+	&& curl -SLO "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/go$GO_VERSION.linux-aarch64.tar.gz" \
+	&& echo "83345ebe96ac57de79d6ca2676602efd62a538934c6ce5608a3fe454faf70984  go1.6.4.linux-aarch64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "go$GO_VERSION.linux-aarch64.tar.gz" -C /usr/local/go --strip-components=1 \
+	&& rm -f go$GO_VERSION.linux-aarch64.tar.gz
 
 ENV GOROOT /usr/local/go
 ENV GOPATH /go

--- a/golang/artik710/fedora/1.6/Dockerfile
+++ b/golang/artik710/fedora/1.6/Dockerfile
@@ -3,10 +3,10 @@ FROM resin/artik710-fedora-buildpack-deps:latest
 ENV GO_VERSION 1.6.4
 
 RUN mkdir -p /usr/local/go \
-	&& curl -SLO "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/go$GO_VERSION.linux-armv7hf.tar.gz" \
-	&& echo "2e1041466b9bdffb1c07c691c2cfd6346ee3ce122f57fdf92710f24a400dc4e6  go1.6.4.linux-armv7hf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "go$GO_VERSION.linux-armv7hf.tar.gz" -C /usr/local/go --strip-components=1 \
-	&& rm -f go$GO_VERSION.linux-armv7hf.tar.gz
+	&& curl -SLO "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/go$GO_VERSION.linux-aarch64.tar.gz" \
+	&& echo "83345ebe96ac57de79d6ca2676602efd62a538934c6ce5608a3fe454faf70984  go1.6.4.linux-aarch64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "go$GO_VERSION.linux-aarch64.tar.gz" -C /usr/local/go --strip-components=1 \
+	&& rm -f go$GO_VERSION.linux-aarch64.tar.gz
 
 ENV GOROOT /usr/local/go
 ENV GOPATH /go

--- a/golang/artik710/fedora/1.6/slim/Dockerfile
+++ b/golang/artik710/fedora/1.6/slim/Dockerfile
@@ -10,10 +10,10 @@ RUN buildDeps='gcc gcc-c++ git' \
 	&& dnf install -y $buildDeps \
 	&& dnf clean all \
 	&& mkdir -p /usr/local/go \
-	&& curl -SLO "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/go$GO_VERSION.linux-armv7hf.tar.gz" \
-	&& echo "2e1041466b9bdffb1c07c691c2cfd6346ee3ce122f57fdf92710f24a400dc4e6  go1.6.4.linux-armv7hf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "go$GO_VERSION.linux-armv7hf.tar.gz" -C /usr/local/go --strip-components=1 \
-	&& rm go$GO_VERSION.linux-armv7hf.tar.gz \
+	&& curl -SLO "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/go$GO_VERSION.linux-aarch64.tar.gz" \
+	&& echo "83345ebe96ac57de79d6ca2676602efd62a538934c6ce5608a3fe454faf70984  go1.6.4.linux-aarch64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "go$GO_VERSION.linux-aarch64.tar.gz" -C /usr/local/go --strip-components=1 \
+	&& rm go$GO_VERSION.linux-aarch64.tar.gz \
 	&& mkdir -p "$GOPATH/src" "$GOPATH/bin" \
 	&& chmod -R 777 "$GOPATH"
 

--- a/golang/artik710/fedora/1.7/24/Dockerfile
+++ b/golang/artik710/fedora/1.7/24/Dockerfile
@@ -3,10 +3,10 @@ FROM resin/artik710-fedora-buildpack-deps:24
 ENV GO_VERSION 1.7.5
 
 RUN mkdir -p /usr/local/go \
-	&& curl -SLO "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/go$GO_VERSION.linux-armv7hf.tar.gz" \
-	&& echo "4dc6e9e851bd48b92b758ff2127ffc5ac7320b35e1dd1b7aa51e74191fbee259  go1.7.5.linux-armv7hf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "go$GO_VERSION.linux-armv7hf.tar.gz" -C /usr/local/go --strip-components=1 \
-	&& rm -f go$GO_VERSION.linux-armv7hf.tar.gz
+	&& curl -SLO "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/go$GO_VERSION.linux-aarch64.tar.gz" \
+	&& echo "ad531f420f8fd2db2b506ec2683760be7a223af6e995122040526504b11a736c  go1.7.5.linux-aarch64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "go$GO_VERSION.linux-aarch64.tar.gz" -C /usr/local/go --strip-components=1 \
+	&& rm -f go$GO_VERSION.linux-aarch64.tar.gz
 
 ENV GOROOT /usr/local/go
 ENV GOPATH /go

--- a/golang/artik710/fedora/1.7/Dockerfile
+++ b/golang/artik710/fedora/1.7/Dockerfile
@@ -3,10 +3,10 @@ FROM resin/artik710-fedora-buildpack-deps:latest
 ENV GO_VERSION 1.7.5
 
 RUN mkdir -p /usr/local/go \
-	&& curl -SLO "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/go$GO_VERSION.linux-armv7hf.tar.gz" \
-	&& echo "4dc6e9e851bd48b92b758ff2127ffc5ac7320b35e1dd1b7aa51e74191fbee259  go1.7.5.linux-armv7hf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "go$GO_VERSION.linux-armv7hf.tar.gz" -C /usr/local/go --strip-components=1 \
-	&& rm -f go$GO_VERSION.linux-armv7hf.tar.gz
+	&& curl -SLO "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/go$GO_VERSION.linux-aarch64.tar.gz" \
+	&& echo "ad531f420f8fd2db2b506ec2683760be7a223af6e995122040526504b11a736c  go1.7.5.linux-aarch64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "go$GO_VERSION.linux-aarch64.tar.gz" -C /usr/local/go --strip-components=1 \
+	&& rm -f go$GO_VERSION.linux-aarch64.tar.gz
 
 ENV GOROOT /usr/local/go
 ENV GOPATH /go

--- a/golang/artik710/fedora/1.7/slim/Dockerfile
+++ b/golang/artik710/fedora/1.7/slim/Dockerfile
@@ -10,10 +10,10 @@ RUN buildDeps='gcc gcc-c++ git' \
 	&& dnf install -y $buildDeps \
 	&& dnf clean all \
 	&& mkdir -p /usr/local/go \
-	&& curl -SLO "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/go$GO_VERSION.linux-armv7hf.tar.gz" \
-	&& echo "4dc6e9e851bd48b92b758ff2127ffc5ac7320b35e1dd1b7aa51e74191fbee259  go1.7.5.linux-armv7hf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "go$GO_VERSION.linux-armv7hf.tar.gz" -C /usr/local/go --strip-components=1 \
-	&& rm go$GO_VERSION.linux-armv7hf.tar.gz \
+	&& curl -SLO "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/go$GO_VERSION.linux-aarch64.tar.gz" \
+	&& echo "ad531f420f8fd2db2b506ec2683760be7a223af6e995122040526504b11a736c  go1.7.5.linux-aarch64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "go$GO_VERSION.linux-aarch64.tar.gz" -C /usr/local/go --strip-components=1 \
+	&& rm go$GO_VERSION.linux-aarch64.tar.gz \
 	&& mkdir -p "$GOPATH/src" "$GOPATH/bin" \
 	&& chmod -R 777 "$GOPATH"
 

--- a/golang/artik710/fedora/1.8/24/Dockerfile
+++ b/golang/artik710/fedora/1.8/24/Dockerfile
@@ -3,10 +3,10 @@ FROM resin/artik710-fedora-buildpack-deps:24
 ENV GO_VERSION 1.8.7
 
 RUN mkdir -p /usr/local/go \
-	&& curl -SLO "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/go$GO_VERSION.linux-armv7hf.tar.gz" \
-	&& echo "2f1485b0a6a800cd2544fe86387af93bb4c946c1978eeca36280be31bf41a73c  go1.8.7.linux-armv7hf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "go$GO_VERSION.linux-armv7hf.tar.gz" -C /usr/local/go --strip-components=1 \
-	&& rm -f go$GO_VERSION.linux-armv7hf.tar.gz
+	&& curl -SLO "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/go$GO_VERSION.linux-aarch64.tar.gz" \
+	&& echo "67ec30fded78b65175e779a0ddfdc19ab1233e51ae44818fcbada9fa3cafd72f  go1.8.7.linux-aarch64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "go$GO_VERSION.linux-aarch64.tar.gz" -C /usr/local/go --strip-components=1 \
+	&& rm -f go$GO_VERSION.linux-aarch64.tar.gz
 
 ENV GOROOT /usr/local/go
 ENV GOPATH /go

--- a/golang/artik710/fedora/1.8/Dockerfile
+++ b/golang/artik710/fedora/1.8/Dockerfile
@@ -3,10 +3,10 @@ FROM resin/artik710-fedora-buildpack-deps:latest
 ENV GO_VERSION 1.8.7
 
 RUN mkdir -p /usr/local/go \
-	&& curl -SLO "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/go$GO_VERSION.linux-armv7hf.tar.gz" \
-	&& echo "2f1485b0a6a800cd2544fe86387af93bb4c946c1978eeca36280be31bf41a73c  go1.8.7.linux-armv7hf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "go$GO_VERSION.linux-armv7hf.tar.gz" -C /usr/local/go --strip-components=1 \
-	&& rm -f go$GO_VERSION.linux-armv7hf.tar.gz
+	&& curl -SLO "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/go$GO_VERSION.linux-aarch64.tar.gz" \
+	&& echo "67ec30fded78b65175e779a0ddfdc19ab1233e51ae44818fcbada9fa3cafd72f  go1.8.7.linux-aarch64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "go$GO_VERSION.linux-aarch64.tar.gz" -C /usr/local/go --strip-components=1 \
+	&& rm -f go$GO_VERSION.linux-aarch64.tar.gz
 
 ENV GOROOT /usr/local/go
 ENV GOPATH /go

--- a/golang/artik710/fedora/1.8/slim/Dockerfile
+++ b/golang/artik710/fedora/1.8/slim/Dockerfile
@@ -10,10 +10,10 @@ RUN buildDeps='gcc gcc-c++ git' \
 	&& dnf install -y $buildDeps \
 	&& dnf clean all \
 	&& mkdir -p /usr/local/go \
-	&& curl -SLO "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/go$GO_VERSION.linux-armv7hf.tar.gz" \
-	&& echo "2f1485b0a6a800cd2544fe86387af93bb4c946c1978eeca36280be31bf41a73c  go1.8.7.linux-armv7hf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "go$GO_VERSION.linux-armv7hf.tar.gz" -C /usr/local/go --strip-components=1 \
-	&& rm go$GO_VERSION.linux-armv7hf.tar.gz \
+	&& curl -SLO "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/go$GO_VERSION.linux-aarch64.tar.gz" \
+	&& echo "67ec30fded78b65175e779a0ddfdc19ab1233e51ae44818fcbada9fa3cafd72f  go1.8.7.linux-aarch64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "go$GO_VERSION.linux-aarch64.tar.gz" -C /usr/local/go --strip-components=1 \
+	&& rm go$GO_VERSION.linux-aarch64.tar.gz \
 	&& mkdir -p "$GOPATH/src" "$GOPATH/bin" \
 	&& chmod -R 777 "$GOPATH"
 

--- a/golang/artik710/fedora/1.9/24/Dockerfile
+++ b/golang/artik710/fedora/1.9/24/Dockerfile
@@ -3,10 +3,10 @@ FROM resin/artik710-fedora-buildpack-deps:24
 ENV GO_VERSION 1.9.4
 
 RUN mkdir -p /usr/local/go \
-	&& curl -SLO "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/go$GO_VERSION.linux-armv7hf.tar.gz" \
-	&& echo "7f65a8338f88d49c373f5bcbf8ec58cc1c2d5a6d3921a17d290011370f6af5b6  go1.9.4.linux-armv7hf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "go$GO_VERSION.linux-armv7hf.tar.gz" -C /usr/local/go --strip-components=1 \
-	&& rm -f go$GO_VERSION.linux-armv7hf.tar.gz
+	&& curl -SLO "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/go$GO_VERSION.linux-aarch64.tar.gz" \
+	&& echo "daec3bb8f6f36161369e5a0886ae2f95f9282a98c83b1f065dce116b3b4c3110  go1.9.4.linux-aarch64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "go$GO_VERSION.linux-aarch64.tar.gz" -C /usr/local/go --strip-components=1 \
+	&& rm -f go$GO_VERSION.linux-aarch64.tar.gz
 
 ENV GOROOT /usr/local/go
 ENV GOPATH /go

--- a/golang/artik710/fedora/1.9/Dockerfile
+++ b/golang/artik710/fedora/1.9/Dockerfile
@@ -3,10 +3,10 @@ FROM resin/artik710-fedora-buildpack-deps:latest
 ENV GO_VERSION 1.9.4
 
 RUN mkdir -p /usr/local/go \
-	&& curl -SLO "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/go$GO_VERSION.linux-armv7hf.tar.gz" \
-	&& echo "7f65a8338f88d49c373f5bcbf8ec58cc1c2d5a6d3921a17d290011370f6af5b6  go1.9.4.linux-armv7hf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "go$GO_VERSION.linux-armv7hf.tar.gz" -C /usr/local/go --strip-components=1 \
-	&& rm -f go$GO_VERSION.linux-armv7hf.tar.gz
+	&& curl -SLO "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/go$GO_VERSION.linux-aarch64.tar.gz" \
+	&& echo "daec3bb8f6f36161369e5a0886ae2f95f9282a98c83b1f065dce116b3b4c3110  go1.9.4.linux-aarch64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "go$GO_VERSION.linux-aarch64.tar.gz" -C /usr/local/go --strip-components=1 \
+	&& rm -f go$GO_VERSION.linux-aarch64.tar.gz
 
 ENV GOROOT /usr/local/go
 ENV GOPATH /go

--- a/golang/artik710/fedora/1.9/slim/Dockerfile
+++ b/golang/artik710/fedora/1.9/slim/Dockerfile
@@ -10,10 +10,10 @@ RUN buildDeps='gcc gcc-c++ git' \
 	&& dnf install -y $buildDeps \
 	&& dnf clean all \
 	&& mkdir -p /usr/local/go \
-	&& curl -SLO "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/go$GO_VERSION.linux-armv7hf.tar.gz" \
-	&& echo "7f65a8338f88d49c373f5bcbf8ec58cc1c2d5a6d3921a17d290011370f6af5b6  go1.9.4.linux-armv7hf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "go$GO_VERSION.linux-armv7hf.tar.gz" -C /usr/local/go --strip-components=1 \
-	&& rm go$GO_VERSION.linux-armv7hf.tar.gz \
+	&& curl -SLO "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/go$GO_VERSION.linux-aarch64.tar.gz" \
+	&& echo "daec3bb8f6f36161369e5a0886ae2f95f9282a98c83b1f065dce116b3b4c3110  go1.9.4.linux-aarch64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "go$GO_VERSION.linux-aarch64.tar.gz" -C /usr/local/go --strip-components=1 \
+	&& rm go$GO_VERSION.linux-aarch64.tar.gz \
 	&& mkdir -p "$GOPATH/src" "$GOPATH/bin" \
 	&& chmod -R 777 "$GOPATH"
 

--- a/golang/generate-dockerfile.sh
+++ b/golang/generate-dockerfile.sh
@@ -253,22 +253,6 @@ for target in $targets; do
 		fedora_binary_url=$resinUrl
 		fedora_binary_arch='armv7hf'
 	;;
-	'artik710')
-		binary_url=$resinUrl
-		binary_arch='armv7hf'
-		alpine_binary_url=$resinUrl
-		alpine_binary_arch='alpine-armhf'
-		fedora_binary_url=$resinUrl
-		fedora_binary_arch='armv7hf'
-	;;
-	'kitra710')
-		binary_url=$resinUrl
-		binary_arch='armv7hf'
-		alpine_binary_url=$resinUrl
-		alpine_binary_arch='alpine-armhf'
-		fedora_binary_url=$resinUrl
-		fedora_binary_arch='armv7hf'
-	;;
 	'kitra520')
 		binary_url=$resinUrl
 		binary_arch='armv7hf'
@@ -293,7 +277,7 @@ for target in $targets; do
 		fedora_binary_url=$resinUrl
 		fedora_binary_arch='armv7hf'
 	;;
-	'jetson-tx2'|'jetson-tx1')
+	'jetson-tx2'|'jetson-tx1'|'artik710'|'kitra710')
 		binary_url=$resinUrl
 		binary_arch='aarch64'
 		alpine_binary_url=$resinUrl

--- a/golang/kitra710/alpine/1.6/Dockerfile
+++ b/golang/kitra710/alpine/1.6/Dockerfile
@@ -3,10 +3,10 @@ FROM resin/kitra710-alpine-buildpack-deps:latest
 ENV GO_VERSION 1.6.4
 
 RUN mkdir -p /usr/local/go \
-	&& curl -SLO "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/go$GO_VERSION.linux-alpine-armhf.tar.gz" \
-	&& echo "0771bc6209ab359df2dc73ceb0bd06e6d2751b016dd7165dfb3512b86620bfaf  go1.6.4.linux-alpine-armhf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "go$GO_VERSION.linux-alpine-armhf.tar.gz" -C /usr/local/go --strip-components=1 \
-	&& rm -f go$GO_VERSION.linux-alpine-armhf.tar.gz
+	&& curl -SLO "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/go$GO_VERSION.linux-alpine-aarch64.tar.gz" \
+	&& echo "ece8a5076e7c02233c78b7ddf9f370f3f86fe0626231138f61895aa4b2fd7c71  go1.6.4.linux-alpine-aarch64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "go$GO_VERSION.linux-alpine-aarch64.tar.gz" -C /usr/local/go --strip-components=1 \
+	&& rm -f go$GO_VERSION.linux-alpine-aarch64.tar.gz
 
 ENV GOROOT /usr/local/go
 ENV GOPATH /go

--- a/golang/kitra710/alpine/1.6/edge/Dockerfile
+++ b/golang/kitra710/alpine/1.6/edge/Dockerfile
@@ -3,10 +3,10 @@ FROM resin/kitra710-alpine-buildpack-deps:edge
 ENV GO_VERSION 1.6.4
 
 RUN mkdir -p /usr/local/go \
-	&& curl -SLO "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/go$GO_VERSION.linux-alpine-armhf.tar.gz" \
-	&& echo "0771bc6209ab359df2dc73ceb0bd06e6d2751b016dd7165dfb3512b86620bfaf  go1.6.4.linux-alpine-armhf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "go$GO_VERSION.linux-alpine-armhf.tar.gz" -C /usr/local/go --strip-components=1 \
-	&& rm -f go$GO_VERSION.linux-alpine-armhf.tar.gz
+	&& curl -SLO "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/go$GO_VERSION.linux-alpine-aarch64.tar.gz" \
+	&& echo "ece8a5076e7c02233c78b7ddf9f370f3f86fe0626231138f61895aa4b2fd7c71  go1.6.4.linux-alpine-aarch64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "go$GO_VERSION.linux-alpine-aarch64.tar.gz" -C /usr/local/go --strip-components=1 \
+	&& rm -f go$GO_VERSION.linux-alpine-aarch64.tar.gz
 
 ENV GOROOT /usr/local/go
 ENV GOPATH /go

--- a/golang/kitra710/alpine/1.6/slim/Dockerfile
+++ b/golang/kitra710/alpine/1.6/slim/Dockerfile
@@ -8,10 +8,10 @@ RUN buildDeps='curl' \
 	&& set -x \
 	&& apk add --no-cache $buildDeps \
 	&& mkdir -p /usr/local/go \
-	&& curl -SLO "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/go$GO_VERSION.linux-alpine-armhf.tar.gz" \
-	&& echo "0771bc6209ab359df2dc73ceb0bd06e6d2751b016dd7165dfb3512b86620bfaf  go1.6.4.linux-alpine-armhf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "go$GO_VERSION.linux-alpine-armhf.tar.gz" -C /usr/local/go --strip-components=1 \
-	&& rm -f go$GO_VERSION.linux-alpine-armhf.tar.gz \
+	&& curl -SLO "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/go$GO_VERSION.linux-alpine-aarch64.tar.gz" \
+	&& echo "ece8a5076e7c02233c78b7ddf9f370f3f86fe0626231138f61895aa4b2fd7c71  go1.6.4.linux-alpine-aarch64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "go$GO_VERSION.linux-alpine-aarch64.tar.gz" -C /usr/local/go --strip-components=1 \
+	&& rm -f go$GO_VERSION.linux-alpine-aarch64.tar.gz \
 	&& apk del $buildDeps
 
 ENV GOROOT /usr/local/go

--- a/golang/kitra710/alpine/1.7/Dockerfile
+++ b/golang/kitra710/alpine/1.7/Dockerfile
@@ -3,10 +3,10 @@ FROM resin/kitra710-alpine-buildpack-deps:latest
 ENV GO_VERSION 1.7.5
 
 RUN mkdir -p /usr/local/go \
-	&& curl -SLO "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/go$GO_VERSION.linux-alpine-armhf.tar.gz" \
-	&& echo "445b61cd7fbb8246769bf394a9e930cc6fc90c14bd90dbf49d41127af23759d2  go1.7.5.linux-alpine-armhf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "go$GO_VERSION.linux-alpine-armhf.tar.gz" -C /usr/local/go --strip-components=1 \
-	&& rm -f go$GO_VERSION.linux-alpine-armhf.tar.gz
+	&& curl -SLO "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/go$GO_VERSION.linux-alpine-aarch64.tar.gz" \
+	&& echo "eadfd8bfa92147b9792c95ab324faa1e55a9fd75aecf49d493394f5a86e60dc6  go1.7.5.linux-alpine-aarch64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "go$GO_VERSION.linux-alpine-aarch64.tar.gz" -C /usr/local/go --strip-components=1 \
+	&& rm -f go$GO_VERSION.linux-alpine-aarch64.tar.gz
 
 ENV GOROOT /usr/local/go
 ENV GOPATH /go

--- a/golang/kitra710/alpine/1.7/edge/Dockerfile
+++ b/golang/kitra710/alpine/1.7/edge/Dockerfile
@@ -3,10 +3,10 @@ FROM resin/kitra710-alpine-buildpack-deps:edge
 ENV GO_VERSION 1.7.5
 
 RUN mkdir -p /usr/local/go \
-	&& curl -SLO "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/go$GO_VERSION.linux-alpine-armhf.tar.gz" \
-	&& echo "445b61cd7fbb8246769bf394a9e930cc6fc90c14bd90dbf49d41127af23759d2  go1.7.5.linux-alpine-armhf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "go$GO_VERSION.linux-alpine-armhf.tar.gz" -C /usr/local/go --strip-components=1 \
-	&& rm -f go$GO_VERSION.linux-alpine-armhf.tar.gz
+	&& curl -SLO "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/go$GO_VERSION.linux-alpine-aarch64.tar.gz" \
+	&& echo "eadfd8bfa92147b9792c95ab324faa1e55a9fd75aecf49d493394f5a86e60dc6  go1.7.5.linux-alpine-aarch64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "go$GO_VERSION.linux-alpine-aarch64.tar.gz" -C /usr/local/go --strip-components=1 \
+	&& rm -f go$GO_VERSION.linux-alpine-aarch64.tar.gz
 
 ENV GOROOT /usr/local/go
 ENV GOPATH /go

--- a/golang/kitra710/alpine/1.7/slim/Dockerfile
+++ b/golang/kitra710/alpine/1.7/slim/Dockerfile
@@ -8,10 +8,10 @@ RUN buildDeps='curl' \
 	&& set -x \
 	&& apk add --no-cache $buildDeps \
 	&& mkdir -p /usr/local/go \
-	&& curl -SLO "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/go$GO_VERSION.linux-alpine-armhf.tar.gz" \
-	&& echo "445b61cd7fbb8246769bf394a9e930cc6fc90c14bd90dbf49d41127af23759d2  go1.7.5.linux-alpine-armhf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "go$GO_VERSION.linux-alpine-armhf.tar.gz" -C /usr/local/go --strip-components=1 \
-	&& rm -f go$GO_VERSION.linux-alpine-armhf.tar.gz \
+	&& curl -SLO "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/go$GO_VERSION.linux-alpine-aarch64.tar.gz" \
+	&& echo "eadfd8bfa92147b9792c95ab324faa1e55a9fd75aecf49d493394f5a86e60dc6  go1.7.5.linux-alpine-aarch64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "go$GO_VERSION.linux-alpine-aarch64.tar.gz" -C /usr/local/go --strip-components=1 \
+	&& rm -f go$GO_VERSION.linux-alpine-aarch64.tar.gz \
 	&& apk del $buildDeps
 
 ENV GOROOT /usr/local/go

--- a/golang/kitra710/alpine/1.8/Dockerfile
+++ b/golang/kitra710/alpine/1.8/Dockerfile
@@ -3,10 +3,10 @@ FROM resin/kitra710-alpine-buildpack-deps:latest
 ENV GO_VERSION 1.8.7
 
 RUN mkdir -p /usr/local/go \
-	&& curl -SLO "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/go$GO_VERSION.linux-alpine-armhf.tar.gz" \
-	&& echo "a77b103fdc390214c4d1da4fea88d72e93cb2a67a0ece9ab117ef9d6718b0296  go1.8.7.linux-alpine-armhf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "go$GO_VERSION.linux-alpine-armhf.tar.gz" -C /usr/local/go --strip-components=1 \
-	&& rm -f go$GO_VERSION.linux-alpine-armhf.tar.gz
+	&& curl -SLO "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/go$GO_VERSION.linux-alpine-aarch64.tar.gz" \
+	&& echo "3412b8ec0fc011b868a253368a4cf6cda6a23d5cb70a717e196825479a15c55c  go1.8.7.linux-alpine-aarch64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "go$GO_VERSION.linux-alpine-aarch64.tar.gz" -C /usr/local/go --strip-components=1 \
+	&& rm -f go$GO_VERSION.linux-alpine-aarch64.tar.gz
 
 ENV GOROOT /usr/local/go
 ENV GOPATH /go

--- a/golang/kitra710/alpine/1.8/edge/Dockerfile
+++ b/golang/kitra710/alpine/1.8/edge/Dockerfile
@@ -3,10 +3,10 @@ FROM resin/kitra710-alpine-buildpack-deps:edge
 ENV GO_VERSION 1.8.7
 
 RUN mkdir -p /usr/local/go \
-	&& curl -SLO "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/go$GO_VERSION.linux-alpine-armhf.tar.gz" \
-	&& echo "a77b103fdc390214c4d1da4fea88d72e93cb2a67a0ece9ab117ef9d6718b0296  go1.8.7.linux-alpine-armhf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "go$GO_VERSION.linux-alpine-armhf.tar.gz" -C /usr/local/go --strip-components=1 \
-	&& rm -f go$GO_VERSION.linux-alpine-armhf.tar.gz
+	&& curl -SLO "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/go$GO_VERSION.linux-alpine-aarch64.tar.gz" \
+	&& echo "3412b8ec0fc011b868a253368a4cf6cda6a23d5cb70a717e196825479a15c55c  go1.8.7.linux-alpine-aarch64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "go$GO_VERSION.linux-alpine-aarch64.tar.gz" -C /usr/local/go --strip-components=1 \
+	&& rm -f go$GO_VERSION.linux-alpine-aarch64.tar.gz
 
 ENV GOROOT /usr/local/go
 ENV GOPATH /go

--- a/golang/kitra710/alpine/1.8/slim/Dockerfile
+++ b/golang/kitra710/alpine/1.8/slim/Dockerfile
@@ -8,10 +8,10 @@ RUN buildDeps='curl' \
 	&& set -x \
 	&& apk add --no-cache $buildDeps \
 	&& mkdir -p /usr/local/go \
-	&& curl -SLO "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/go$GO_VERSION.linux-alpine-armhf.tar.gz" \
-	&& echo "a77b103fdc390214c4d1da4fea88d72e93cb2a67a0ece9ab117ef9d6718b0296  go1.8.7.linux-alpine-armhf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "go$GO_VERSION.linux-alpine-armhf.tar.gz" -C /usr/local/go --strip-components=1 \
-	&& rm -f go$GO_VERSION.linux-alpine-armhf.tar.gz \
+	&& curl -SLO "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/go$GO_VERSION.linux-alpine-aarch64.tar.gz" \
+	&& echo "3412b8ec0fc011b868a253368a4cf6cda6a23d5cb70a717e196825479a15c55c  go1.8.7.linux-alpine-aarch64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "go$GO_VERSION.linux-alpine-aarch64.tar.gz" -C /usr/local/go --strip-components=1 \
+	&& rm -f go$GO_VERSION.linux-alpine-aarch64.tar.gz \
 	&& apk del $buildDeps
 
 ENV GOROOT /usr/local/go

--- a/golang/kitra710/alpine/1.9/Dockerfile
+++ b/golang/kitra710/alpine/1.9/Dockerfile
@@ -3,10 +3,10 @@ FROM resin/kitra710-alpine-buildpack-deps:latest
 ENV GO_VERSION 1.9.4
 
 RUN mkdir -p /usr/local/go \
-	&& curl -SLO "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/go$GO_VERSION.linux-alpine-armhf.tar.gz" \
-	&& echo "01ce5ea71b05cb0e61facea4f992b8695938cb23bbb46a6558203989a9ee3661  go1.9.4.linux-alpine-armhf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "go$GO_VERSION.linux-alpine-armhf.tar.gz" -C /usr/local/go --strip-components=1 \
-	&& rm -f go$GO_VERSION.linux-alpine-armhf.tar.gz
+	&& curl -SLO "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/go$GO_VERSION.linux-alpine-aarch64.tar.gz" \
+	&& echo "85452c2bf5e213db51ea29cbb6cd58bcb6dc7704da5eb526136fdd4911567e57  go1.9.4.linux-alpine-aarch64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "go$GO_VERSION.linux-alpine-aarch64.tar.gz" -C /usr/local/go --strip-components=1 \
+	&& rm -f go$GO_VERSION.linux-alpine-aarch64.tar.gz
 
 ENV GOROOT /usr/local/go
 ENV GOPATH /go

--- a/golang/kitra710/alpine/1.9/edge/Dockerfile
+++ b/golang/kitra710/alpine/1.9/edge/Dockerfile
@@ -3,10 +3,10 @@ FROM resin/kitra710-alpine-buildpack-deps:edge
 ENV GO_VERSION 1.9.4
 
 RUN mkdir -p /usr/local/go \
-	&& curl -SLO "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/go$GO_VERSION.linux-alpine-armhf.tar.gz" \
-	&& echo "01ce5ea71b05cb0e61facea4f992b8695938cb23bbb46a6558203989a9ee3661  go1.9.4.linux-alpine-armhf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "go$GO_VERSION.linux-alpine-armhf.tar.gz" -C /usr/local/go --strip-components=1 \
-	&& rm -f go$GO_VERSION.linux-alpine-armhf.tar.gz
+	&& curl -SLO "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/go$GO_VERSION.linux-alpine-aarch64.tar.gz" \
+	&& echo "85452c2bf5e213db51ea29cbb6cd58bcb6dc7704da5eb526136fdd4911567e57  go1.9.4.linux-alpine-aarch64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "go$GO_VERSION.linux-alpine-aarch64.tar.gz" -C /usr/local/go --strip-components=1 \
+	&& rm -f go$GO_VERSION.linux-alpine-aarch64.tar.gz
 
 ENV GOROOT /usr/local/go
 ENV GOPATH /go

--- a/golang/kitra710/alpine/1.9/slim/Dockerfile
+++ b/golang/kitra710/alpine/1.9/slim/Dockerfile
@@ -8,10 +8,10 @@ RUN buildDeps='curl' \
 	&& set -x \
 	&& apk add --no-cache $buildDeps \
 	&& mkdir -p /usr/local/go \
-	&& curl -SLO "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/go$GO_VERSION.linux-alpine-armhf.tar.gz" \
-	&& echo "01ce5ea71b05cb0e61facea4f992b8695938cb23bbb46a6558203989a9ee3661  go1.9.4.linux-alpine-armhf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "go$GO_VERSION.linux-alpine-armhf.tar.gz" -C /usr/local/go --strip-components=1 \
-	&& rm -f go$GO_VERSION.linux-alpine-armhf.tar.gz \
+	&& curl -SLO "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/go$GO_VERSION.linux-alpine-aarch64.tar.gz" \
+	&& echo "85452c2bf5e213db51ea29cbb6cd58bcb6dc7704da5eb526136fdd4911567e57  go1.9.4.linux-alpine-aarch64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "go$GO_VERSION.linux-alpine-aarch64.tar.gz" -C /usr/local/go --strip-components=1 \
+	&& rm -f go$GO_VERSION.linux-alpine-aarch64.tar.gz \
 	&& apk del $buildDeps
 
 ENV GOROOT /usr/local/go

--- a/golang/kitra710/debian/1.6/Dockerfile
+++ b/golang/kitra710/debian/1.6/Dockerfile
@@ -3,10 +3,10 @@ FROM resin/kitra710-buildpack-deps:jessie
 ENV GO_VERSION 1.6.4
 
 RUN mkdir -p /usr/local/go \
-	&& curl -SLO "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/go$GO_VERSION.linux-armv7hf.tar.gz" \
-	&& echo "2e1041466b9bdffb1c07c691c2cfd6346ee3ce122f57fdf92710f24a400dc4e6  go1.6.4.linux-armv7hf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "go$GO_VERSION.linux-armv7hf.tar.gz" -C /usr/local/go --strip-components=1 \
-	&& rm -f go$GO_VERSION.linux-armv7hf.tar.gz
+	&& curl -SLO "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/go$GO_VERSION.linux-aarch64.tar.gz" \
+	&& echo "83345ebe96ac57de79d6ca2676602efd62a538934c6ce5608a3fe454faf70984  go1.6.4.linux-aarch64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "go$GO_VERSION.linux-aarch64.tar.gz" -C /usr/local/go --strip-components=1 \
+	&& rm -f go$GO_VERSION.linux-aarch64.tar.gz
 
 ENV GOROOT /usr/local/go
 ENV GOPATH /go

--- a/golang/kitra710/debian/1.6/slim/Dockerfile
+++ b/golang/kitra710/debian/1.6/slim/Dockerfile
@@ -7,10 +7,10 @@ RUN buildDeps='curl gcc g++ git' \
 	&& apt-get update && apt-get install -y $buildDeps \
 	&& rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/local/go \
-	&& curl -SLO "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/go$GO_VERSION.linux-armv7hf.tar.gz" \
-	&& echo "2e1041466b9bdffb1c07c691c2cfd6346ee3ce122f57fdf92710f24a400dc4e6  go1.6.4.linux-armv7hf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "go$GO_VERSION.linux-armv7hf.tar.gz" -C /usr/local/go --strip-components=1 \
-	&& rm -f go$GO_VERSION.linux-armv7hf.tar.gz
+	&& curl -SLO "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/go$GO_VERSION.linux-aarch64.tar.gz" \
+	&& echo "83345ebe96ac57de79d6ca2676602efd62a538934c6ce5608a3fe454faf70984  go1.6.4.linux-aarch64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "go$GO_VERSION.linux-aarch64.tar.gz" -C /usr/local/go --strip-components=1 \
+	&& rm -f go$GO_VERSION.linux-aarch64.tar.gz
 
 ENV GOROOT /usr/local/go
 ENV GOPATH /go

--- a/golang/kitra710/debian/1.6/wheezy/Dockerfile
+++ b/golang/kitra710/debian/1.6/wheezy/Dockerfile
@@ -3,10 +3,10 @@ FROM resin/kitra710-buildpack-deps:wheezy
 ENV GO_VERSION 1.6.4
 
 RUN mkdir -p /usr/local/go \
-	&& curl -SLO "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/go$GO_VERSION.linux-armv7hf.tar.gz" \
-	&& echo "2e1041466b9bdffb1c07c691c2cfd6346ee3ce122f57fdf92710f24a400dc4e6  go1.6.4.linux-armv7hf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "go$GO_VERSION.linux-armv7hf.tar.gz" -C /usr/local/go --strip-components=1 \
-	&& rm -f go$GO_VERSION.linux-armv7hf.tar.gz
+	&& curl -SLO "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/go$GO_VERSION.linux-aarch64.tar.gz" \
+	&& echo "83345ebe96ac57de79d6ca2676602efd62a538934c6ce5608a3fe454faf70984  go1.6.4.linux-aarch64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "go$GO_VERSION.linux-aarch64.tar.gz" -C /usr/local/go --strip-components=1 \
+	&& rm -f go$GO_VERSION.linux-aarch64.tar.gz
 
 ENV GOROOT /usr/local/go
 ENV GOPATH /go

--- a/golang/kitra710/debian/1.7/Dockerfile
+++ b/golang/kitra710/debian/1.7/Dockerfile
@@ -3,10 +3,10 @@ FROM resin/kitra710-buildpack-deps:jessie
 ENV GO_VERSION 1.7.5
 
 RUN mkdir -p /usr/local/go \
-	&& curl -SLO "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/go$GO_VERSION.linux-armv7hf.tar.gz" \
-	&& echo "4dc6e9e851bd48b92b758ff2127ffc5ac7320b35e1dd1b7aa51e74191fbee259  go1.7.5.linux-armv7hf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "go$GO_VERSION.linux-armv7hf.tar.gz" -C /usr/local/go --strip-components=1 \
-	&& rm -f go$GO_VERSION.linux-armv7hf.tar.gz
+	&& curl -SLO "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/go$GO_VERSION.linux-aarch64.tar.gz" \
+	&& echo "ad531f420f8fd2db2b506ec2683760be7a223af6e995122040526504b11a736c  go1.7.5.linux-aarch64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "go$GO_VERSION.linux-aarch64.tar.gz" -C /usr/local/go --strip-components=1 \
+	&& rm -f go$GO_VERSION.linux-aarch64.tar.gz
 
 ENV GOROOT /usr/local/go
 ENV GOPATH /go

--- a/golang/kitra710/debian/1.7/slim/Dockerfile
+++ b/golang/kitra710/debian/1.7/slim/Dockerfile
@@ -7,10 +7,10 @@ RUN buildDeps='curl gcc g++ git' \
 	&& apt-get update && apt-get install -y $buildDeps \
 	&& rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/local/go \
-	&& curl -SLO "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/go$GO_VERSION.linux-armv7hf.tar.gz" \
-	&& echo "4dc6e9e851bd48b92b758ff2127ffc5ac7320b35e1dd1b7aa51e74191fbee259  go1.7.5.linux-armv7hf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "go$GO_VERSION.linux-armv7hf.tar.gz" -C /usr/local/go --strip-components=1 \
-	&& rm -f go$GO_VERSION.linux-armv7hf.tar.gz
+	&& curl -SLO "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/go$GO_VERSION.linux-aarch64.tar.gz" \
+	&& echo "ad531f420f8fd2db2b506ec2683760be7a223af6e995122040526504b11a736c  go1.7.5.linux-aarch64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "go$GO_VERSION.linux-aarch64.tar.gz" -C /usr/local/go --strip-components=1 \
+	&& rm -f go$GO_VERSION.linux-aarch64.tar.gz
 
 ENV GOROOT /usr/local/go
 ENV GOPATH /go

--- a/golang/kitra710/debian/1.7/wheezy/Dockerfile
+++ b/golang/kitra710/debian/1.7/wheezy/Dockerfile
@@ -3,10 +3,10 @@ FROM resin/kitra710-buildpack-deps:wheezy
 ENV GO_VERSION 1.7.5
 
 RUN mkdir -p /usr/local/go \
-	&& curl -SLO "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/go$GO_VERSION.linux-armv7hf.tar.gz" \
-	&& echo "4dc6e9e851bd48b92b758ff2127ffc5ac7320b35e1dd1b7aa51e74191fbee259  go1.7.5.linux-armv7hf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "go$GO_VERSION.linux-armv7hf.tar.gz" -C /usr/local/go --strip-components=1 \
-	&& rm -f go$GO_VERSION.linux-armv7hf.tar.gz
+	&& curl -SLO "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/go$GO_VERSION.linux-aarch64.tar.gz" \
+	&& echo "ad531f420f8fd2db2b506ec2683760be7a223af6e995122040526504b11a736c  go1.7.5.linux-aarch64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "go$GO_VERSION.linux-aarch64.tar.gz" -C /usr/local/go --strip-components=1 \
+	&& rm -f go$GO_VERSION.linux-aarch64.tar.gz
 
 ENV GOROOT /usr/local/go
 ENV GOPATH /go

--- a/golang/kitra710/debian/1.8/Dockerfile
+++ b/golang/kitra710/debian/1.8/Dockerfile
@@ -3,10 +3,10 @@ FROM resin/kitra710-buildpack-deps:jessie
 ENV GO_VERSION 1.8.7
 
 RUN mkdir -p /usr/local/go \
-	&& curl -SLO "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/go$GO_VERSION.linux-armv7hf.tar.gz" \
-	&& echo "2f1485b0a6a800cd2544fe86387af93bb4c946c1978eeca36280be31bf41a73c  go1.8.7.linux-armv7hf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "go$GO_VERSION.linux-armv7hf.tar.gz" -C /usr/local/go --strip-components=1 \
-	&& rm -f go$GO_VERSION.linux-armv7hf.tar.gz
+	&& curl -SLO "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/go$GO_VERSION.linux-aarch64.tar.gz" \
+	&& echo "67ec30fded78b65175e779a0ddfdc19ab1233e51ae44818fcbada9fa3cafd72f  go1.8.7.linux-aarch64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "go$GO_VERSION.linux-aarch64.tar.gz" -C /usr/local/go --strip-components=1 \
+	&& rm -f go$GO_VERSION.linux-aarch64.tar.gz
 
 ENV GOROOT /usr/local/go
 ENV GOPATH /go

--- a/golang/kitra710/debian/1.8/slim/Dockerfile
+++ b/golang/kitra710/debian/1.8/slim/Dockerfile
@@ -7,10 +7,10 @@ RUN buildDeps='curl gcc g++ git' \
 	&& apt-get update && apt-get install -y $buildDeps \
 	&& rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/local/go \
-	&& curl -SLO "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/go$GO_VERSION.linux-armv7hf.tar.gz" \
-	&& echo "2f1485b0a6a800cd2544fe86387af93bb4c946c1978eeca36280be31bf41a73c  go1.8.7.linux-armv7hf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "go$GO_VERSION.linux-armv7hf.tar.gz" -C /usr/local/go --strip-components=1 \
-	&& rm -f go$GO_VERSION.linux-armv7hf.tar.gz
+	&& curl -SLO "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/go$GO_VERSION.linux-aarch64.tar.gz" \
+	&& echo "67ec30fded78b65175e779a0ddfdc19ab1233e51ae44818fcbada9fa3cafd72f  go1.8.7.linux-aarch64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "go$GO_VERSION.linux-aarch64.tar.gz" -C /usr/local/go --strip-components=1 \
+	&& rm -f go$GO_VERSION.linux-aarch64.tar.gz
 
 ENV GOROOT /usr/local/go
 ENV GOPATH /go

--- a/golang/kitra710/debian/1.8/wheezy/Dockerfile
+++ b/golang/kitra710/debian/1.8/wheezy/Dockerfile
@@ -3,10 +3,10 @@ FROM resin/kitra710-buildpack-deps:wheezy
 ENV GO_VERSION 1.8.7
 
 RUN mkdir -p /usr/local/go \
-	&& curl -SLO "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/go$GO_VERSION.linux-armv7hf.tar.gz" \
-	&& echo "2f1485b0a6a800cd2544fe86387af93bb4c946c1978eeca36280be31bf41a73c  go1.8.7.linux-armv7hf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "go$GO_VERSION.linux-armv7hf.tar.gz" -C /usr/local/go --strip-components=1 \
-	&& rm -f go$GO_VERSION.linux-armv7hf.tar.gz
+	&& curl -SLO "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/go$GO_VERSION.linux-aarch64.tar.gz" \
+	&& echo "67ec30fded78b65175e779a0ddfdc19ab1233e51ae44818fcbada9fa3cafd72f  go1.8.7.linux-aarch64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "go$GO_VERSION.linux-aarch64.tar.gz" -C /usr/local/go --strip-components=1 \
+	&& rm -f go$GO_VERSION.linux-aarch64.tar.gz
 
 ENV GOROOT /usr/local/go
 ENV GOPATH /go

--- a/golang/kitra710/debian/1.9/Dockerfile
+++ b/golang/kitra710/debian/1.9/Dockerfile
@@ -3,10 +3,10 @@ FROM resin/kitra710-buildpack-deps:jessie
 ENV GO_VERSION 1.9.4
 
 RUN mkdir -p /usr/local/go \
-	&& curl -SLO "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/go$GO_VERSION.linux-armv7hf.tar.gz" \
-	&& echo "7f65a8338f88d49c373f5bcbf8ec58cc1c2d5a6d3921a17d290011370f6af5b6  go1.9.4.linux-armv7hf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "go$GO_VERSION.linux-armv7hf.tar.gz" -C /usr/local/go --strip-components=1 \
-	&& rm -f go$GO_VERSION.linux-armv7hf.tar.gz
+	&& curl -SLO "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/go$GO_VERSION.linux-aarch64.tar.gz" \
+	&& echo "daec3bb8f6f36161369e5a0886ae2f95f9282a98c83b1f065dce116b3b4c3110  go1.9.4.linux-aarch64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "go$GO_VERSION.linux-aarch64.tar.gz" -C /usr/local/go --strip-components=1 \
+	&& rm -f go$GO_VERSION.linux-aarch64.tar.gz
 
 ENV GOROOT /usr/local/go
 ENV GOPATH /go

--- a/golang/kitra710/debian/1.9/slim/Dockerfile
+++ b/golang/kitra710/debian/1.9/slim/Dockerfile
@@ -7,10 +7,10 @@ RUN buildDeps='curl gcc g++ git' \
 	&& apt-get update && apt-get install -y $buildDeps \
 	&& rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/local/go \
-	&& curl -SLO "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/go$GO_VERSION.linux-armv7hf.tar.gz" \
-	&& echo "7f65a8338f88d49c373f5bcbf8ec58cc1c2d5a6d3921a17d290011370f6af5b6  go1.9.4.linux-armv7hf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "go$GO_VERSION.linux-armv7hf.tar.gz" -C /usr/local/go --strip-components=1 \
-	&& rm -f go$GO_VERSION.linux-armv7hf.tar.gz
+	&& curl -SLO "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/go$GO_VERSION.linux-aarch64.tar.gz" \
+	&& echo "daec3bb8f6f36161369e5a0886ae2f95f9282a98c83b1f065dce116b3b4c3110  go1.9.4.linux-aarch64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "go$GO_VERSION.linux-aarch64.tar.gz" -C /usr/local/go --strip-components=1 \
+	&& rm -f go$GO_VERSION.linux-aarch64.tar.gz
 
 ENV GOROOT /usr/local/go
 ENV GOPATH /go

--- a/golang/kitra710/debian/1.9/wheezy/Dockerfile
+++ b/golang/kitra710/debian/1.9/wheezy/Dockerfile
@@ -3,10 +3,10 @@ FROM resin/kitra710-buildpack-deps:wheezy
 ENV GO_VERSION 1.9.4
 
 RUN mkdir -p /usr/local/go \
-	&& curl -SLO "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/go$GO_VERSION.linux-armv7hf.tar.gz" \
-	&& echo "7f65a8338f88d49c373f5bcbf8ec58cc1c2d5a6d3921a17d290011370f6af5b6  go1.9.4.linux-armv7hf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "go$GO_VERSION.linux-armv7hf.tar.gz" -C /usr/local/go --strip-components=1 \
-	&& rm -f go$GO_VERSION.linux-armv7hf.tar.gz
+	&& curl -SLO "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/go$GO_VERSION.linux-aarch64.tar.gz" \
+	&& echo "daec3bb8f6f36161369e5a0886ae2f95f9282a98c83b1f065dce116b3b4c3110  go1.9.4.linux-aarch64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "go$GO_VERSION.linux-aarch64.tar.gz" -C /usr/local/go --strip-components=1 \
+	&& rm -f go$GO_VERSION.linux-aarch64.tar.gz
 
 ENV GOROOT /usr/local/go
 ENV GOPATH /go

--- a/golang/kitra710/fedora/1.6/24/Dockerfile
+++ b/golang/kitra710/fedora/1.6/24/Dockerfile
@@ -3,10 +3,10 @@ FROM resin/kitra710-fedora-buildpack-deps:24
 ENV GO_VERSION 1.6.4
 
 RUN mkdir -p /usr/local/go \
-	&& curl -SLO "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/go$GO_VERSION.linux-armv7hf.tar.gz" \
-	&& echo "2e1041466b9bdffb1c07c691c2cfd6346ee3ce122f57fdf92710f24a400dc4e6  go1.6.4.linux-armv7hf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "go$GO_VERSION.linux-armv7hf.tar.gz" -C /usr/local/go --strip-components=1 \
-	&& rm -f go$GO_VERSION.linux-armv7hf.tar.gz
+	&& curl -SLO "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/go$GO_VERSION.linux-aarch64.tar.gz" \
+	&& echo "83345ebe96ac57de79d6ca2676602efd62a538934c6ce5608a3fe454faf70984  go1.6.4.linux-aarch64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "go$GO_VERSION.linux-aarch64.tar.gz" -C /usr/local/go --strip-components=1 \
+	&& rm -f go$GO_VERSION.linux-aarch64.tar.gz
 
 ENV GOROOT /usr/local/go
 ENV GOPATH /go

--- a/golang/kitra710/fedora/1.6/Dockerfile
+++ b/golang/kitra710/fedora/1.6/Dockerfile
@@ -3,10 +3,10 @@ FROM resin/kitra710-fedora-buildpack-deps:latest
 ENV GO_VERSION 1.6.4
 
 RUN mkdir -p /usr/local/go \
-	&& curl -SLO "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/go$GO_VERSION.linux-armv7hf.tar.gz" \
-	&& echo "2e1041466b9bdffb1c07c691c2cfd6346ee3ce122f57fdf92710f24a400dc4e6  go1.6.4.linux-armv7hf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "go$GO_VERSION.linux-armv7hf.tar.gz" -C /usr/local/go --strip-components=1 \
-	&& rm -f go$GO_VERSION.linux-armv7hf.tar.gz
+	&& curl -SLO "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/go$GO_VERSION.linux-aarch64.tar.gz" \
+	&& echo "83345ebe96ac57de79d6ca2676602efd62a538934c6ce5608a3fe454faf70984  go1.6.4.linux-aarch64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "go$GO_VERSION.linux-aarch64.tar.gz" -C /usr/local/go --strip-components=1 \
+	&& rm -f go$GO_VERSION.linux-aarch64.tar.gz
 
 ENV GOROOT /usr/local/go
 ENV GOPATH /go

--- a/golang/kitra710/fedora/1.6/slim/Dockerfile
+++ b/golang/kitra710/fedora/1.6/slim/Dockerfile
@@ -10,10 +10,10 @@ RUN buildDeps='gcc gcc-c++ git' \
 	&& dnf install -y $buildDeps \
 	&& dnf clean all \
 	&& mkdir -p /usr/local/go \
-	&& curl -SLO "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/go$GO_VERSION.linux-armv7hf.tar.gz" \
-	&& echo "2e1041466b9bdffb1c07c691c2cfd6346ee3ce122f57fdf92710f24a400dc4e6  go1.6.4.linux-armv7hf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "go$GO_VERSION.linux-armv7hf.tar.gz" -C /usr/local/go --strip-components=1 \
-	&& rm go$GO_VERSION.linux-armv7hf.tar.gz \
+	&& curl -SLO "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/go$GO_VERSION.linux-aarch64.tar.gz" \
+	&& echo "83345ebe96ac57de79d6ca2676602efd62a538934c6ce5608a3fe454faf70984  go1.6.4.linux-aarch64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "go$GO_VERSION.linux-aarch64.tar.gz" -C /usr/local/go --strip-components=1 \
+	&& rm go$GO_VERSION.linux-aarch64.tar.gz \
 	&& mkdir -p "$GOPATH/src" "$GOPATH/bin" \
 	&& chmod -R 777 "$GOPATH"
 

--- a/golang/kitra710/fedora/1.7/24/Dockerfile
+++ b/golang/kitra710/fedora/1.7/24/Dockerfile
@@ -3,10 +3,10 @@ FROM resin/kitra710-fedora-buildpack-deps:24
 ENV GO_VERSION 1.7.5
 
 RUN mkdir -p /usr/local/go \
-	&& curl -SLO "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/go$GO_VERSION.linux-armv7hf.tar.gz" \
-	&& echo "4dc6e9e851bd48b92b758ff2127ffc5ac7320b35e1dd1b7aa51e74191fbee259  go1.7.5.linux-armv7hf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "go$GO_VERSION.linux-armv7hf.tar.gz" -C /usr/local/go --strip-components=1 \
-	&& rm -f go$GO_VERSION.linux-armv7hf.tar.gz
+	&& curl -SLO "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/go$GO_VERSION.linux-aarch64.tar.gz" \
+	&& echo "ad531f420f8fd2db2b506ec2683760be7a223af6e995122040526504b11a736c  go1.7.5.linux-aarch64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "go$GO_VERSION.linux-aarch64.tar.gz" -C /usr/local/go --strip-components=1 \
+	&& rm -f go$GO_VERSION.linux-aarch64.tar.gz
 
 ENV GOROOT /usr/local/go
 ENV GOPATH /go

--- a/golang/kitra710/fedora/1.7/Dockerfile
+++ b/golang/kitra710/fedora/1.7/Dockerfile
@@ -3,10 +3,10 @@ FROM resin/kitra710-fedora-buildpack-deps:latest
 ENV GO_VERSION 1.7.5
 
 RUN mkdir -p /usr/local/go \
-	&& curl -SLO "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/go$GO_VERSION.linux-armv7hf.tar.gz" \
-	&& echo "4dc6e9e851bd48b92b758ff2127ffc5ac7320b35e1dd1b7aa51e74191fbee259  go1.7.5.linux-armv7hf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "go$GO_VERSION.linux-armv7hf.tar.gz" -C /usr/local/go --strip-components=1 \
-	&& rm -f go$GO_VERSION.linux-armv7hf.tar.gz
+	&& curl -SLO "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/go$GO_VERSION.linux-aarch64.tar.gz" \
+	&& echo "ad531f420f8fd2db2b506ec2683760be7a223af6e995122040526504b11a736c  go1.7.5.linux-aarch64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "go$GO_VERSION.linux-aarch64.tar.gz" -C /usr/local/go --strip-components=1 \
+	&& rm -f go$GO_VERSION.linux-aarch64.tar.gz
 
 ENV GOROOT /usr/local/go
 ENV GOPATH /go

--- a/golang/kitra710/fedora/1.7/slim/Dockerfile
+++ b/golang/kitra710/fedora/1.7/slim/Dockerfile
@@ -10,10 +10,10 @@ RUN buildDeps='gcc gcc-c++ git' \
 	&& dnf install -y $buildDeps \
 	&& dnf clean all \
 	&& mkdir -p /usr/local/go \
-	&& curl -SLO "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/go$GO_VERSION.linux-armv7hf.tar.gz" \
-	&& echo "4dc6e9e851bd48b92b758ff2127ffc5ac7320b35e1dd1b7aa51e74191fbee259  go1.7.5.linux-armv7hf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "go$GO_VERSION.linux-armv7hf.tar.gz" -C /usr/local/go --strip-components=1 \
-	&& rm go$GO_VERSION.linux-armv7hf.tar.gz \
+	&& curl -SLO "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/go$GO_VERSION.linux-aarch64.tar.gz" \
+	&& echo "ad531f420f8fd2db2b506ec2683760be7a223af6e995122040526504b11a736c  go1.7.5.linux-aarch64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "go$GO_VERSION.linux-aarch64.tar.gz" -C /usr/local/go --strip-components=1 \
+	&& rm go$GO_VERSION.linux-aarch64.tar.gz \
 	&& mkdir -p "$GOPATH/src" "$GOPATH/bin" \
 	&& chmod -R 777 "$GOPATH"
 

--- a/golang/kitra710/fedora/1.8/24/Dockerfile
+++ b/golang/kitra710/fedora/1.8/24/Dockerfile
@@ -3,10 +3,10 @@ FROM resin/kitra710-fedora-buildpack-deps:24
 ENV GO_VERSION 1.8.7
 
 RUN mkdir -p /usr/local/go \
-	&& curl -SLO "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/go$GO_VERSION.linux-armv7hf.tar.gz" \
-	&& echo "2f1485b0a6a800cd2544fe86387af93bb4c946c1978eeca36280be31bf41a73c  go1.8.7.linux-armv7hf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "go$GO_VERSION.linux-armv7hf.tar.gz" -C /usr/local/go --strip-components=1 \
-	&& rm -f go$GO_VERSION.linux-armv7hf.tar.gz
+	&& curl -SLO "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/go$GO_VERSION.linux-aarch64.tar.gz" \
+	&& echo "67ec30fded78b65175e779a0ddfdc19ab1233e51ae44818fcbada9fa3cafd72f  go1.8.7.linux-aarch64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "go$GO_VERSION.linux-aarch64.tar.gz" -C /usr/local/go --strip-components=1 \
+	&& rm -f go$GO_VERSION.linux-aarch64.tar.gz
 
 ENV GOROOT /usr/local/go
 ENV GOPATH /go

--- a/golang/kitra710/fedora/1.8/Dockerfile
+++ b/golang/kitra710/fedora/1.8/Dockerfile
@@ -3,10 +3,10 @@ FROM resin/kitra710-fedora-buildpack-deps:latest
 ENV GO_VERSION 1.8.7
 
 RUN mkdir -p /usr/local/go \
-	&& curl -SLO "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/go$GO_VERSION.linux-armv7hf.tar.gz" \
-	&& echo "2f1485b0a6a800cd2544fe86387af93bb4c946c1978eeca36280be31bf41a73c  go1.8.7.linux-armv7hf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "go$GO_VERSION.linux-armv7hf.tar.gz" -C /usr/local/go --strip-components=1 \
-	&& rm -f go$GO_VERSION.linux-armv7hf.tar.gz
+	&& curl -SLO "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/go$GO_VERSION.linux-aarch64.tar.gz" \
+	&& echo "67ec30fded78b65175e779a0ddfdc19ab1233e51ae44818fcbada9fa3cafd72f  go1.8.7.linux-aarch64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "go$GO_VERSION.linux-aarch64.tar.gz" -C /usr/local/go --strip-components=1 \
+	&& rm -f go$GO_VERSION.linux-aarch64.tar.gz
 
 ENV GOROOT /usr/local/go
 ENV GOPATH /go

--- a/golang/kitra710/fedora/1.8/slim/Dockerfile
+++ b/golang/kitra710/fedora/1.8/slim/Dockerfile
@@ -10,10 +10,10 @@ RUN buildDeps='gcc gcc-c++ git' \
 	&& dnf install -y $buildDeps \
 	&& dnf clean all \
 	&& mkdir -p /usr/local/go \
-	&& curl -SLO "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/go$GO_VERSION.linux-armv7hf.tar.gz" \
-	&& echo "2f1485b0a6a800cd2544fe86387af93bb4c946c1978eeca36280be31bf41a73c  go1.8.7.linux-armv7hf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "go$GO_VERSION.linux-armv7hf.tar.gz" -C /usr/local/go --strip-components=1 \
-	&& rm go$GO_VERSION.linux-armv7hf.tar.gz \
+	&& curl -SLO "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/go$GO_VERSION.linux-aarch64.tar.gz" \
+	&& echo "67ec30fded78b65175e779a0ddfdc19ab1233e51ae44818fcbada9fa3cafd72f  go1.8.7.linux-aarch64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "go$GO_VERSION.linux-aarch64.tar.gz" -C /usr/local/go --strip-components=1 \
+	&& rm go$GO_VERSION.linux-aarch64.tar.gz \
 	&& mkdir -p "$GOPATH/src" "$GOPATH/bin" \
 	&& chmod -R 777 "$GOPATH"
 

--- a/golang/kitra710/fedora/1.9/24/Dockerfile
+++ b/golang/kitra710/fedora/1.9/24/Dockerfile
@@ -3,10 +3,10 @@ FROM resin/kitra710-fedora-buildpack-deps:24
 ENV GO_VERSION 1.9.4
 
 RUN mkdir -p /usr/local/go \
-	&& curl -SLO "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/go$GO_VERSION.linux-armv7hf.tar.gz" \
-	&& echo "7f65a8338f88d49c373f5bcbf8ec58cc1c2d5a6d3921a17d290011370f6af5b6  go1.9.4.linux-armv7hf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "go$GO_VERSION.linux-armv7hf.tar.gz" -C /usr/local/go --strip-components=1 \
-	&& rm -f go$GO_VERSION.linux-armv7hf.tar.gz
+	&& curl -SLO "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/go$GO_VERSION.linux-aarch64.tar.gz" \
+	&& echo "daec3bb8f6f36161369e5a0886ae2f95f9282a98c83b1f065dce116b3b4c3110  go1.9.4.linux-aarch64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "go$GO_VERSION.linux-aarch64.tar.gz" -C /usr/local/go --strip-components=1 \
+	&& rm -f go$GO_VERSION.linux-aarch64.tar.gz
 
 ENV GOROOT /usr/local/go
 ENV GOPATH /go

--- a/golang/kitra710/fedora/1.9/Dockerfile
+++ b/golang/kitra710/fedora/1.9/Dockerfile
@@ -3,10 +3,10 @@ FROM resin/kitra710-fedora-buildpack-deps:latest
 ENV GO_VERSION 1.9.4
 
 RUN mkdir -p /usr/local/go \
-	&& curl -SLO "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/go$GO_VERSION.linux-armv7hf.tar.gz" \
-	&& echo "7f65a8338f88d49c373f5bcbf8ec58cc1c2d5a6d3921a17d290011370f6af5b6  go1.9.4.linux-armv7hf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "go$GO_VERSION.linux-armv7hf.tar.gz" -C /usr/local/go --strip-components=1 \
-	&& rm -f go$GO_VERSION.linux-armv7hf.tar.gz
+	&& curl -SLO "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/go$GO_VERSION.linux-aarch64.tar.gz" \
+	&& echo "daec3bb8f6f36161369e5a0886ae2f95f9282a98c83b1f065dce116b3b4c3110  go1.9.4.linux-aarch64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "go$GO_VERSION.linux-aarch64.tar.gz" -C /usr/local/go --strip-components=1 \
+	&& rm -f go$GO_VERSION.linux-aarch64.tar.gz
 
 ENV GOROOT /usr/local/go
 ENV GOPATH /go

--- a/golang/kitra710/fedora/1.9/slim/Dockerfile
+++ b/golang/kitra710/fedora/1.9/slim/Dockerfile
@@ -10,10 +10,10 @@ RUN buildDeps='gcc gcc-c++ git' \
 	&& dnf install -y $buildDeps \
 	&& dnf clean all \
 	&& mkdir -p /usr/local/go \
-	&& curl -SLO "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/go$GO_VERSION.linux-armv7hf.tar.gz" \
-	&& echo "7f65a8338f88d49c373f5bcbf8ec58cc1c2d5a6d3921a17d290011370f6af5b6  go1.9.4.linux-armv7hf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "go$GO_VERSION.linux-armv7hf.tar.gz" -C /usr/local/go --strip-components=1 \
-	&& rm go$GO_VERSION.linux-armv7hf.tar.gz \
+	&& curl -SLO "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/go$GO_VERSION.linux-aarch64.tar.gz" \
+	&& echo "daec3bb8f6f36161369e5a0886ae2f95f9282a98c83b1f065dce116b3b4c3110  go1.9.4.linux-aarch64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "go$GO_VERSION.linux-aarch64.tar.gz" -C /usr/local/go --strip-components=1 \
+	&& rm go$GO_VERSION.linux-aarch64.tar.gz \
 	&& mkdir -p "$GOPATH/src" "$GOPATH/bin" \
 	&& chmod -R 777 "$GOPATH"
 

--- a/node/artik710/alpine/4.8/Dockerfile
+++ b/node/artik710/alpine/4.8/Dockerfile
@@ -6,10 +6,10 @@ ENV NODE_VERSION 4.8.7
 # Install dependencies
 RUN apk add --no-cache libgcc libstdc++ libuv libcrypto1.0 libssl1.0
 
-RUN curl -SLO "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/node-v$NODE_VERSION-linux-alpine-armhf.tar.gz" \
-	&& echo "fec4448579a5d9078537bcd719a1578c627845df7919ad39092c6b9df49c9259  node-v4.8.7-linux-alpine-armhf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "node-v$NODE_VERSION-linux-alpine-armhf.tar.gz" -C /usr/local --strip-components=1 \
-	&& rm "node-v$NODE_VERSION-linux-alpine-armhf.tar.gz" \
+RUN curl -SLO "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/node-v$NODE_VERSION-linux-alpine-aarch64.tar.gz" \
+	&& echo "8bbc599bc95cd87490a116d51030437d23fae3682cb38b33bd10cadc30995bc3  node-v4.8.7-linux-alpine-aarch64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "node-v$NODE_VERSION-linux-alpine-aarch64.tar.gz" -C /usr/local --strip-components=1 \
+	&& rm "node-v$NODE_VERSION-linux-alpine-aarch64.tar.gz" \
 	&& npm config set unsafe-perm true -g --unsafe-perm \
 	&& rm -rf /tmp/*
 

--- a/node/artik710/alpine/4.8/edge/Dockerfile
+++ b/node/artik710/alpine/4.8/edge/Dockerfile
@@ -6,10 +6,10 @@ ENV NODE_VERSION 4.8.7
 # Install dependencies
 RUN apk add --no-cache libgcc libstdc++ libuv libcrypto1.0 libssl1.0
 
-RUN curl -SLO "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/node-v$NODE_VERSION-linux-alpine-armhf.tar.gz" \
-	&& echo "fec4448579a5d9078537bcd719a1578c627845df7919ad39092c6b9df49c9259  node-v4.8.7-linux-alpine-armhf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "node-v$NODE_VERSION-linux-alpine-armhf.tar.gz" -C /usr/local --strip-components=1 \
-	&& rm "node-v$NODE_VERSION-linux-alpine-armhf.tar.gz" \
+RUN curl -SLO "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/node-v$NODE_VERSION-linux-alpine-aarch64.tar.gz" \
+	&& echo "8bbc599bc95cd87490a116d51030437d23fae3682cb38b33bd10cadc30995bc3  node-v4.8.7-linux-alpine-aarch64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "node-v$NODE_VERSION-linux-alpine-aarch64.tar.gz" -C /usr/local --strip-components=1 \
+	&& rm "node-v$NODE_VERSION-linux-alpine-aarch64.tar.gz" \
 	&& npm config set unsafe-perm true -g --unsafe-perm \
 	&& rm -rf /tmp/*
 

--- a/node/artik710/alpine/4.8/slim/Dockerfile
+++ b/node/artik710/alpine/4.8/slim/Dockerfile
@@ -9,10 +9,10 @@ RUN apk add --no-cache libgcc libstdc++ libuv libcrypto1.0 libssl1.0
 RUN buildDeps='curl' \
 	&& set -x \
 	&& apk add --no-cache $buildDeps \
-	&& curl -SLO "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/node-v$NODE_VERSION-linux-alpine-armhf.tar.gz" \
-	&& echo "fec4448579a5d9078537bcd719a1578c627845df7919ad39092c6b9df49c9259  node-v4.8.7-linux-alpine-armhf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "node-v$NODE_VERSION-linux-alpine-armhf.tar.gz" -C /usr/local --strip-components=1 \
-	&& rm "node-v$NODE_VERSION-linux-alpine-armhf.tar.gz" \
+	&& curl -SLO "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/node-v$NODE_VERSION-linux-alpine-aarch64.tar.gz" \
+	&& echo "8bbc599bc95cd87490a116d51030437d23fae3682cb38b33bd10cadc30995bc3  node-v4.8.7-linux-alpine-aarch64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "node-v$NODE_VERSION-linux-alpine-aarch64.tar.gz" -C /usr/local --strip-components=1 \
+	&& rm "node-v$NODE_VERSION-linux-alpine-aarch64.tar.gz" \
 	&& apk del $buildDeps \
 	&& npm config set unsafe-perm true -g --unsafe-perm \
 	&& rm -rf /tmp/*

--- a/node/artik710/alpine/5.12/Dockerfile
+++ b/node/artik710/alpine/5.12/Dockerfile
@@ -6,10 +6,10 @@ ENV NODE_VERSION 5.12.0
 # Install dependencies
 RUN apk add --no-cache libgcc libstdc++ libuv libcrypto1.0 libssl1.0
 
-RUN curl -SLO "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/node-v$NODE_VERSION-linux-alpine-armhf.tar.gz" \
-	&& echo "bbaa5d89b483272f930b65361bc241c5fb694471712af2e15a3afd65e7d1611f  node-v5.12.0-linux-alpine-armhf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "node-v$NODE_VERSION-linux-alpine-armhf.tar.gz" -C /usr/local --strip-components=1 \
-	&& rm "node-v$NODE_VERSION-linux-alpine-armhf.tar.gz" \
+RUN curl -SLO "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/node-v$NODE_VERSION-linux-alpine-aarch64.tar.gz" \
+	&& echo "1eeed8c7aa1f1125218b18cb6a62c7049f60bd763c5400ba55d2f706b9629fbd  node-v5.12.0-linux-alpine-aarch64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "node-v$NODE_VERSION-linux-alpine-aarch64.tar.gz" -C /usr/local --strip-components=1 \
+	&& rm "node-v$NODE_VERSION-linux-alpine-aarch64.tar.gz" \
 	&& npm config set unsafe-perm true -g --unsafe-perm \
 	&& rm -rf /tmp/*
 

--- a/node/artik710/alpine/5.12/edge/Dockerfile
+++ b/node/artik710/alpine/5.12/edge/Dockerfile
@@ -6,10 +6,10 @@ ENV NODE_VERSION 5.12.0
 # Install dependencies
 RUN apk add --no-cache libgcc libstdc++ libuv libcrypto1.0 libssl1.0
 
-RUN curl -SLO "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/node-v$NODE_VERSION-linux-alpine-armhf.tar.gz" \
-	&& echo "bbaa5d89b483272f930b65361bc241c5fb694471712af2e15a3afd65e7d1611f  node-v5.12.0-linux-alpine-armhf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "node-v$NODE_VERSION-linux-alpine-armhf.tar.gz" -C /usr/local --strip-components=1 \
-	&& rm "node-v$NODE_VERSION-linux-alpine-armhf.tar.gz" \
+RUN curl -SLO "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/node-v$NODE_VERSION-linux-alpine-aarch64.tar.gz" \
+	&& echo "1eeed8c7aa1f1125218b18cb6a62c7049f60bd763c5400ba55d2f706b9629fbd  node-v5.12.0-linux-alpine-aarch64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "node-v$NODE_VERSION-linux-alpine-aarch64.tar.gz" -C /usr/local --strip-components=1 \
+	&& rm "node-v$NODE_VERSION-linux-alpine-aarch64.tar.gz" \
 	&& npm config set unsafe-perm true -g --unsafe-perm \
 	&& rm -rf /tmp/*
 

--- a/node/artik710/alpine/5.12/slim/Dockerfile
+++ b/node/artik710/alpine/5.12/slim/Dockerfile
@@ -9,10 +9,10 @@ RUN apk add --no-cache libgcc libstdc++ libuv libcrypto1.0 libssl1.0
 RUN buildDeps='curl' \
 	&& set -x \
 	&& apk add --no-cache $buildDeps \
-	&& curl -SLO "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/node-v$NODE_VERSION-linux-alpine-armhf.tar.gz" \
-	&& echo "bbaa5d89b483272f930b65361bc241c5fb694471712af2e15a3afd65e7d1611f  node-v5.12.0-linux-alpine-armhf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "node-v$NODE_VERSION-linux-alpine-armhf.tar.gz" -C /usr/local --strip-components=1 \
-	&& rm "node-v$NODE_VERSION-linux-alpine-armhf.tar.gz" \
+	&& curl -SLO "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/node-v$NODE_VERSION-linux-alpine-aarch64.tar.gz" \
+	&& echo "1eeed8c7aa1f1125218b18cb6a62c7049f60bd763c5400ba55d2f706b9629fbd  node-v5.12.0-linux-alpine-aarch64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "node-v$NODE_VERSION-linux-alpine-aarch64.tar.gz" -C /usr/local --strip-components=1 \
+	&& rm "node-v$NODE_VERSION-linux-alpine-aarch64.tar.gz" \
 	&& apk del $buildDeps \
 	&& npm config set unsafe-perm true -g --unsafe-perm \
 	&& rm -rf /tmp/*

--- a/node/artik710/alpine/6.13/Dockerfile
+++ b/node/artik710/alpine/6.13/Dockerfile
@@ -6,10 +6,10 @@ ENV NODE_VERSION 6.13.1
 # Install dependencies
 RUN apk add --no-cache libgcc libstdc++ libuv libcrypto1.0 libssl1.0
 
-RUN curl -SLO "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/node-v$NODE_VERSION-linux-alpine-armhf.tar.gz" \
-	&& echo "03e99b6e5486535c47ff72ff390092f8952c50cc8a9983acc8736bbd77555a8e  node-v6.13.1-linux-alpine-armhf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "node-v$NODE_VERSION-linux-alpine-armhf.tar.gz" -C /usr/local --strip-components=1 \
-	&& rm "node-v$NODE_VERSION-linux-alpine-armhf.tar.gz" \
+RUN curl -SLO "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/node-v$NODE_VERSION-linux-alpine-aarch64.tar.gz" \
+	&& echo "367a810c0621bb3d914396ecbe6f596109ee76e4759d122042a54769924cbd63  node-v6.13.1-linux-alpine-aarch64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "node-v$NODE_VERSION-linux-alpine-aarch64.tar.gz" -C /usr/local --strip-components=1 \
+	&& rm "node-v$NODE_VERSION-linux-alpine-aarch64.tar.gz" \
 	&& npm config set unsafe-perm true -g --unsafe-perm \
 	&& rm -rf /tmp/*
 

--- a/node/artik710/alpine/6.13/edge/Dockerfile
+++ b/node/artik710/alpine/6.13/edge/Dockerfile
@@ -6,10 +6,10 @@ ENV NODE_VERSION 6.13.1
 # Install dependencies
 RUN apk add --no-cache libgcc libstdc++ libuv libcrypto1.0 libssl1.0
 
-RUN curl -SLO "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/node-v$NODE_VERSION-linux-alpine-armhf.tar.gz" \
-	&& echo "03e99b6e5486535c47ff72ff390092f8952c50cc8a9983acc8736bbd77555a8e  node-v6.13.1-linux-alpine-armhf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "node-v$NODE_VERSION-linux-alpine-armhf.tar.gz" -C /usr/local --strip-components=1 \
-	&& rm "node-v$NODE_VERSION-linux-alpine-armhf.tar.gz" \
+RUN curl -SLO "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/node-v$NODE_VERSION-linux-alpine-aarch64.tar.gz" \
+	&& echo "367a810c0621bb3d914396ecbe6f596109ee76e4759d122042a54769924cbd63  node-v6.13.1-linux-alpine-aarch64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "node-v$NODE_VERSION-linux-alpine-aarch64.tar.gz" -C /usr/local --strip-components=1 \
+	&& rm "node-v$NODE_VERSION-linux-alpine-aarch64.tar.gz" \
 	&& npm config set unsafe-perm true -g --unsafe-perm \
 	&& rm -rf /tmp/*
 

--- a/node/artik710/alpine/6.13/slim/Dockerfile
+++ b/node/artik710/alpine/6.13/slim/Dockerfile
@@ -9,10 +9,10 @@ RUN apk add --no-cache libgcc libstdc++ libuv libcrypto1.0 libssl1.0
 RUN buildDeps='curl' \
 	&& set -x \
 	&& apk add --no-cache $buildDeps \
-	&& curl -SLO "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/node-v$NODE_VERSION-linux-alpine-armhf.tar.gz" \
-	&& echo "03e99b6e5486535c47ff72ff390092f8952c50cc8a9983acc8736bbd77555a8e  node-v6.13.1-linux-alpine-armhf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "node-v$NODE_VERSION-linux-alpine-armhf.tar.gz" -C /usr/local --strip-components=1 \
-	&& rm "node-v$NODE_VERSION-linux-alpine-armhf.tar.gz" \
+	&& curl -SLO "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/node-v$NODE_VERSION-linux-alpine-aarch64.tar.gz" \
+	&& echo "367a810c0621bb3d914396ecbe6f596109ee76e4759d122042a54769924cbd63  node-v6.13.1-linux-alpine-aarch64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "node-v$NODE_VERSION-linux-alpine-aarch64.tar.gz" -C /usr/local --strip-components=1 \
+	&& rm "node-v$NODE_VERSION-linux-alpine-aarch64.tar.gz" \
 	&& apk del $buildDeps \
 	&& npm config set unsafe-perm true -g --unsafe-perm \
 	&& rm -rf /tmp/*

--- a/node/artik710/alpine/7.10/Dockerfile
+++ b/node/artik710/alpine/7.10/Dockerfile
@@ -6,10 +6,10 @@ ENV NODE_VERSION 7.10.1
 # Install dependencies
 RUN apk add --no-cache libgcc libstdc++ libuv libcrypto1.0 libssl1.0
 
-RUN curl -SLO "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/node-v$NODE_VERSION-linux-alpine-armhf.tar.gz" \
-	&& echo "8eb485eff51ac2046e3d4b6108f82bd7648549b01887ca1cbf6dbd21177185df  node-v7.10.1-linux-alpine-armhf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "node-v$NODE_VERSION-linux-alpine-armhf.tar.gz" -C /usr/local --strip-components=1 \
-	&& rm "node-v$NODE_VERSION-linux-alpine-armhf.tar.gz" \
+RUN curl -SLO "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/node-v$NODE_VERSION-linux-alpine-aarch64.tar.gz" \
+	&& echo "f4f13afb28993fe512b51f7bcb796c5ca2b3fd6f290472ed855a9648cfa6eccc  node-v7.10.1-linux-alpine-aarch64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "node-v$NODE_VERSION-linux-alpine-aarch64.tar.gz" -C /usr/local --strip-components=1 \
+	&& rm "node-v$NODE_VERSION-linux-alpine-aarch64.tar.gz" \
 	&& npm config set unsafe-perm true -g --unsafe-perm \
 	&& rm -rf /tmp/*
 

--- a/node/artik710/alpine/7.10/edge/Dockerfile
+++ b/node/artik710/alpine/7.10/edge/Dockerfile
@@ -6,10 +6,10 @@ ENV NODE_VERSION 7.10.1
 # Install dependencies
 RUN apk add --no-cache libgcc libstdc++ libuv libcrypto1.0 libssl1.0
 
-RUN curl -SLO "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/node-v$NODE_VERSION-linux-alpine-armhf.tar.gz" \
-	&& echo "8eb485eff51ac2046e3d4b6108f82bd7648549b01887ca1cbf6dbd21177185df  node-v7.10.1-linux-alpine-armhf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "node-v$NODE_VERSION-linux-alpine-armhf.tar.gz" -C /usr/local --strip-components=1 \
-	&& rm "node-v$NODE_VERSION-linux-alpine-armhf.tar.gz" \
+RUN curl -SLO "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/node-v$NODE_VERSION-linux-alpine-aarch64.tar.gz" \
+	&& echo "f4f13afb28993fe512b51f7bcb796c5ca2b3fd6f290472ed855a9648cfa6eccc  node-v7.10.1-linux-alpine-aarch64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "node-v$NODE_VERSION-linux-alpine-aarch64.tar.gz" -C /usr/local --strip-components=1 \
+	&& rm "node-v$NODE_VERSION-linux-alpine-aarch64.tar.gz" \
 	&& npm config set unsafe-perm true -g --unsafe-perm \
 	&& rm -rf /tmp/*
 

--- a/node/artik710/alpine/7.10/slim/Dockerfile
+++ b/node/artik710/alpine/7.10/slim/Dockerfile
@@ -9,10 +9,10 @@ RUN apk add --no-cache libgcc libstdc++ libuv libcrypto1.0 libssl1.0
 RUN buildDeps='curl' \
 	&& set -x \
 	&& apk add --no-cache $buildDeps \
-	&& curl -SLO "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/node-v$NODE_VERSION-linux-alpine-armhf.tar.gz" \
-	&& echo "8eb485eff51ac2046e3d4b6108f82bd7648549b01887ca1cbf6dbd21177185df  node-v7.10.1-linux-alpine-armhf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "node-v$NODE_VERSION-linux-alpine-armhf.tar.gz" -C /usr/local --strip-components=1 \
-	&& rm "node-v$NODE_VERSION-linux-alpine-armhf.tar.gz" \
+	&& curl -SLO "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/node-v$NODE_VERSION-linux-alpine-aarch64.tar.gz" \
+	&& echo "f4f13afb28993fe512b51f7bcb796c5ca2b3fd6f290472ed855a9648cfa6eccc  node-v7.10.1-linux-alpine-aarch64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "node-v$NODE_VERSION-linux-alpine-aarch64.tar.gz" -C /usr/local --strip-components=1 \
+	&& rm "node-v$NODE_VERSION-linux-alpine-aarch64.tar.gz" \
 	&& apk del $buildDeps \
 	&& npm config set unsafe-perm true -g --unsafe-perm \
 	&& rm -rf /tmp/*

--- a/node/artik710/alpine/8.9/Dockerfile
+++ b/node/artik710/alpine/8.9/Dockerfile
@@ -6,10 +6,10 @@ ENV NODE_VERSION 8.9.4
 # Install dependencies
 RUN apk add --no-cache libgcc libstdc++ libuv libcrypto1.0 libssl1.0
 
-RUN curl -SLO "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/node-v$NODE_VERSION-linux-alpine-armhf.tar.gz" \
-	&& echo "0d97b5b666fef3b7c6206f54d815e1c3442730e60f002c7a5a60eae6c0f33ceb  node-v8.9.4-linux-alpine-armhf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "node-v$NODE_VERSION-linux-alpine-armhf.tar.gz" -C /usr/local --strip-components=1 \
-	&& rm "node-v$NODE_VERSION-linux-alpine-armhf.tar.gz" \
+RUN curl -SLO "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/node-v$NODE_VERSION-linux-alpine-aarch64.tar.gz" \
+	&& echo "d9e566a6e804d4f71e6d39c2c9976e5e9d30105c35076ae7bf6f586ae1020f28  node-v8.9.4-linux-alpine-aarch64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "node-v$NODE_VERSION-linux-alpine-aarch64.tar.gz" -C /usr/local --strip-components=1 \
+	&& rm "node-v$NODE_VERSION-linux-alpine-aarch64.tar.gz" \
 	&& npm config set unsafe-perm true -g --unsafe-perm \
 	&& rm -rf /tmp/*
 

--- a/node/artik710/alpine/8.9/edge/Dockerfile
+++ b/node/artik710/alpine/8.9/edge/Dockerfile
@@ -6,10 +6,10 @@ ENV NODE_VERSION 8.9.4
 # Install dependencies
 RUN apk add --no-cache libgcc libstdc++ libuv libcrypto1.0 libssl1.0
 
-RUN curl -SLO "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/node-v$NODE_VERSION-linux-alpine-armhf.tar.gz" \
-	&& echo "0d97b5b666fef3b7c6206f54d815e1c3442730e60f002c7a5a60eae6c0f33ceb  node-v8.9.4-linux-alpine-armhf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "node-v$NODE_VERSION-linux-alpine-armhf.tar.gz" -C /usr/local --strip-components=1 \
-	&& rm "node-v$NODE_VERSION-linux-alpine-armhf.tar.gz" \
+RUN curl -SLO "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/node-v$NODE_VERSION-linux-alpine-aarch64.tar.gz" \
+	&& echo "d9e566a6e804d4f71e6d39c2c9976e5e9d30105c35076ae7bf6f586ae1020f28  node-v8.9.4-linux-alpine-aarch64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "node-v$NODE_VERSION-linux-alpine-aarch64.tar.gz" -C /usr/local --strip-components=1 \
+	&& rm "node-v$NODE_VERSION-linux-alpine-aarch64.tar.gz" \
 	&& npm config set unsafe-perm true -g --unsafe-perm \
 	&& rm -rf /tmp/*
 

--- a/node/artik710/alpine/8.9/slim/Dockerfile
+++ b/node/artik710/alpine/8.9/slim/Dockerfile
@@ -9,10 +9,10 @@ RUN apk add --no-cache libgcc libstdc++ libuv libcrypto1.0 libssl1.0
 RUN buildDeps='curl' \
 	&& set -x \
 	&& apk add --no-cache $buildDeps \
-	&& curl -SLO "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/node-v$NODE_VERSION-linux-alpine-armhf.tar.gz" \
-	&& echo "0d97b5b666fef3b7c6206f54d815e1c3442730e60f002c7a5a60eae6c0f33ceb  node-v8.9.4-linux-alpine-armhf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "node-v$NODE_VERSION-linux-alpine-armhf.tar.gz" -C /usr/local --strip-components=1 \
-	&& rm "node-v$NODE_VERSION-linux-alpine-armhf.tar.gz" \
+	&& curl -SLO "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/node-v$NODE_VERSION-linux-alpine-aarch64.tar.gz" \
+	&& echo "d9e566a6e804d4f71e6d39c2c9976e5e9d30105c35076ae7bf6f586ae1020f28  node-v8.9.4-linux-alpine-aarch64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "node-v$NODE_VERSION-linux-alpine-aarch64.tar.gz" -C /usr/local --strip-components=1 \
+	&& rm "node-v$NODE_VERSION-linux-alpine-aarch64.tar.gz" \
 	&& apk del $buildDeps \
 	&& npm config set unsafe-perm true -g --unsafe-perm \
 	&& rm -rf /tmp/*

--- a/node/artik710/alpine/9.5/Dockerfile
+++ b/node/artik710/alpine/9.5/Dockerfile
@@ -6,10 +6,10 @@ ENV NODE_VERSION 9.5.0
 # Install dependencies
 RUN apk add --no-cache libgcc libstdc++ libuv libcrypto1.0 libssl1.0
 
-RUN curl -SLO "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/node-v$NODE_VERSION-linux-alpine-armhf.tar.gz" \
-	&& echo "431072120208ec8c419cded1f5ffa20e79a4d032eb150e634f91d7053f083859  node-v9.5.0-linux-alpine-armhf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "node-v$NODE_VERSION-linux-alpine-armhf.tar.gz" -C /usr/local --strip-components=1 \
-	&& rm "node-v$NODE_VERSION-linux-alpine-armhf.tar.gz" \
+RUN curl -SLO "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/node-v$NODE_VERSION-linux-alpine-aarch64.tar.gz" \
+	&& echo "fa97eb3697ccd086151ca07fcd877fbb5ebdec6898cdd64375ea1ef9d6b368ff  node-v9.5.0-linux-alpine-aarch64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "node-v$NODE_VERSION-linux-alpine-aarch64.tar.gz" -C /usr/local --strip-components=1 \
+	&& rm "node-v$NODE_VERSION-linux-alpine-aarch64.tar.gz" \
 	&& npm config set unsafe-perm true -g --unsafe-perm \
 	&& rm -rf /tmp/*
 

--- a/node/artik710/alpine/9.5/edge/Dockerfile
+++ b/node/artik710/alpine/9.5/edge/Dockerfile
@@ -6,10 +6,10 @@ ENV NODE_VERSION 9.5.0
 # Install dependencies
 RUN apk add --no-cache libgcc libstdc++ libuv libcrypto1.0 libssl1.0
 
-RUN curl -SLO "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/node-v$NODE_VERSION-linux-alpine-armhf.tar.gz" \
-	&& echo "431072120208ec8c419cded1f5ffa20e79a4d032eb150e634f91d7053f083859  node-v9.5.0-linux-alpine-armhf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "node-v$NODE_VERSION-linux-alpine-armhf.tar.gz" -C /usr/local --strip-components=1 \
-	&& rm "node-v$NODE_VERSION-linux-alpine-armhf.tar.gz" \
+RUN curl -SLO "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/node-v$NODE_VERSION-linux-alpine-aarch64.tar.gz" \
+	&& echo "fa97eb3697ccd086151ca07fcd877fbb5ebdec6898cdd64375ea1ef9d6b368ff  node-v9.5.0-linux-alpine-aarch64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "node-v$NODE_VERSION-linux-alpine-aarch64.tar.gz" -C /usr/local --strip-components=1 \
+	&& rm "node-v$NODE_VERSION-linux-alpine-aarch64.tar.gz" \
 	&& npm config set unsafe-perm true -g --unsafe-perm \
 	&& rm -rf /tmp/*
 

--- a/node/artik710/alpine/9.5/slim/Dockerfile
+++ b/node/artik710/alpine/9.5/slim/Dockerfile
@@ -9,10 +9,10 @@ RUN apk add --no-cache libgcc libstdc++ libuv libcrypto1.0 libssl1.0
 RUN buildDeps='curl' \
 	&& set -x \
 	&& apk add --no-cache $buildDeps \
-	&& curl -SLO "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/node-v$NODE_VERSION-linux-alpine-armhf.tar.gz" \
-	&& echo "431072120208ec8c419cded1f5ffa20e79a4d032eb150e634f91d7053f083859  node-v9.5.0-linux-alpine-armhf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "node-v$NODE_VERSION-linux-alpine-armhf.tar.gz" -C /usr/local --strip-components=1 \
-	&& rm "node-v$NODE_VERSION-linux-alpine-armhf.tar.gz" \
+	&& curl -SLO "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/node-v$NODE_VERSION-linux-alpine-aarch64.tar.gz" \
+	&& echo "fa97eb3697ccd086151ca07fcd877fbb5ebdec6898cdd64375ea1ef9d6b368ff  node-v9.5.0-linux-alpine-aarch64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "node-v$NODE_VERSION-linux-alpine-aarch64.tar.gz" -C /usr/local --strip-components=1 \
+	&& rm "node-v$NODE_VERSION-linux-alpine-aarch64.tar.gz" \
 	&& apk del $buildDeps \
 	&& npm config set unsafe-perm true -g --unsafe-perm \
 	&& rm -rf /tmp/*

--- a/node/artik710/debian/4.8/Dockerfile
+++ b/node/artik710/debian/4.8/Dockerfile
@@ -3,10 +3,10 @@ FROM resin/artik710-buildpack-deps:jessie
 
 ENV NODE_VERSION 4.8.7
 
-RUN curl -SLO "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/node-v$NODE_VERSION-linux-armv7hf.tar.gz" \
-	&& echo "d66b71cbb5484ce39c5323bf5c975e17ff813b49255de3b1e947bc8e862a8d5a  node-v4.8.7-linux-armv7hf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "node-v$NODE_VERSION-linux-armv7hf.tar.gz" -C /usr/local --strip-components=1 \
-	&& rm "node-v$NODE_VERSION-linux-armv7hf.tar.gz" \
+RUN curl -SLO "http://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-arm64.tar.gz" \
+	&& echo "2a81bc51d0973c22fe04276cc965dddd162a7e1287b9a1c59306be9c24f37c0f  node-v4.8.7-linux-arm64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "node-v$NODE_VERSION-linux-arm64.tar.gz" -C /usr/local --strip-components=1 \
+	&& rm "node-v$NODE_VERSION-linux-arm64.tar.gz" \
 	&& npm config set unsafe-perm true -g --unsafe-perm \
 	&& rm -rf /tmp/*
 

--- a/node/artik710/debian/4.8/slim/Dockerfile
+++ b/node/artik710/debian/4.8/slim/Dockerfile
@@ -7,10 +7,10 @@ RUN buildDeps='curl' \
 	&& set -x \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends \
 	&& rm -rf /var/lib/apt/lists/* \
-	&& curl -SLO "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/node-v$NODE_VERSION-linux-armv7hf.tar.gz" \
-	&& echo "d66b71cbb5484ce39c5323bf5c975e17ff813b49255de3b1e947bc8e862a8d5a  node-v4.8.7-linux-armv7hf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "node-v$NODE_VERSION-linux-armv7hf.tar.gz" -C /usr/local --strip-components=1 \
-	&& rm "node-v$NODE_VERSION-linux-armv7hf.tar.gz" \
+	&& curl -SLO "http://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-arm64.tar.gz" \
+	&& echo "2a81bc51d0973c22fe04276cc965dddd162a7e1287b9a1c59306be9c24f37c0f  node-v4.8.7-linux-arm64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "node-v$NODE_VERSION-linux-arm64.tar.gz" -C /usr/local --strip-components=1 \
+	&& rm "node-v$NODE_VERSION-linux-arm64.tar.gz" \
 	&& apt-get purge -y --auto-remove $buildDeps \
 	&& npm config set unsafe-perm true -g --unsafe-perm \
 	&& rm -rf /tmp/*

--- a/node/artik710/debian/4.8/wheezy/Dockerfile
+++ b/node/artik710/debian/4.8/wheezy/Dockerfile
@@ -3,10 +3,10 @@ FROM resin/artik710-buildpack-deps:wheezy
 
 ENV NODE_VERSION 4.8.7
 
-RUN curl -SLO "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/node-v$NODE_VERSION-linux-armv7hf.tar.gz" \
-	&& echo "d66b71cbb5484ce39c5323bf5c975e17ff813b49255de3b1e947bc8e862a8d5a  node-v4.8.7-linux-armv7hf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "node-v$NODE_VERSION-linux-armv7hf.tar.gz" -C /usr/local --strip-components=1 \
-	&& rm "node-v$NODE_VERSION-linux-armv7hf.tar.gz" \
+RUN curl -SLO "http://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-arm64.tar.gz" \
+	&& echo "2a81bc51d0973c22fe04276cc965dddd162a7e1287b9a1c59306be9c24f37c0f  node-v4.8.7-linux-arm64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "node-v$NODE_VERSION-linux-arm64.tar.gz" -C /usr/local --strip-components=1 \
+	&& rm "node-v$NODE_VERSION-linux-arm64.tar.gz" \
 	&& npm config set unsafe-perm true -g --unsafe-perm \
 	&& rm -rf /tmp/*
 

--- a/node/artik710/debian/5.12/Dockerfile
+++ b/node/artik710/debian/5.12/Dockerfile
@@ -3,10 +3,10 @@ FROM resin/artik710-buildpack-deps:jessie
 
 ENV NODE_VERSION 5.12.0
 
-RUN curl -SLO "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/node-v$NODE_VERSION-linux-armv7hf.tar.gz" \
-	&& echo "" | sha256sum -c - \
-	&& tar -xzf "node-v$NODE_VERSION-linux-armv7hf.tar.gz" -C /usr/local --strip-components=1 \
-	&& rm "node-v$NODE_VERSION-linux-armv7hf.tar.gz" \
+RUN curl -SLO "http://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-arm64.tar.gz" \
+	&& echo "db02351d2c205a3c60218f937a41a8b8d665f326e7dfa263954ab39f8a8a2bc3  node-v5.12.0-linux-arm64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "node-v$NODE_VERSION-linux-arm64.tar.gz" -C /usr/local --strip-components=1 \
+	&& rm "node-v$NODE_VERSION-linux-arm64.tar.gz" \
 	&& npm config set unsafe-perm true -g --unsafe-perm \
 	&& rm -rf /tmp/*
 

--- a/node/artik710/debian/5.12/slim/Dockerfile
+++ b/node/artik710/debian/5.12/slim/Dockerfile
@@ -7,10 +7,10 @@ RUN buildDeps='curl' \
 	&& set -x \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends \
 	&& rm -rf /var/lib/apt/lists/* \
-	&& curl -SLO "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/node-v$NODE_VERSION-linux-armv7hf.tar.gz" \
-	&& echo "" | sha256sum -c - \
-	&& tar -xzf "node-v$NODE_VERSION-linux-armv7hf.tar.gz" -C /usr/local --strip-components=1 \
-	&& rm "node-v$NODE_VERSION-linux-armv7hf.tar.gz" \
+	&& curl -SLO "http://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-arm64.tar.gz" \
+	&& echo "db02351d2c205a3c60218f937a41a8b8d665f326e7dfa263954ab39f8a8a2bc3  node-v5.12.0-linux-arm64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "node-v$NODE_VERSION-linux-arm64.tar.gz" -C /usr/local --strip-components=1 \
+	&& rm "node-v$NODE_VERSION-linux-arm64.tar.gz" \
 	&& apt-get purge -y --auto-remove $buildDeps \
 	&& npm config set unsafe-perm true -g --unsafe-perm \
 	&& rm -rf /tmp/*

--- a/node/artik710/debian/5.12/wheezy/Dockerfile
+++ b/node/artik710/debian/5.12/wheezy/Dockerfile
@@ -3,10 +3,10 @@ FROM resin/artik710-buildpack-deps:wheezy
 
 ENV NODE_VERSION 5.12.0
 
-RUN curl -SLO "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/node-v$NODE_VERSION-linux-armv7hf.tar.gz" \
-	&& echo "" | sha256sum -c - \
-	&& tar -xzf "node-v$NODE_VERSION-linux-armv7hf.tar.gz" -C /usr/local --strip-components=1 \
-	&& rm "node-v$NODE_VERSION-linux-armv7hf.tar.gz" \
+RUN curl -SLO "http://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-arm64.tar.gz" \
+	&& echo "db02351d2c205a3c60218f937a41a8b8d665f326e7dfa263954ab39f8a8a2bc3  node-v5.12.0-linux-arm64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "node-v$NODE_VERSION-linux-arm64.tar.gz" -C /usr/local --strip-components=1 \
+	&& rm "node-v$NODE_VERSION-linux-arm64.tar.gz" \
 	&& npm config set unsafe-perm true -g --unsafe-perm \
 	&& rm -rf /tmp/*
 

--- a/node/artik710/debian/6.13/Dockerfile
+++ b/node/artik710/debian/6.13/Dockerfile
@@ -3,10 +3,10 @@ FROM resin/artik710-buildpack-deps:jessie
 
 ENV NODE_VERSION 6.13.1
 
-RUN curl -SLO "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/node-v$NODE_VERSION-linux-armv7hf.tar.gz" \
-	&& echo "79a93450c25edfbdc3b705f30269273511416ec9ff71d4e661702034267e8d75  node-v6.13.1-linux-armv7hf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "node-v$NODE_VERSION-linux-armv7hf.tar.gz" -C /usr/local --strip-components=1 \
-	&& rm "node-v$NODE_VERSION-linux-armv7hf.tar.gz" \
+RUN curl -SLO "http://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-arm64.tar.gz" \
+	&& echo "27c9dd1c907f751f073f6d092b72a184a836aac7cac40fdf056edcc1987102b3  node-v6.13.1-linux-arm64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "node-v$NODE_VERSION-linux-arm64.tar.gz" -C /usr/local --strip-components=1 \
+	&& rm "node-v$NODE_VERSION-linux-arm64.tar.gz" \
 	&& npm config set unsafe-perm true -g --unsafe-perm \
 	&& rm -rf /tmp/*
 

--- a/node/artik710/debian/6.13/slim/Dockerfile
+++ b/node/artik710/debian/6.13/slim/Dockerfile
@@ -7,10 +7,10 @@ RUN buildDeps='curl' \
 	&& set -x \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends \
 	&& rm -rf /var/lib/apt/lists/* \
-	&& curl -SLO "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/node-v$NODE_VERSION-linux-armv7hf.tar.gz" \
-	&& echo "79a93450c25edfbdc3b705f30269273511416ec9ff71d4e661702034267e8d75  node-v6.13.1-linux-armv7hf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "node-v$NODE_VERSION-linux-armv7hf.tar.gz" -C /usr/local --strip-components=1 \
-	&& rm "node-v$NODE_VERSION-linux-armv7hf.tar.gz" \
+	&& curl -SLO "http://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-arm64.tar.gz" \
+	&& echo "27c9dd1c907f751f073f6d092b72a184a836aac7cac40fdf056edcc1987102b3  node-v6.13.1-linux-arm64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "node-v$NODE_VERSION-linux-arm64.tar.gz" -C /usr/local --strip-components=1 \
+	&& rm "node-v$NODE_VERSION-linux-arm64.tar.gz" \
 	&& apt-get purge -y --auto-remove $buildDeps \
 	&& npm config set unsafe-perm true -g --unsafe-perm \
 	&& rm -rf /tmp/*

--- a/node/artik710/debian/6.3/wheezy/Dockerfile
+++ b/node/artik710/debian/6.3/wheezy/Dockerfile
@@ -3,10 +3,10 @@ FROM resin/artik710-buildpack-deps:wheezy
 
 ENV NODE_VERSION 6.3.1
 
-RUN curl -SLO "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/node-v$NODE_VERSION-linux-armv7hf.tar.gz" \
-	&& echo "" | sha256sum -c - \
-	&& tar -xzf "node-v$NODE_VERSION-linux-armv7hf.tar.gz" -C /usr/local --strip-components=1 \
-	&& rm "node-v$NODE_VERSION-linux-armv7hf.tar.gz" \
+RUN curl -SLO "http://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-arm64.tar.gz" \
+	&& echo "66ef087709f7709f0bf066904df06815ac7ad213181d6dcc2adb4f9dc831704f  node-v6.3.1-linux-arm64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "node-v$NODE_VERSION-linux-arm64.tar.gz" -C /usr/local --strip-components=1 \
+	&& rm "node-v$NODE_VERSION-linux-arm64.tar.gz" \
 	&& npm config set unsafe-perm true -g --unsafe-perm \
 	&& rm -rf /tmp/*
 

--- a/node/artik710/debian/7.10/Dockerfile
+++ b/node/artik710/debian/7.10/Dockerfile
@@ -3,10 +3,10 @@ FROM resin/artik710-buildpack-deps:jessie
 
 ENV NODE_VERSION 7.10.1
 
-RUN curl -SLO "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/node-v$NODE_VERSION-linux-armv7hf.tar.gz" \
-	&& echo "819eff8b457d484d407fc11985d013ddae47568f4b3fb0e125bdddc0fba32875  node-v7.10.1-linux-armv7hf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "node-v$NODE_VERSION-linux-armv7hf.tar.gz" -C /usr/local --strip-components=1 \
-	&& rm "node-v$NODE_VERSION-linux-armv7hf.tar.gz" \
+RUN curl -SLO "http://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-arm64.tar.gz" \
+	&& echo "157be398d666b0753d219b9f4cdd3517d4335ddb2c3800242d3934f191932920  node-v7.10.1-linux-arm64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "node-v$NODE_VERSION-linux-arm64.tar.gz" -C /usr/local --strip-components=1 \
+	&& rm "node-v$NODE_VERSION-linux-arm64.tar.gz" \
 	&& npm config set unsafe-perm true -g --unsafe-perm \
 	&& rm -rf /tmp/*
 

--- a/node/artik710/debian/7.10/slim/Dockerfile
+++ b/node/artik710/debian/7.10/slim/Dockerfile
@@ -7,10 +7,10 @@ RUN buildDeps='curl' \
 	&& set -x \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends \
 	&& rm -rf /var/lib/apt/lists/* \
-	&& curl -SLO "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/node-v$NODE_VERSION-linux-armv7hf.tar.gz" \
-	&& echo "819eff8b457d484d407fc11985d013ddae47568f4b3fb0e125bdddc0fba32875  node-v7.10.1-linux-armv7hf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "node-v$NODE_VERSION-linux-armv7hf.tar.gz" -C /usr/local --strip-components=1 \
-	&& rm "node-v$NODE_VERSION-linux-armv7hf.tar.gz" \
+	&& curl -SLO "http://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-arm64.tar.gz" \
+	&& echo "157be398d666b0753d219b9f4cdd3517d4335ddb2c3800242d3934f191932920  node-v7.10.1-linux-arm64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "node-v$NODE_VERSION-linux-arm64.tar.gz" -C /usr/local --strip-components=1 \
+	&& rm "node-v$NODE_VERSION-linux-arm64.tar.gz" \
 	&& apt-get purge -y --auto-remove $buildDeps \
 	&& npm config set unsafe-perm true -g --unsafe-perm \
 	&& rm -rf /tmp/*

--- a/node/artik710/debian/8.9/Dockerfile
+++ b/node/artik710/debian/8.9/Dockerfile
@@ -3,10 +3,10 @@ FROM resin/artik710-buildpack-deps:jessie
 
 ENV NODE_VERSION 8.9.4
 
-RUN curl -SLO "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/node-v$NODE_VERSION-linux-armv7hf.tar.gz" \
-	&& echo "9a5b8591c9884ee88df2b5925f60ae2b9347579ce6012830f2a1e66a7365ed5a  node-v8.9.4-linux-armv7hf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "node-v$NODE_VERSION-linux-armv7hf.tar.gz" -C /usr/local --strip-components=1 \
-	&& rm "node-v$NODE_VERSION-linux-armv7hf.tar.gz" \
+RUN curl -SLO "http://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-arm64.tar.gz" \
+	&& echo "2b133c7d23033fbc2419e66fc08bba35c427a97aba83ed6848b6b4678c0cac65  node-v8.9.4-linux-arm64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "node-v$NODE_VERSION-linux-arm64.tar.gz" -C /usr/local --strip-components=1 \
+	&& rm "node-v$NODE_VERSION-linux-arm64.tar.gz" \
 	&& npm config set unsafe-perm true -g --unsafe-perm \
 	&& rm -rf /tmp/*
 

--- a/node/artik710/debian/8.9/slim/Dockerfile
+++ b/node/artik710/debian/8.9/slim/Dockerfile
@@ -7,10 +7,10 @@ RUN buildDeps='curl' \
 	&& set -x \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends \
 	&& rm -rf /var/lib/apt/lists/* \
-	&& curl -SLO "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/node-v$NODE_VERSION-linux-armv7hf.tar.gz" \
-	&& echo "9a5b8591c9884ee88df2b5925f60ae2b9347579ce6012830f2a1e66a7365ed5a  node-v8.9.4-linux-armv7hf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "node-v$NODE_VERSION-linux-armv7hf.tar.gz" -C /usr/local --strip-components=1 \
-	&& rm "node-v$NODE_VERSION-linux-armv7hf.tar.gz" \
+	&& curl -SLO "http://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-arm64.tar.gz" \
+	&& echo "2b133c7d23033fbc2419e66fc08bba35c427a97aba83ed6848b6b4678c0cac65  node-v8.9.4-linux-arm64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "node-v$NODE_VERSION-linux-arm64.tar.gz" -C /usr/local --strip-components=1 \
+	&& rm "node-v$NODE_VERSION-linux-arm64.tar.gz" \
 	&& apt-get purge -y --auto-remove $buildDeps \
 	&& npm config set unsafe-perm true -g --unsafe-perm \
 	&& rm -rf /tmp/*

--- a/node/artik710/debian/9.5/Dockerfile
+++ b/node/artik710/debian/9.5/Dockerfile
@@ -3,10 +3,10 @@ FROM resin/artik710-buildpack-deps:jessie
 
 ENV NODE_VERSION 9.5.0
 
-RUN curl -SLO "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/node-v$NODE_VERSION-linux-armv7hf.tar.gz" \
-	&& echo "6408a233122cd408f081cbd2e4e79d6c46f653e043dc575a675d91493e9843be  node-v9.5.0-linux-armv7hf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "node-v$NODE_VERSION-linux-armv7hf.tar.gz" -C /usr/local --strip-components=1 \
-	&& rm "node-v$NODE_VERSION-linux-armv7hf.tar.gz" \
+RUN curl -SLO "http://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-arm64.tar.gz" \
+	&& echo "08924ad820d6322e17cc0fbbc365000b76408a4f17c3ed3169b44d8c7448a617  node-v9.5.0-linux-arm64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "node-v$NODE_VERSION-linux-arm64.tar.gz" -C /usr/local --strip-components=1 \
+	&& rm "node-v$NODE_VERSION-linux-arm64.tar.gz" \
 	&& npm config set unsafe-perm true -g --unsafe-perm \
 	&& rm -rf /tmp/*
 

--- a/node/artik710/debian/9.5/slim/Dockerfile
+++ b/node/artik710/debian/9.5/slim/Dockerfile
@@ -7,10 +7,10 @@ RUN buildDeps='curl' \
 	&& set -x \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends \
 	&& rm -rf /var/lib/apt/lists/* \
-	&& curl -SLO "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/node-v$NODE_VERSION-linux-armv7hf.tar.gz" \
-	&& echo "6408a233122cd408f081cbd2e4e79d6c46f653e043dc575a675d91493e9843be  node-v9.5.0-linux-armv7hf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "node-v$NODE_VERSION-linux-armv7hf.tar.gz" -C /usr/local --strip-components=1 \
-	&& rm "node-v$NODE_VERSION-linux-armv7hf.tar.gz" \
+	&& curl -SLO "http://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-arm64.tar.gz" \
+	&& echo "08924ad820d6322e17cc0fbbc365000b76408a4f17c3ed3169b44d8c7448a617  node-v9.5.0-linux-arm64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "node-v$NODE_VERSION-linux-arm64.tar.gz" -C /usr/local --strip-components=1 \
+	&& rm "node-v$NODE_VERSION-linux-arm64.tar.gz" \
 	&& apt-get purge -y --auto-remove $buildDeps \
 	&& npm config set unsafe-perm true -g --unsafe-perm \
 	&& rm -rf /tmp/*

--- a/node/artik710/fedora/4.8/24/Dockerfile
+++ b/node/artik710/fedora/4.8/24/Dockerfile
@@ -3,10 +3,10 @@ FROM resin/artik710-fedora-buildpack-deps:24
 
 ENV NODE_VERSION 4.8.7
 
-RUN curl -SLO "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/node-v$NODE_VERSION-linux-armv7hf.tar.gz" \
-	&& echo "d66b71cbb5484ce39c5323bf5c975e17ff813b49255de3b1e947bc8e862a8d5a  node-v4.8.7-linux-armv7hf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "node-v$NODE_VERSION-linux-armv7hf.tar.gz" -C /usr/local --strip-components=1 \
-	&& rm "node-v$NODE_VERSION-linux-armv7hf.tar.gz" \
+RUN curl -SLO "http://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-arm64.tar.gz" \
+	&& echo "2a81bc51d0973c22fe04276cc965dddd162a7e1287b9a1c59306be9c24f37c0f  node-v4.8.7-linux-arm64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "node-v$NODE_VERSION-linux-arm64.tar.gz" -C /usr/local --strip-components=1 \
+	&& rm "node-v$NODE_VERSION-linux-arm64.tar.gz" \
 	&& npm config set unsafe-perm true -g --unsafe-perm \
 	&& rm -rf /tmp/*
 

--- a/node/artik710/fedora/4.8/Dockerfile
+++ b/node/artik710/fedora/4.8/Dockerfile
@@ -3,10 +3,10 @@ FROM resin/artik710-fedora-buildpack-deps:latest
 
 ENV NODE_VERSION 4.8.7
 
-RUN curl -SLO "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/node-v$NODE_VERSION-linux-armv7hf.tar.gz" \
-	&& echo "d66b71cbb5484ce39c5323bf5c975e17ff813b49255de3b1e947bc8e862a8d5a  node-v4.8.7-linux-armv7hf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "node-v$NODE_VERSION-linux-armv7hf.tar.gz" -C /usr/local --strip-components=1 \
-	&& rm "node-v$NODE_VERSION-linux-armv7hf.tar.gz" \
+RUN curl -SLO "http://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-arm64.tar.gz" \
+	&& echo "2a81bc51d0973c22fe04276cc965dddd162a7e1287b9a1c59306be9c24f37c0f  node-v4.8.7-linux-arm64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "node-v$NODE_VERSION-linux-arm64.tar.gz" -C /usr/local --strip-components=1 \
+	&& rm "node-v$NODE_VERSION-linux-arm64.tar.gz" \
 	&& npm config set unsafe-perm true -g --unsafe-perm \
 	&& rm -rf /tmp/*
 

--- a/node/artik710/fedora/4.8/slim/Dockerfile
+++ b/node/artik710/fedora/4.8/slim/Dockerfile
@@ -3,10 +3,10 @@ FROM resin/artik710-fedora:latest
 
 ENV NODE_VERSION 4.8.7
 
-RUN curl -SLO "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/node-v$NODE_VERSION-linux-armv7hf.tar.gz" \
-	&& echo "d66b71cbb5484ce39c5323bf5c975e17ff813b49255de3b1e947bc8e862a8d5a  node-v4.8.7-linux-armv7hf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "node-v$NODE_VERSION-linux-armv7hf.tar.gz" -C /usr/local --strip-components=1 \
-	&& rm "node-v$NODE_VERSION-linux-armv7hf.tar.gz" \
+RUN curl -SLO "http://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-arm64.tar.gz" \
+	&& echo "2a81bc51d0973c22fe04276cc965dddd162a7e1287b9a1c59306be9c24f37c0f  node-v4.8.7-linux-arm64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "node-v$NODE_VERSION-linux-arm64.tar.gz" -C /usr/local --strip-components=1 \
+	&& rm "node-v$NODE_VERSION-linux-arm64.tar.gz" \
 	&& npm config set unsafe-perm true -g --unsafe-perm \
 	&& rm -rf /tmp/*
 

--- a/node/artik710/fedora/5.12/24/Dockerfile
+++ b/node/artik710/fedora/5.12/24/Dockerfile
@@ -3,10 +3,10 @@ FROM resin/artik710-fedora-buildpack-deps:24
 
 ENV NODE_VERSION 5.12.0
 
-RUN curl -SLO "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/node-v$NODE_VERSION-linux-armv7hf.tar.gz" \
-	&& echo "" | sha256sum -c - \
-	&& tar -xzf "node-v$NODE_VERSION-linux-armv7hf.tar.gz" -C /usr/local --strip-components=1 \
-	&& rm "node-v$NODE_VERSION-linux-armv7hf.tar.gz" \
+RUN curl -SLO "http://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-arm64.tar.gz" \
+	&& echo "db02351d2c205a3c60218f937a41a8b8d665f326e7dfa263954ab39f8a8a2bc3  node-v5.12.0-linux-arm64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "node-v$NODE_VERSION-linux-arm64.tar.gz" -C /usr/local --strip-components=1 \
+	&& rm "node-v$NODE_VERSION-linux-arm64.tar.gz" \
 	&& npm config set unsafe-perm true -g --unsafe-perm \
 	&& rm -rf /tmp/*
 

--- a/node/artik710/fedora/5.12/Dockerfile
+++ b/node/artik710/fedora/5.12/Dockerfile
@@ -3,10 +3,10 @@ FROM resin/artik710-fedora-buildpack-deps:latest
 
 ENV NODE_VERSION 5.12.0
 
-RUN curl -SLO "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/node-v$NODE_VERSION-linux-armv7hf.tar.gz" \
-	&& echo "" | sha256sum -c - \
-	&& tar -xzf "node-v$NODE_VERSION-linux-armv7hf.tar.gz" -C /usr/local --strip-components=1 \
-	&& rm "node-v$NODE_VERSION-linux-armv7hf.tar.gz" \
+RUN curl -SLO "http://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-arm64.tar.gz" \
+	&& echo "db02351d2c205a3c60218f937a41a8b8d665f326e7dfa263954ab39f8a8a2bc3  node-v5.12.0-linux-arm64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "node-v$NODE_VERSION-linux-arm64.tar.gz" -C /usr/local --strip-components=1 \
+	&& rm "node-v$NODE_VERSION-linux-arm64.tar.gz" \
 	&& npm config set unsafe-perm true -g --unsafe-perm \
 	&& rm -rf /tmp/*
 

--- a/node/artik710/fedora/5.12/slim/Dockerfile
+++ b/node/artik710/fedora/5.12/slim/Dockerfile
@@ -3,10 +3,10 @@ FROM resin/artik710-fedora:latest
 
 ENV NODE_VERSION 5.12.0
 
-RUN curl -SLO "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/node-v$NODE_VERSION-linux-armv7hf.tar.gz" \
-	&& echo "" | sha256sum -c - \
-	&& tar -xzf "node-v$NODE_VERSION-linux-armv7hf.tar.gz" -C /usr/local --strip-components=1 \
-	&& rm "node-v$NODE_VERSION-linux-armv7hf.tar.gz" \
+RUN curl -SLO "http://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-arm64.tar.gz" \
+	&& echo "db02351d2c205a3c60218f937a41a8b8d665f326e7dfa263954ab39f8a8a2bc3  node-v5.12.0-linux-arm64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "node-v$NODE_VERSION-linux-arm64.tar.gz" -C /usr/local --strip-components=1 \
+	&& rm "node-v$NODE_VERSION-linux-arm64.tar.gz" \
 	&& npm config set unsafe-perm true -g --unsafe-perm \
 	&& rm -rf /tmp/*
 

--- a/node/artik710/fedora/6.13/24/Dockerfile
+++ b/node/artik710/fedora/6.13/24/Dockerfile
@@ -3,10 +3,10 @@ FROM resin/artik710-fedora-buildpack-deps:24
 
 ENV NODE_VERSION 6.13.1
 
-RUN curl -SLO "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/node-v$NODE_VERSION-linux-armv7hf.tar.gz" \
-	&& echo "79a93450c25edfbdc3b705f30269273511416ec9ff71d4e661702034267e8d75  node-v6.13.1-linux-armv7hf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "node-v$NODE_VERSION-linux-armv7hf.tar.gz" -C /usr/local --strip-components=1 \
-	&& rm "node-v$NODE_VERSION-linux-armv7hf.tar.gz" \
+RUN curl -SLO "http://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-arm64.tar.gz" \
+	&& echo "27c9dd1c907f751f073f6d092b72a184a836aac7cac40fdf056edcc1987102b3  node-v6.13.1-linux-arm64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "node-v$NODE_VERSION-linux-arm64.tar.gz" -C /usr/local --strip-components=1 \
+	&& rm "node-v$NODE_VERSION-linux-arm64.tar.gz" \
 	&& npm config set unsafe-perm true -g --unsafe-perm \
 	&& rm -rf /tmp/*
 

--- a/node/artik710/fedora/6.13/Dockerfile
+++ b/node/artik710/fedora/6.13/Dockerfile
@@ -3,10 +3,10 @@ FROM resin/artik710-fedora-buildpack-deps:latest
 
 ENV NODE_VERSION 6.13.1
 
-RUN curl -SLO "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/node-v$NODE_VERSION-linux-armv7hf.tar.gz" \
-	&& echo "79a93450c25edfbdc3b705f30269273511416ec9ff71d4e661702034267e8d75  node-v6.13.1-linux-armv7hf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "node-v$NODE_VERSION-linux-armv7hf.tar.gz" -C /usr/local --strip-components=1 \
-	&& rm "node-v$NODE_VERSION-linux-armv7hf.tar.gz" \
+RUN curl -SLO "http://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-arm64.tar.gz" \
+	&& echo "27c9dd1c907f751f073f6d092b72a184a836aac7cac40fdf056edcc1987102b3  node-v6.13.1-linux-arm64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "node-v$NODE_VERSION-linux-arm64.tar.gz" -C /usr/local --strip-components=1 \
+	&& rm "node-v$NODE_VERSION-linux-arm64.tar.gz" \
 	&& npm config set unsafe-perm true -g --unsafe-perm \
 	&& rm -rf /tmp/*
 

--- a/node/artik710/fedora/6.13/slim/Dockerfile
+++ b/node/artik710/fedora/6.13/slim/Dockerfile
@@ -3,10 +3,10 @@ FROM resin/artik710-fedora:latest
 
 ENV NODE_VERSION 6.13.1
 
-RUN curl -SLO "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/node-v$NODE_VERSION-linux-armv7hf.tar.gz" \
-	&& echo "79a93450c25edfbdc3b705f30269273511416ec9ff71d4e661702034267e8d75  node-v6.13.1-linux-armv7hf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "node-v$NODE_VERSION-linux-armv7hf.tar.gz" -C /usr/local --strip-components=1 \
-	&& rm "node-v$NODE_VERSION-linux-armv7hf.tar.gz" \
+RUN curl -SLO "http://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-arm64.tar.gz" \
+	&& echo "27c9dd1c907f751f073f6d092b72a184a836aac7cac40fdf056edcc1987102b3  node-v6.13.1-linux-arm64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "node-v$NODE_VERSION-linux-arm64.tar.gz" -C /usr/local --strip-components=1 \
+	&& rm "node-v$NODE_VERSION-linux-arm64.tar.gz" \
 	&& npm config set unsafe-perm true -g --unsafe-perm \
 	&& rm -rf /tmp/*
 

--- a/node/artik710/fedora/7.10/24/Dockerfile
+++ b/node/artik710/fedora/7.10/24/Dockerfile
@@ -3,10 +3,10 @@ FROM resin/artik710-fedora-buildpack-deps:24
 
 ENV NODE_VERSION 7.10.1
 
-RUN curl -SLO "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/node-v$NODE_VERSION-linux-armv7hf.tar.gz" \
-	&& echo "819eff8b457d484d407fc11985d013ddae47568f4b3fb0e125bdddc0fba32875  node-v7.10.1-linux-armv7hf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "node-v$NODE_VERSION-linux-armv7hf.tar.gz" -C /usr/local --strip-components=1 \
-	&& rm "node-v$NODE_VERSION-linux-armv7hf.tar.gz" \
+RUN curl -SLO "http://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-arm64.tar.gz" \
+	&& echo "157be398d666b0753d219b9f4cdd3517d4335ddb2c3800242d3934f191932920  node-v7.10.1-linux-arm64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "node-v$NODE_VERSION-linux-arm64.tar.gz" -C /usr/local --strip-components=1 \
+	&& rm "node-v$NODE_VERSION-linux-arm64.tar.gz" \
 	&& npm config set unsafe-perm true -g --unsafe-perm \
 	&& rm -rf /tmp/*
 

--- a/node/artik710/fedora/7.10/Dockerfile
+++ b/node/artik710/fedora/7.10/Dockerfile
@@ -3,10 +3,10 @@ FROM resin/artik710-fedora-buildpack-deps:latest
 
 ENV NODE_VERSION 7.10.1
 
-RUN curl -SLO "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/node-v$NODE_VERSION-linux-armv7hf.tar.gz" \
-	&& echo "819eff8b457d484d407fc11985d013ddae47568f4b3fb0e125bdddc0fba32875  node-v7.10.1-linux-armv7hf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "node-v$NODE_VERSION-linux-armv7hf.tar.gz" -C /usr/local --strip-components=1 \
-	&& rm "node-v$NODE_VERSION-linux-armv7hf.tar.gz" \
+RUN curl -SLO "http://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-arm64.tar.gz" \
+	&& echo "157be398d666b0753d219b9f4cdd3517d4335ddb2c3800242d3934f191932920  node-v7.10.1-linux-arm64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "node-v$NODE_VERSION-linux-arm64.tar.gz" -C /usr/local --strip-components=1 \
+	&& rm "node-v$NODE_VERSION-linux-arm64.tar.gz" \
 	&& npm config set unsafe-perm true -g --unsafe-perm \
 	&& rm -rf /tmp/*
 

--- a/node/artik710/fedora/7.10/slim/Dockerfile
+++ b/node/artik710/fedora/7.10/slim/Dockerfile
@@ -3,10 +3,10 @@ FROM resin/artik710-fedora:latest
 
 ENV NODE_VERSION 7.10.1
 
-RUN curl -SLO "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/node-v$NODE_VERSION-linux-armv7hf.tar.gz" \
-	&& echo "819eff8b457d484d407fc11985d013ddae47568f4b3fb0e125bdddc0fba32875  node-v7.10.1-linux-armv7hf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "node-v$NODE_VERSION-linux-armv7hf.tar.gz" -C /usr/local --strip-components=1 \
-	&& rm "node-v$NODE_VERSION-linux-armv7hf.tar.gz" \
+RUN curl -SLO "http://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-arm64.tar.gz" \
+	&& echo "157be398d666b0753d219b9f4cdd3517d4335ddb2c3800242d3934f191932920  node-v7.10.1-linux-arm64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "node-v$NODE_VERSION-linux-arm64.tar.gz" -C /usr/local --strip-components=1 \
+	&& rm "node-v$NODE_VERSION-linux-arm64.tar.gz" \
 	&& npm config set unsafe-perm true -g --unsafe-perm \
 	&& rm -rf /tmp/*
 

--- a/node/artik710/fedora/8.9/24/Dockerfile
+++ b/node/artik710/fedora/8.9/24/Dockerfile
@@ -3,10 +3,10 @@ FROM resin/artik710-fedora-buildpack-deps:24
 
 ENV NODE_VERSION 8.9.4
 
-RUN curl -SLO "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/node-v$NODE_VERSION-linux-armv7hf.tar.gz" \
-	&& echo "9a5b8591c9884ee88df2b5925f60ae2b9347579ce6012830f2a1e66a7365ed5a  node-v8.9.4-linux-armv7hf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "node-v$NODE_VERSION-linux-armv7hf.tar.gz" -C /usr/local --strip-components=1 \
-	&& rm "node-v$NODE_VERSION-linux-armv7hf.tar.gz" \
+RUN curl -SLO "http://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-arm64.tar.gz" \
+	&& echo "2b133c7d23033fbc2419e66fc08bba35c427a97aba83ed6848b6b4678c0cac65  node-v8.9.4-linux-arm64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "node-v$NODE_VERSION-linux-arm64.tar.gz" -C /usr/local --strip-components=1 \
+	&& rm "node-v$NODE_VERSION-linux-arm64.tar.gz" \
 	&& npm config set unsafe-perm true -g --unsafe-perm \
 	&& rm -rf /tmp/*
 

--- a/node/artik710/fedora/8.9/Dockerfile
+++ b/node/artik710/fedora/8.9/Dockerfile
@@ -3,10 +3,10 @@ FROM resin/artik710-fedora-buildpack-deps:latest
 
 ENV NODE_VERSION 8.9.4
 
-RUN curl -SLO "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/node-v$NODE_VERSION-linux-armv7hf.tar.gz" \
-	&& echo "9a5b8591c9884ee88df2b5925f60ae2b9347579ce6012830f2a1e66a7365ed5a  node-v8.9.4-linux-armv7hf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "node-v$NODE_VERSION-linux-armv7hf.tar.gz" -C /usr/local --strip-components=1 \
-	&& rm "node-v$NODE_VERSION-linux-armv7hf.tar.gz" \
+RUN curl -SLO "http://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-arm64.tar.gz" \
+	&& echo "2b133c7d23033fbc2419e66fc08bba35c427a97aba83ed6848b6b4678c0cac65  node-v8.9.4-linux-arm64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "node-v$NODE_VERSION-linux-arm64.tar.gz" -C /usr/local --strip-components=1 \
+	&& rm "node-v$NODE_VERSION-linux-arm64.tar.gz" \
 	&& npm config set unsafe-perm true -g --unsafe-perm \
 	&& rm -rf /tmp/*
 

--- a/node/artik710/fedora/8.9/slim/Dockerfile
+++ b/node/artik710/fedora/8.9/slim/Dockerfile
@@ -3,10 +3,10 @@ FROM resin/artik710-fedora:latest
 
 ENV NODE_VERSION 8.9.4
 
-RUN curl -SLO "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/node-v$NODE_VERSION-linux-armv7hf.tar.gz" \
-	&& echo "9a5b8591c9884ee88df2b5925f60ae2b9347579ce6012830f2a1e66a7365ed5a  node-v8.9.4-linux-armv7hf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "node-v$NODE_VERSION-linux-armv7hf.tar.gz" -C /usr/local --strip-components=1 \
-	&& rm "node-v$NODE_VERSION-linux-armv7hf.tar.gz" \
+RUN curl -SLO "http://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-arm64.tar.gz" \
+	&& echo "2b133c7d23033fbc2419e66fc08bba35c427a97aba83ed6848b6b4678c0cac65  node-v8.9.4-linux-arm64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "node-v$NODE_VERSION-linux-arm64.tar.gz" -C /usr/local --strip-components=1 \
+	&& rm "node-v$NODE_VERSION-linux-arm64.tar.gz" \
 	&& npm config set unsafe-perm true -g --unsafe-perm \
 	&& rm -rf /tmp/*
 

--- a/node/artik710/fedora/9.5/24/Dockerfile
+++ b/node/artik710/fedora/9.5/24/Dockerfile
@@ -3,10 +3,10 @@ FROM resin/artik710-fedora-buildpack-deps:24
 
 ENV NODE_VERSION 9.5.0
 
-RUN curl -SLO "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/node-v$NODE_VERSION-linux-armv7hf.tar.gz" \
-	&& echo "6408a233122cd408f081cbd2e4e79d6c46f653e043dc575a675d91493e9843be  node-v9.5.0-linux-armv7hf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "node-v$NODE_VERSION-linux-armv7hf.tar.gz" -C /usr/local --strip-components=1 \
-	&& rm "node-v$NODE_VERSION-linux-armv7hf.tar.gz" \
+RUN curl -SLO "http://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-arm64.tar.gz" \
+	&& echo "08924ad820d6322e17cc0fbbc365000b76408a4f17c3ed3169b44d8c7448a617  node-v9.5.0-linux-arm64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "node-v$NODE_VERSION-linux-arm64.tar.gz" -C /usr/local --strip-components=1 \
+	&& rm "node-v$NODE_VERSION-linux-arm64.tar.gz" \
 	&& npm config set unsafe-perm true -g --unsafe-perm \
 	&& rm -rf /tmp/*
 

--- a/node/artik710/fedora/9.5/Dockerfile
+++ b/node/artik710/fedora/9.5/Dockerfile
@@ -3,10 +3,10 @@ FROM resin/artik710-fedora-buildpack-deps:latest
 
 ENV NODE_VERSION 9.5.0
 
-RUN curl -SLO "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/node-v$NODE_VERSION-linux-armv7hf.tar.gz" \
-	&& echo "6408a233122cd408f081cbd2e4e79d6c46f653e043dc575a675d91493e9843be  node-v9.5.0-linux-armv7hf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "node-v$NODE_VERSION-linux-armv7hf.tar.gz" -C /usr/local --strip-components=1 \
-	&& rm "node-v$NODE_VERSION-linux-armv7hf.tar.gz" \
+RUN curl -SLO "http://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-arm64.tar.gz" \
+	&& echo "08924ad820d6322e17cc0fbbc365000b76408a4f17c3ed3169b44d8c7448a617  node-v9.5.0-linux-arm64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "node-v$NODE_VERSION-linux-arm64.tar.gz" -C /usr/local --strip-components=1 \
+	&& rm "node-v$NODE_VERSION-linux-arm64.tar.gz" \
 	&& npm config set unsafe-perm true -g --unsafe-perm \
 	&& rm -rf /tmp/*
 

--- a/node/artik710/fedora/9.5/slim/Dockerfile
+++ b/node/artik710/fedora/9.5/slim/Dockerfile
@@ -3,10 +3,10 @@ FROM resin/artik710-fedora:latest
 
 ENV NODE_VERSION 9.5.0
 
-RUN curl -SLO "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/node-v$NODE_VERSION-linux-armv7hf.tar.gz" \
-	&& echo "6408a233122cd408f081cbd2e4e79d6c46f653e043dc575a675d91493e9843be  node-v9.5.0-linux-armv7hf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "node-v$NODE_VERSION-linux-armv7hf.tar.gz" -C /usr/local --strip-components=1 \
-	&& rm "node-v$NODE_VERSION-linux-armv7hf.tar.gz" \
+RUN curl -SLO "http://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-arm64.tar.gz" \
+	&& echo "08924ad820d6322e17cc0fbbc365000b76408a4f17c3ed3169b44d8c7448a617  node-v9.5.0-linux-arm64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "node-v$NODE_VERSION-linux-arm64.tar.gz" -C /usr/local --strip-components=1 \
+	&& rm "node-v$NODE_VERSION-linux-arm64.tar.gz" \
 	&& npm config set unsafe-perm true -g --unsafe-perm \
 	&& rm -rf /tmp/*
 

--- a/node/generate-latest-dockerfile.sh
+++ b/node/generate-latest-dockerfile.sh
@@ -184,14 +184,6 @@ for target in $targets; do
 			binaryUrl=$resinUrl
 			binaryArch='armv7hf'
 		;;
-		'artik710')
-			binaryUrl=$resinUrl
-			binaryArch='armv7hf'
-		;;
-		'kitra710')
-			binaryUrl=$resinUrl
-			binaryArch='armv7hf'
-		;;
 		'kitra520')
 			binaryUrl=$resinUrl
 			binaryArch='armv7hf'
@@ -204,7 +196,7 @@ for target in $targets; do
 			binaryUrl=$resinUrl
 			binaryArch='armv7hf'
 		;;
-		'jetson-tx2'|'jetson-tx1')
+		'jetson-tx2'|'jetson-tx1'|'kitra710'|'artik710')
 			binaryUrl=$nodejsUrl
 			binaryArch='arm64'
 		;;

--- a/node/kitra710/alpine/4.8/Dockerfile
+++ b/node/kitra710/alpine/4.8/Dockerfile
@@ -6,10 +6,10 @@ ENV NODE_VERSION 4.8.7
 # Install dependencies
 RUN apk add --no-cache libgcc libstdc++ libuv libcrypto1.0 libssl1.0
 
-RUN curl -SLO "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/node-v$NODE_VERSION-linux-alpine-armhf.tar.gz" \
-	&& echo "fec4448579a5d9078537bcd719a1578c627845df7919ad39092c6b9df49c9259  node-v4.8.7-linux-alpine-armhf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "node-v$NODE_VERSION-linux-alpine-armhf.tar.gz" -C /usr/local --strip-components=1 \
-	&& rm "node-v$NODE_VERSION-linux-alpine-armhf.tar.gz" \
+RUN curl -SLO "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/node-v$NODE_VERSION-linux-alpine-aarch64.tar.gz" \
+	&& echo "8bbc599bc95cd87490a116d51030437d23fae3682cb38b33bd10cadc30995bc3  node-v4.8.7-linux-alpine-aarch64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "node-v$NODE_VERSION-linux-alpine-aarch64.tar.gz" -C /usr/local --strip-components=1 \
+	&& rm "node-v$NODE_VERSION-linux-alpine-aarch64.tar.gz" \
 	&& npm config set unsafe-perm true -g --unsafe-perm \
 	&& rm -rf /tmp/*
 

--- a/node/kitra710/alpine/4.8/edge/Dockerfile
+++ b/node/kitra710/alpine/4.8/edge/Dockerfile
@@ -6,10 +6,10 @@ ENV NODE_VERSION 4.8.7
 # Install dependencies
 RUN apk add --no-cache libgcc libstdc++ libuv libcrypto1.0 libssl1.0
 
-RUN curl -SLO "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/node-v$NODE_VERSION-linux-alpine-armhf.tar.gz" \
-	&& echo "fec4448579a5d9078537bcd719a1578c627845df7919ad39092c6b9df49c9259  node-v4.8.7-linux-alpine-armhf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "node-v$NODE_VERSION-linux-alpine-armhf.tar.gz" -C /usr/local --strip-components=1 \
-	&& rm "node-v$NODE_VERSION-linux-alpine-armhf.tar.gz" \
+RUN curl -SLO "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/node-v$NODE_VERSION-linux-alpine-aarch64.tar.gz" \
+	&& echo "8bbc599bc95cd87490a116d51030437d23fae3682cb38b33bd10cadc30995bc3  node-v4.8.7-linux-alpine-aarch64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "node-v$NODE_VERSION-linux-alpine-aarch64.tar.gz" -C /usr/local --strip-components=1 \
+	&& rm "node-v$NODE_VERSION-linux-alpine-aarch64.tar.gz" \
 	&& npm config set unsafe-perm true -g --unsafe-perm \
 	&& rm -rf /tmp/*
 

--- a/node/kitra710/alpine/4.8/slim/Dockerfile
+++ b/node/kitra710/alpine/4.8/slim/Dockerfile
@@ -9,10 +9,10 @@ RUN apk add --no-cache libgcc libstdc++ libuv libcrypto1.0 libssl1.0
 RUN buildDeps='curl' \
 	&& set -x \
 	&& apk add --no-cache $buildDeps \
-	&& curl -SLO "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/node-v$NODE_VERSION-linux-alpine-armhf.tar.gz" \
-	&& echo "fec4448579a5d9078537bcd719a1578c627845df7919ad39092c6b9df49c9259  node-v4.8.7-linux-alpine-armhf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "node-v$NODE_VERSION-linux-alpine-armhf.tar.gz" -C /usr/local --strip-components=1 \
-	&& rm "node-v$NODE_VERSION-linux-alpine-armhf.tar.gz" \
+	&& curl -SLO "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/node-v$NODE_VERSION-linux-alpine-aarch64.tar.gz" \
+	&& echo "8bbc599bc95cd87490a116d51030437d23fae3682cb38b33bd10cadc30995bc3  node-v4.8.7-linux-alpine-aarch64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "node-v$NODE_VERSION-linux-alpine-aarch64.tar.gz" -C /usr/local --strip-components=1 \
+	&& rm "node-v$NODE_VERSION-linux-alpine-aarch64.tar.gz" \
 	&& apk del $buildDeps \
 	&& npm config set unsafe-perm true -g --unsafe-perm \
 	&& rm -rf /tmp/*

--- a/node/kitra710/alpine/5.12/Dockerfile
+++ b/node/kitra710/alpine/5.12/Dockerfile
@@ -6,10 +6,10 @@ ENV NODE_VERSION 5.12.0
 # Install dependencies
 RUN apk add --no-cache libgcc libstdc++ libuv libcrypto1.0 libssl1.0
 
-RUN curl -SLO "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/node-v$NODE_VERSION-linux-alpine-armhf.tar.gz" \
-	&& echo "bbaa5d89b483272f930b65361bc241c5fb694471712af2e15a3afd65e7d1611f  node-v5.12.0-linux-alpine-armhf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "node-v$NODE_VERSION-linux-alpine-armhf.tar.gz" -C /usr/local --strip-components=1 \
-	&& rm "node-v$NODE_VERSION-linux-alpine-armhf.tar.gz" \
+RUN curl -SLO "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/node-v$NODE_VERSION-linux-alpine-aarch64.tar.gz" \
+	&& echo "1eeed8c7aa1f1125218b18cb6a62c7049f60bd763c5400ba55d2f706b9629fbd  node-v5.12.0-linux-alpine-aarch64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "node-v$NODE_VERSION-linux-alpine-aarch64.tar.gz" -C /usr/local --strip-components=1 \
+	&& rm "node-v$NODE_VERSION-linux-alpine-aarch64.tar.gz" \
 	&& npm config set unsafe-perm true -g --unsafe-perm \
 	&& rm -rf /tmp/*
 

--- a/node/kitra710/alpine/5.12/edge/Dockerfile
+++ b/node/kitra710/alpine/5.12/edge/Dockerfile
@@ -6,10 +6,10 @@ ENV NODE_VERSION 5.12.0
 # Install dependencies
 RUN apk add --no-cache libgcc libstdc++ libuv libcrypto1.0 libssl1.0
 
-RUN curl -SLO "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/node-v$NODE_VERSION-linux-alpine-armhf.tar.gz" \
-	&& echo "bbaa5d89b483272f930b65361bc241c5fb694471712af2e15a3afd65e7d1611f  node-v5.12.0-linux-alpine-armhf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "node-v$NODE_VERSION-linux-alpine-armhf.tar.gz" -C /usr/local --strip-components=1 \
-	&& rm "node-v$NODE_VERSION-linux-alpine-armhf.tar.gz" \
+RUN curl -SLO "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/node-v$NODE_VERSION-linux-alpine-aarch64.tar.gz" \
+	&& echo "1eeed8c7aa1f1125218b18cb6a62c7049f60bd763c5400ba55d2f706b9629fbd  node-v5.12.0-linux-alpine-aarch64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "node-v$NODE_VERSION-linux-alpine-aarch64.tar.gz" -C /usr/local --strip-components=1 \
+	&& rm "node-v$NODE_VERSION-linux-alpine-aarch64.tar.gz" \
 	&& npm config set unsafe-perm true -g --unsafe-perm \
 	&& rm -rf /tmp/*
 

--- a/node/kitra710/alpine/5.12/slim/Dockerfile
+++ b/node/kitra710/alpine/5.12/slim/Dockerfile
@@ -9,10 +9,10 @@ RUN apk add --no-cache libgcc libstdc++ libuv libcrypto1.0 libssl1.0
 RUN buildDeps='curl' \
 	&& set -x \
 	&& apk add --no-cache $buildDeps \
-	&& curl -SLO "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/node-v$NODE_VERSION-linux-alpine-armhf.tar.gz" \
-	&& echo "bbaa5d89b483272f930b65361bc241c5fb694471712af2e15a3afd65e7d1611f  node-v5.12.0-linux-alpine-armhf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "node-v$NODE_VERSION-linux-alpine-armhf.tar.gz" -C /usr/local --strip-components=1 \
-	&& rm "node-v$NODE_VERSION-linux-alpine-armhf.tar.gz" \
+	&& curl -SLO "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/node-v$NODE_VERSION-linux-alpine-aarch64.tar.gz" \
+	&& echo "1eeed8c7aa1f1125218b18cb6a62c7049f60bd763c5400ba55d2f706b9629fbd  node-v5.12.0-linux-alpine-aarch64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "node-v$NODE_VERSION-linux-alpine-aarch64.tar.gz" -C /usr/local --strip-components=1 \
+	&& rm "node-v$NODE_VERSION-linux-alpine-aarch64.tar.gz" \
 	&& apk del $buildDeps \
 	&& npm config set unsafe-perm true -g --unsafe-perm \
 	&& rm -rf /tmp/*

--- a/node/kitra710/alpine/6.13/Dockerfile
+++ b/node/kitra710/alpine/6.13/Dockerfile
@@ -6,10 +6,10 @@ ENV NODE_VERSION 6.13.1
 # Install dependencies
 RUN apk add --no-cache libgcc libstdc++ libuv libcrypto1.0 libssl1.0
 
-RUN curl -SLO "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/node-v$NODE_VERSION-linux-alpine-armhf.tar.gz" \
-	&& echo "03e99b6e5486535c47ff72ff390092f8952c50cc8a9983acc8736bbd77555a8e  node-v6.13.1-linux-alpine-armhf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "node-v$NODE_VERSION-linux-alpine-armhf.tar.gz" -C /usr/local --strip-components=1 \
-	&& rm "node-v$NODE_VERSION-linux-alpine-armhf.tar.gz" \
+RUN curl -SLO "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/node-v$NODE_VERSION-linux-alpine-aarch64.tar.gz" \
+	&& echo "367a810c0621bb3d914396ecbe6f596109ee76e4759d122042a54769924cbd63  node-v6.13.1-linux-alpine-aarch64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "node-v$NODE_VERSION-linux-alpine-aarch64.tar.gz" -C /usr/local --strip-components=1 \
+	&& rm "node-v$NODE_VERSION-linux-alpine-aarch64.tar.gz" \
 	&& npm config set unsafe-perm true -g --unsafe-perm \
 	&& rm -rf /tmp/*
 

--- a/node/kitra710/alpine/6.13/edge/Dockerfile
+++ b/node/kitra710/alpine/6.13/edge/Dockerfile
@@ -6,10 +6,10 @@ ENV NODE_VERSION 6.13.1
 # Install dependencies
 RUN apk add --no-cache libgcc libstdc++ libuv libcrypto1.0 libssl1.0
 
-RUN curl -SLO "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/node-v$NODE_VERSION-linux-alpine-armhf.tar.gz" \
-	&& echo "03e99b6e5486535c47ff72ff390092f8952c50cc8a9983acc8736bbd77555a8e  node-v6.13.1-linux-alpine-armhf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "node-v$NODE_VERSION-linux-alpine-armhf.tar.gz" -C /usr/local --strip-components=1 \
-	&& rm "node-v$NODE_VERSION-linux-alpine-armhf.tar.gz" \
+RUN curl -SLO "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/node-v$NODE_VERSION-linux-alpine-aarch64.tar.gz" \
+	&& echo "367a810c0621bb3d914396ecbe6f596109ee76e4759d122042a54769924cbd63  node-v6.13.1-linux-alpine-aarch64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "node-v$NODE_VERSION-linux-alpine-aarch64.tar.gz" -C /usr/local --strip-components=1 \
+	&& rm "node-v$NODE_VERSION-linux-alpine-aarch64.tar.gz" \
 	&& npm config set unsafe-perm true -g --unsafe-perm \
 	&& rm -rf /tmp/*
 

--- a/node/kitra710/alpine/6.13/slim/Dockerfile
+++ b/node/kitra710/alpine/6.13/slim/Dockerfile
@@ -9,10 +9,10 @@ RUN apk add --no-cache libgcc libstdc++ libuv libcrypto1.0 libssl1.0
 RUN buildDeps='curl' \
 	&& set -x \
 	&& apk add --no-cache $buildDeps \
-	&& curl -SLO "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/node-v$NODE_VERSION-linux-alpine-armhf.tar.gz" \
-	&& echo "03e99b6e5486535c47ff72ff390092f8952c50cc8a9983acc8736bbd77555a8e  node-v6.13.1-linux-alpine-armhf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "node-v$NODE_VERSION-linux-alpine-armhf.tar.gz" -C /usr/local --strip-components=1 \
-	&& rm "node-v$NODE_VERSION-linux-alpine-armhf.tar.gz" \
+	&& curl -SLO "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/node-v$NODE_VERSION-linux-alpine-aarch64.tar.gz" \
+	&& echo "367a810c0621bb3d914396ecbe6f596109ee76e4759d122042a54769924cbd63  node-v6.13.1-linux-alpine-aarch64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "node-v$NODE_VERSION-linux-alpine-aarch64.tar.gz" -C /usr/local --strip-components=1 \
+	&& rm "node-v$NODE_VERSION-linux-alpine-aarch64.tar.gz" \
 	&& apk del $buildDeps \
 	&& npm config set unsafe-perm true -g --unsafe-perm \
 	&& rm -rf /tmp/*

--- a/node/kitra710/alpine/7.10/Dockerfile
+++ b/node/kitra710/alpine/7.10/Dockerfile
@@ -6,10 +6,10 @@ ENV NODE_VERSION 7.10.1
 # Install dependencies
 RUN apk add --no-cache libgcc libstdc++ libuv libcrypto1.0 libssl1.0
 
-RUN curl -SLO "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/node-v$NODE_VERSION-linux-alpine-armhf.tar.gz" \
-	&& echo "8eb485eff51ac2046e3d4b6108f82bd7648549b01887ca1cbf6dbd21177185df  node-v7.10.1-linux-alpine-armhf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "node-v$NODE_VERSION-linux-alpine-armhf.tar.gz" -C /usr/local --strip-components=1 \
-	&& rm "node-v$NODE_VERSION-linux-alpine-armhf.tar.gz" \
+RUN curl -SLO "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/node-v$NODE_VERSION-linux-alpine-aarch64.tar.gz" \
+	&& echo "f4f13afb28993fe512b51f7bcb796c5ca2b3fd6f290472ed855a9648cfa6eccc  node-v7.10.1-linux-alpine-aarch64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "node-v$NODE_VERSION-linux-alpine-aarch64.tar.gz" -C /usr/local --strip-components=1 \
+	&& rm "node-v$NODE_VERSION-linux-alpine-aarch64.tar.gz" \
 	&& npm config set unsafe-perm true -g --unsafe-perm \
 	&& rm -rf /tmp/*
 

--- a/node/kitra710/alpine/7.10/edge/Dockerfile
+++ b/node/kitra710/alpine/7.10/edge/Dockerfile
@@ -6,10 +6,10 @@ ENV NODE_VERSION 7.10.1
 # Install dependencies
 RUN apk add --no-cache libgcc libstdc++ libuv libcrypto1.0 libssl1.0
 
-RUN curl -SLO "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/node-v$NODE_VERSION-linux-alpine-armhf.tar.gz" \
-	&& echo "8eb485eff51ac2046e3d4b6108f82bd7648549b01887ca1cbf6dbd21177185df  node-v7.10.1-linux-alpine-armhf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "node-v$NODE_VERSION-linux-alpine-armhf.tar.gz" -C /usr/local --strip-components=1 \
-	&& rm "node-v$NODE_VERSION-linux-alpine-armhf.tar.gz" \
+RUN curl -SLO "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/node-v$NODE_VERSION-linux-alpine-aarch64.tar.gz" \
+	&& echo "f4f13afb28993fe512b51f7bcb796c5ca2b3fd6f290472ed855a9648cfa6eccc  node-v7.10.1-linux-alpine-aarch64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "node-v$NODE_VERSION-linux-alpine-aarch64.tar.gz" -C /usr/local --strip-components=1 \
+	&& rm "node-v$NODE_VERSION-linux-alpine-aarch64.tar.gz" \
 	&& npm config set unsafe-perm true -g --unsafe-perm \
 	&& rm -rf /tmp/*
 

--- a/node/kitra710/alpine/7.10/slim/Dockerfile
+++ b/node/kitra710/alpine/7.10/slim/Dockerfile
@@ -9,10 +9,10 @@ RUN apk add --no-cache libgcc libstdc++ libuv libcrypto1.0 libssl1.0
 RUN buildDeps='curl' \
 	&& set -x \
 	&& apk add --no-cache $buildDeps \
-	&& curl -SLO "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/node-v$NODE_VERSION-linux-alpine-armhf.tar.gz" \
-	&& echo "8eb485eff51ac2046e3d4b6108f82bd7648549b01887ca1cbf6dbd21177185df  node-v7.10.1-linux-alpine-armhf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "node-v$NODE_VERSION-linux-alpine-armhf.tar.gz" -C /usr/local --strip-components=1 \
-	&& rm "node-v$NODE_VERSION-linux-alpine-armhf.tar.gz" \
+	&& curl -SLO "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/node-v$NODE_VERSION-linux-alpine-aarch64.tar.gz" \
+	&& echo "f4f13afb28993fe512b51f7bcb796c5ca2b3fd6f290472ed855a9648cfa6eccc  node-v7.10.1-linux-alpine-aarch64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "node-v$NODE_VERSION-linux-alpine-aarch64.tar.gz" -C /usr/local --strip-components=1 \
+	&& rm "node-v$NODE_VERSION-linux-alpine-aarch64.tar.gz" \
 	&& apk del $buildDeps \
 	&& npm config set unsafe-perm true -g --unsafe-perm \
 	&& rm -rf /tmp/*

--- a/node/kitra710/alpine/8.9/Dockerfile
+++ b/node/kitra710/alpine/8.9/Dockerfile
@@ -6,10 +6,10 @@ ENV NODE_VERSION 8.9.4
 # Install dependencies
 RUN apk add --no-cache libgcc libstdc++ libuv libcrypto1.0 libssl1.0
 
-RUN curl -SLO "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/node-v$NODE_VERSION-linux-alpine-armhf.tar.gz" \
-	&& echo "0d97b5b666fef3b7c6206f54d815e1c3442730e60f002c7a5a60eae6c0f33ceb  node-v8.9.4-linux-alpine-armhf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "node-v$NODE_VERSION-linux-alpine-armhf.tar.gz" -C /usr/local --strip-components=1 \
-	&& rm "node-v$NODE_VERSION-linux-alpine-armhf.tar.gz" \
+RUN curl -SLO "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/node-v$NODE_VERSION-linux-alpine-aarch64.tar.gz" \
+	&& echo "d9e566a6e804d4f71e6d39c2c9976e5e9d30105c35076ae7bf6f586ae1020f28  node-v8.9.4-linux-alpine-aarch64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "node-v$NODE_VERSION-linux-alpine-aarch64.tar.gz" -C /usr/local --strip-components=1 \
+	&& rm "node-v$NODE_VERSION-linux-alpine-aarch64.tar.gz" \
 	&& npm config set unsafe-perm true -g --unsafe-perm \
 	&& rm -rf /tmp/*
 

--- a/node/kitra710/alpine/8.9/edge/Dockerfile
+++ b/node/kitra710/alpine/8.9/edge/Dockerfile
@@ -6,10 +6,10 @@ ENV NODE_VERSION 8.9.4
 # Install dependencies
 RUN apk add --no-cache libgcc libstdc++ libuv libcrypto1.0 libssl1.0
 
-RUN curl -SLO "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/node-v$NODE_VERSION-linux-alpine-armhf.tar.gz" \
-	&& echo "0d97b5b666fef3b7c6206f54d815e1c3442730e60f002c7a5a60eae6c0f33ceb  node-v8.9.4-linux-alpine-armhf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "node-v$NODE_VERSION-linux-alpine-armhf.tar.gz" -C /usr/local --strip-components=1 \
-	&& rm "node-v$NODE_VERSION-linux-alpine-armhf.tar.gz" \
+RUN curl -SLO "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/node-v$NODE_VERSION-linux-alpine-aarch64.tar.gz" \
+	&& echo "d9e566a6e804d4f71e6d39c2c9976e5e9d30105c35076ae7bf6f586ae1020f28  node-v8.9.4-linux-alpine-aarch64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "node-v$NODE_VERSION-linux-alpine-aarch64.tar.gz" -C /usr/local --strip-components=1 \
+	&& rm "node-v$NODE_VERSION-linux-alpine-aarch64.tar.gz" \
 	&& npm config set unsafe-perm true -g --unsafe-perm \
 	&& rm -rf /tmp/*
 

--- a/node/kitra710/alpine/8.9/slim/Dockerfile
+++ b/node/kitra710/alpine/8.9/slim/Dockerfile
@@ -9,10 +9,10 @@ RUN apk add --no-cache libgcc libstdc++ libuv libcrypto1.0 libssl1.0
 RUN buildDeps='curl' \
 	&& set -x \
 	&& apk add --no-cache $buildDeps \
-	&& curl -SLO "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/node-v$NODE_VERSION-linux-alpine-armhf.tar.gz" \
-	&& echo "0d97b5b666fef3b7c6206f54d815e1c3442730e60f002c7a5a60eae6c0f33ceb  node-v8.9.4-linux-alpine-armhf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "node-v$NODE_VERSION-linux-alpine-armhf.tar.gz" -C /usr/local --strip-components=1 \
-	&& rm "node-v$NODE_VERSION-linux-alpine-armhf.tar.gz" \
+	&& curl -SLO "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/node-v$NODE_VERSION-linux-alpine-aarch64.tar.gz" \
+	&& echo "d9e566a6e804d4f71e6d39c2c9976e5e9d30105c35076ae7bf6f586ae1020f28  node-v8.9.4-linux-alpine-aarch64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "node-v$NODE_VERSION-linux-alpine-aarch64.tar.gz" -C /usr/local --strip-components=1 \
+	&& rm "node-v$NODE_VERSION-linux-alpine-aarch64.tar.gz" \
 	&& apk del $buildDeps \
 	&& npm config set unsafe-perm true -g --unsafe-perm \
 	&& rm -rf /tmp/*

--- a/node/kitra710/alpine/9.5/Dockerfile
+++ b/node/kitra710/alpine/9.5/Dockerfile
@@ -6,10 +6,10 @@ ENV NODE_VERSION 9.5.0
 # Install dependencies
 RUN apk add --no-cache libgcc libstdc++ libuv libcrypto1.0 libssl1.0
 
-RUN curl -SLO "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/node-v$NODE_VERSION-linux-alpine-armhf.tar.gz" \
-	&& echo "431072120208ec8c419cded1f5ffa20e79a4d032eb150e634f91d7053f083859  node-v9.5.0-linux-alpine-armhf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "node-v$NODE_VERSION-linux-alpine-armhf.tar.gz" -C /usr/local --strip-components=1 \
-	&& rm "node-v$NODE_VERSION-linux-alpine-armhf.tar.gz" \
+RUN curl -SLO "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/node-v$NODE_VERSION-linux-alpine-aarch64.tar.gz" \
+	&& echo "fa97eb3697ccd086151ca07fcd877fbb5ebdec6898cdd64375ea1ef9d6b368ff  node-v9.5.0-linux-alpine-aarch64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "node-v$NODE_VERSION-linux-alpine-aarch64.tar.gz" -C /usr/local --strip-components=1 \
+	&& rm "node-v$NODE_VERSION-linux-alpine-aarch64.tar.gz" \
 	&& npm config set unsafe-perm true -g --unsafe-perm \
 	&& rm -rf /tmp/*
 

--- a/node/kitra710/alpine/9.5/edge/Dockerfile
+++ b/node/kitra710/alpine/9.5/edge/Dockerfile
@@ -6,10 +6,10 @@ ENV NODE_VERSION 9.5.0
 # Install dependencies
 RUN apk add --no-cache libgcc libstdc++ libuv libcrypto1.0 libssl1.0
 
-RUN curl -SLO "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/node-v$NODE_VERSION-linux-alpine-armhf.tar.gz" \
-	&& echo "431072120208ec8c419cded1f5ffa20e79a4d032eb150e634f91d7053f083859  node-v9.5.0-linux-alpine-armhf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "node-v$NODE_VERSION-linux-alpine-armhf.tar.gz" -C /usr/local --strip-components=1 \
-	&& rm "node-v$NODE_VERSION-linux-alpine-armhf.tar.gz" \
+RUN curl -SLO "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/node-v$NODE_VERSION-linux-alpine-aarch64.tar.gz" \
+	&& echo "fa97eb3697ccd086151ca07fcd877fbb5ebdec6898cdd64375ea1ef9d6b368ff  node-v9.5.0-linux-alpine-aarch64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "node-v$NODE_VERSION-linux-alpine-aarch64.tar.gz" -C /usr/local --strip-components=1 \
+	&& rm "node-v$NODE_VERSION-linux-alpine-aarch64.tar.gz" \
 	&& npm config set unsafe-perm true -g --unsafe-perm \
 	&& rm -rf /tmp/*
 

--- a/node/kitra710/alpine/9.5/slim/Dockerfile
+++ b/node/kitra710/alpine/9.5/slim/Dockerfile
@@ -9,10 +9,10 @@ RUN apk add --no-cache libgcc libstdc++ libuv libcrypto1.0 libssl1.0
 RUN buildDeps='curl' \
 	&& set -x \
 	&& apk add --no-cache $buildDeps \
-	&& curl -SLO "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/node-v$NODE_VERSION-linux-alpine-armhf.tar.gz" \
-	&& echo "431072120208ec8c419cded1f5ffa20e79a4d032eb150e634f91d7053f083859  node-v9.5.0-linux-alpine-armhf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "node-v$NODE_VERSION-linux-alpine-armhf.tar.gz" -C /usr/local --strip-components=1 \
-	&& rm "node-v$NODE_VERSION-linux-alpine-armhf.tar.gz" \
+	&& curl -SLO "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/node-v$NODE_VERSION-linux-alpine-aarch64.tar.gz" \
+	&& echo "fa97eb3697ccd086151ca07fcd877fbb5ebdec6898cdd64375ea1ef9d6b368ff  node-v9.5.0-linux-alpine-aarch64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "node-v$NODE_VERSION-linux-alpine-aarch64.tar.gz" -C /usr/local --strip-components=1 \
+	&& rm "node-v$NODE_VERSION-linux-alpine-aarch64.tar.gz" \
 	&& apk del $buildDeps \
 	&& npm config set unsafe-perm true -g --unsafe-perm \
 	&& rm -rf /tmp/*

--- a/node/kitra710/debian/4.8/Dockerfile
+++ b/node/kitra710/debian/4.8/Dockerfile
@@ -3,10 +3,10 @@ FROM resin/kitra710-buildpack-deps:jessie
 
 ENV NODE_VERSION 4.8.7
 
-RUN curl -SLO "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/node-v$NODE_VERSION-linux-armv7hf.tar.gz" \
-	&& echo "d66b71cbb5484ce39c5323bf5c975e17ff813b49255de3b1e947bc8e862a8d5a  node-v4.8.7-linux-armv7hf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "node-v$NODE_VERSION-linux-armv7hf.tar.gz" -C /usr/local --strip-components=1 \
-	&& rm "node-v$NODE_VERSION-linux-armv7hf.tar.gz" \
+RUN curl -SLO "http://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-arm64.tar.gz" \
+	&& echo "2a81bc51d0973c22fe04276cc965dddd162a7e1287b9a1c59306be9c24f37c0f  node-v4.8.7-linux-arm64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "node-v$NODE_VERSION-linux-arm64.tar.gz" -C /usr/local --strip-components=1 \
+	&& rm "node-v$NODE_VERSION-linux-arm64.tar.gz" \
 	&& npm config set unsafe-perm true -g --unsafe-perm \
 	&& rm -rf /tmp/*
 

--- a/node/kitra710/debian/4.8/slim/Dockerfile
+++ b/node/kitra710/debian/4.8/slim/Dockerfile
@@ -7,10 +7,10 @@ RUN buildDeps='curl' \
 	&& set -x \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends \
 	&& rm -rf /var/lib/apt/lists/* \
-	&& curl -SLO "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/node-v$NODE_VERSION-linux-armv7hf.tar.gz" \
-	&& echo "d66b71cbb5484ce39c5323bf5c975e17ff813b49255de3b1e947bc8e862a8d5a  node-v4.8.7-linux-armv7hf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "node-v$NODE_VERSION-linux-armv7hf.tar.gz" -C /usr/local --strip-components=1 \
-	&& rm "node-v$NODE_VERSION-linux-armv7hf.tar.gz" \
+	&& curl -SLO "http://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-arm64.tar.gz" \
+	&& echo "2a81bc51d0973c22fe04276cc965dddd162a7e1287b9a1c59306be9c24f37c0f  node-v4.8.7-linux-arm64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "node-v$NODE_VERSION-linux-arm64.tar.gz" -C /usr/local --strip-components=1 \
+	&& rm "node-v$NODE_VERSION-linux-arm64.tar.gz" \
 	&& apt-get purge -y --auto-remove $buildDeps \
 	&& npm config set unsafe-perm true -g --unsafe-perm \
 	&& rm -rf /tmp/*

--- a/node/kitra710/debian/4.8/wheezy/Dockerfile
+++ b/node/kitra710/debian/4.8/wheezy/Dockerfile
@@ -3,10 +3,10 @@ FROM resin/kitra710-buildpack-deps:wheezy
 
 ENV NODE_VERSION 4.8.7
 
-RUN curl -SLO "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/node-v$NODE_VERSION-linux-armv7hf.tar.gz" \
-	&& echo "d66b71cbb5484ce39c5323bf5c975e17ff813b49255de3b1e947bc8e862a8d5a  node-v4.8.7-linux-armv7hf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "node-v$NODE_VERSION-linux-armv7hf.tar.gz" -C /usr/local --strip-components=1 \
-	&& rm "node-v$NODE_VERSION-linux-armv7hf.tar.gz" \
+RUN curl -SLO "http://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-arm64.tar.gz" \
+	&& echo "2a81bc51d0973c22fe04276cc965dddd162a7e1287b9a1c59306be9c24f37c0f  node-v4.8.7-linux-arm64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "node-v$NODE_VERSION-linux-arm64.tar.gz" -C /usr/local --strip-components=1 \
+	&& rm "node-v$NODE_VERSION-linux-arm64.tar.gz" \
 	&& npm config set unsafe-perm true -g --unsafe-perm \
 	&& rm -rf /tmp/*
 

--- a/node/kitra710/debian/5.12/Dockerfile
+++ b/node/kitra710/debian/5.12/Dockerfile
@@ -3,10 +3,10 @@ FROM resin/kitra710-buildpack-deps:jessie
 
 ENV NODE_VERSION 5.12.0
 
-RUN curl -SLO "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/node-v$NODE_VERSION-linux-armv7hf.tar.gz" \
-	&& echo "" | sha256sum -c - \
-	&& tar -xzf "node-v$NODE_VERSION-linux-armv7hf.tar.gz" -C /usr/local --strip-components=1 \
-	&& rm "node-v$NODE_VERSION-linux-armv7hf.tar.gz" \
+RUN curl -SLO "http://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-arm64.tar.gz" \
+	&& echo "db02351d2c205a3c60218f937a41a8b8d665f326e7dfa263954ab39f8a8a2bc3  node-v5.12.0-linux-arm64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "node-v$NODE_VERSION-linux-arm64.tar.gz" -C /usr/local --strip-components=1 \
+	&& rm "node-v$NODE_VERSION-linux-arm64.tar.gz" \
 	&& npm config set unsafe-perm true -g --unsafe-perm \
 	&& rm -rf /tmp/*
 

--- a/node/kitra710/debian/5.12/slim/Dockerfile
+++ b/node/kitra710/debian/5.12/slim/Dockerfile
@@ -7,10 +7,10 @@ RUN buildDeps='curl' \
 	&& set -x \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends \
 	&& rm -rf /var/lib/apt/lists/* \
-	&& curl -SLO "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/node-v$NODE_VERSION-linux-armv7hf.tar.gz" \
-	&& echo "" | sha256sum -c - \
-	&& tar -xzf "node-v$NODE_VERSION-linux-armv7hf.tar.gz" -C /usr/local --strip-components=1 \
-	&& rm "node-v$NODE_VERSION-linux-armv7hf.tar.gz" \
+	&& curl -SLO "http://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-arm64.tar.gz" \
+	&& echo "db02351d2c205a3c60218f937a41a8b8d665f326e7dfa263954ab39f8a8a2bc3  node-v5.12.0-linux-arm64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "node-v$NODE_VERSION-linux-arm64.tar.gz" -C /usr/local --strip-components=1 \
+	&& rm "node-v$NODE_VERSION-linux-arm64.tar.gz" \
 	&& apt-get purge -y --auto-remove $buildDeps \
 	&& npm config set unsafe-perm true -g --unsafe-perm \
 	&& rm -rf /tmp/*

--- a/node/kitra710/debian/5.12/wheezy/Dockerfile
+++ b/node/kitra710/debian/5.12/wheezy/Dockerfile
@@ -3,10 +3,10 @@ FROM resin/kitra710-buildpack-deps:wheezy
 
 ENV NODE_VERSION 5.12.0
 
-RUN curl -SLO "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/node-v$NODE_VERSION-linux-armv7hf.tar.gz" \
-	&& echo "" | sha256sum -c - \
-	&& tar -xzf "node-v$NODE_VERSION-linux-armv7hf.tar.gz" -C /usr/local --strip-components=1 \
-	&& rm "node-v$NODE_VERSION-linux-armv7hf.tar.gz" \
+RUN curl -SLO "http://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-arm64.tar.gz" \
+	&& echo "db02351d2c205a3c60218f937a41a8b8d665f326e7dfa263954ab39f8a8a2bc3  node-v5.12.0-linux-arm64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "node-v$NODE_VERSION-linux-arm64.tar.gz" -C /usr/local --strip-components=1 \
+	&& rm "node-v$NODE_VERSION-linux-arm64.tar.gz" \
 	&& npm config set unsafe-perm true -g --unsafe-perm \
 	&& rm -rf /tmp/*
 

--- a/node/kitra710/debian/6.13/Dockerfile
+++ b/node/kitra710/debian/6.13/Dockerfile
@@ -3,10 +3,10 @@ FROM resin/kitra710-buildpack-deps:jessie
 
 ENV NODE_VERSION 6.13.1
 
-RUN curl -SLO "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/node-v$NODE_VERSION-linux-armv7hf.tar.gz" \
-	&& echo "79a93450c25edfbdc3b705f30269273511416ec9ff71d4e661702034267e8d75  node-v6.13.1-linux-armv7hf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "node-v$NODE_VERSION-linux-armv7hf.tar.gz" -C /usr/local --strip-components=1 \
-	&& rm "node-v$NODE_VERSION-linux-armv7hf.tar.gz" \
+RUN curl -SLO "http://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-arm64.tar.gz" \
+	&& echo "27c9dd1c907f751f073f6d092b72a184a836aac7cac40fdf056edcc1987102b3  node-v6.13.1-linux-arm64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "node-v$NODE_VERSION-linux-arm64.tar.gz" -C /usr/local --strip-components=1 \
+	&& rm "node-v$NODE_VERSION-linux-arm64.tar.gz" \
 	&& npm config set unsafe-perm true -g --unsafe-perm \
 	&& rm -rf /tmp/*
 

--- a/node/kitra710/debian/6.13/slim/Dockerfile
+++ b/node/kitra710/debian/6.13/slim/Dockerfile
@@ -7,10 +7,10 @@ RUN buildDeps='curl' \
 	&& set -x \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends \
 	&& rm -rf /var/lib/apt/lists/* \
-	&& curl -SLO "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/node-v$NODE_VERSION-linux-armv7hf.tar.gz" \
-	&& echo "79a93450c25edfbdc3b705f30269273511416ec9ff71d4e661702034267e8d75  node-v6.13.1-linux-armv7hf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "node-v$NODE_VERSION-linux-armv7hf.tar.gz" -C /usr/local --strip-components=1 \
-	&& rm "node-v$NODE_VERSION-linux-armv7hf.tar.gz" \
+	&& curl -SLO "http://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-arm64.tar.gz" \
+	&& echo "27c9dd1c907f751f073f6d092b72a184a836aac7cac40fdf056edcc1987102b3  node-v6.13.1-linux-arm64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "node-v$NODE_VERSION-linux-arm64.tar.gz" -C /usr/local --strip-components=1 \
+	&& rm "node-v$NODE_VERSION-linux-arm64.tar.gz" \
 	&& apt-get purge -y --auto-remove $buildDeps \
 	&& npm config set unsafe-perm true -g --unsafe-perm \
 	&& rm -rf /tmp/*

--- a/node/kitra710/debian/6.3/wheezy/Dockerfile
+++ b/node/kitra710/debian/6.3/wheezy/Dockerfile
@@ -3,10 +3,10 @@ FROM resin/kitra710-buildpack-deps:wheezy
 
 ENV NODE_VERSION 6.3.1
 
-RUN curl -SLO "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/node-v$NODE_VERSION-linux-armv7hf.tar.gz" \
-	&& echo "" | sha256sum -c - \
-	&& tar -xzf "node-v$NODE_VERSION-linux-armv7hf.tar.gz" -C /usr/local --strip-components=1 \
-	&& rm "node-v$NODE_VERSION-linux-armv7hf.tar.gz" \
+RUN curl -SLO "http://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-arm64.tar.gz" \
+	&& echo "66ef087709f7709f0bf066904df06815ac7ad213181d6dcc2adb4f9dc831704f  node-v6.3.1-linux-arm64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "node-v$NODE_VERSION-linux-arm64.tar.gz" -C /usr/local --strip-components=1 \
+	&& rm "node-v$NODE_VERSION-linux-arm64.tar.gz" \
 	&& npm config set unsafe-perm true -g --unsafe-perm \
 	&& rm -rf /tmp/*
 

--- a/node/kitra710/debian/7.10/Dockerfile
+++ b/node/kitra710/debian/7.10/Dockerfile
@@ -3,10 +3,10 @@ FROM resin/kitra710-buildpack-deps:jessie
 
 ENV NODE_VERSION 7.10.1
 
-RUN curl -SLO "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/node-v$NODE_VERSION-linux-armv7hf.tar.gz" \
-	&& echo "819eff8b457d484d407fc11985d013ddae47568f4b3fb0e125bdddc0fba32875  node-v7.10.1-linux-armv7hf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "node-v$NODE_VERSION-linux-armv7hf.tar.gz" -C /usr/local --strip-components=1 \
-	&& rm "node-v$NODE_VERSION-linux-armv7hf.tar.gz" \
+RUN curl -SLO "http://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-arm64.tar.gz" \
+	&& echo "157be398d666b0753d219b9f4cdd3517d4335ddb2c3800242d3934f191932920  node-v7.10.1-linux-arm64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "node-v$NODE_VERSION-linux-arm64.tar.gz" -C /usr/local --strip-components=1 \
+	&& rm "node-v$NODE_VERSION-linux-arm64.tar.gz" \
 	&& npm config set unsafe-perm true -g --unsafe-perm \
 	&& rm -rf /tmp/*
 

--- a/node/kitra710/debian/7.10/slim/Dockerfile
+++ b/node/kitra710/debian/7.10/slim/Dockerfile
@@ -7,10 +7,10 @@ RUN buildDeps='curl' \
 	&& set -x \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends \
 	&& rm -rf /var/lib/apt/lists/* \
-	&& curl -SLO "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/node-v$NODE_VERSION-linux-armv7hf.tar.gz" \
-	&& echo "819eff8b457d484d407fc11985d013ddae47568f4b3fb0e125bdddc0fba32875  node-v7.10.1-linux-armv7hf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "node-v$NODE_VERSION-linux-armv7hf.tar.gz" -C /usr/local --strip-components=1 \
-	&& rm "node-v$NODE_VERSION-linux-armv7hf.tar.gz" \
+	&& curl -SLO "http://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-arm64.tar.gz" \
+	&& echo "157be398d666b0753d219b9f4cdd3517d4335ddb2c3800242d3934f191932920  node-v7.10.1-linux-arm64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "node-v$NODE_VERSION-linux-arm64.tar.gz" -C /usr/local --strip-components=1 \
+	&& rm "node-v$NODE_VERSION-linux-arm64.tar.gz" \
 	&& apt-get purge -y --auto-remove $buildDeps \
 	&& npm config set unsafe-perm true -g --unsafe-perm \
 	&& rm -rf /tmp/*

--- a/node/kitra710/debian/8.9/Dockerfile
+++ b/node/kitra710/debian/8.9/Dockerfile
@@ -3,10 +3,10 @@ FROM resin/kitra710-buildpack-deps:jessie
 
 ENV NODE_VERSION 8.9.4
 
-RUN curl -SLO "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/node-v$NODE_VERSION-linux-armv7hf.tar.gz" \
-	&& echo "9a5b8591c9884ee88df2b5925f60ae2b9347579ce6012830f2a1e66a7365ed5a  node-v8.9.4-linux-armv7hf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "node-v$NODE_VERSION-linux-armv7hf.tar.gz" -C /usr/local --strip-components=1 \
-	&& rm "node-v$NODE_VERSION-linux-armv7hf.tar.gz" \
+RUN curl -SLO "http://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-arm64.tar.gz" \
+	&& echo "2b133c7d23033fbc2419e66fc08bba35c427a97aba83ed6848b6b4678c0cac65  node-v8.9.4-linux-arm64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "node-v$NODE_VERSION-linux-arm64.tar.gz" -C /usr/local --strip-components=1 \
+	&& rm "node-v$NODE_VERSION-linux-arm64.tar.gz" \
 	&& npm config set unsafe-perm true -g --unsafe-perm \
 	&& rm -rf /tmp/*
 

--- a/node/kitra710/debian/8.9/slim/Dockerfile
+++ b/node/kitra710/debian/8.9/slim/Dockerfile
@@ -7,10 +7,10 @@ RUN buildDeps='curl' \
 	&& set -x \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends \
 	&& rm -rf /var/lib/apt/lists/* \
-	&& curl -SLO "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/node-v$NODE_VERSION-linux-armv7hf.tar.gz" \
-	&& echo "9a5b8591c9884ee88df2b5925f60ae2b9347579ce6012830f2a1e66a7365ed5a  node-v8.9.4-linux-armv7hf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "node-v$NODE_VERSION-linux-armv7hf.tar.gz" -C /usr/local --strip-components=1 \
-	&& rm "node-v$NODE_VERSION-linux-armv7hf.tar.gz" \
+	&& curl -SLO "http://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-arm64.tar.gz" \
+	&& echo "2b133c7d23033fbc2419e66fc08bba35c427a97aba83ed6848b6b4678c0cac65  node-v8.9.4-linux-arm64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "node-v$NODE_VERSION-linux-arm64.tar.gz" -C /usr/local --strip-components=1 \
+	&& rm "node-v$NODE_VERSION-linux-arm64.tar.gz" \
 	&& apt-get purge -y --auto-remove $buildDeps \
 	&& npm config set unsafe-perm true -g --unsafe-perm \
 	&& rm -rf /tmp/*

--- a/node/kitra710/debian/9.5/Dockerfile
+++ b/node/kitra710/debian/9.5/Dockerfile
@@ -3,10 +3,10 @@ FROM resin/kitra710-buildpack-deps:jessie
 
 ENV NODE_VERSION 9.5.0
 
-RUN curl -SLO "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/node-v$NODE_VERSION-linux-armv7hf.tar.gz" \
-	&& echo "6408a233122cd408f081cbd2e4e79d6c46f653e043dc575a675d91493e9843be  node-v9.5.0-linux-armv7hf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "node-v$NODE_VERSION-linux-armv7hf.tar.gz" -C /usr/local --strip-components=1 \
-	&& rm "node-v$NODE_VERSION-linux-armv7hf.tar.gz" \
+RUN curl -SLO "http://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-arm64.tar.gz" \
+	&& echo "08924ad820d6322e17cc0fbbc365000b76408a4f17c3ed3169b44d8c7448a617  node-v9.5.0-linux-arm64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "node-v$NODE_VERSION-linux-arm64.tar.gz" -C /usr/local --strip-components=1 \
+	&& rm "node-v$NODE_VERSION-linux-arm64.tar.gz" \
 	&& npm config set unsafe-perm true -g --unsafe-perm \
 	&& rm -rf /tmp/*
 

--- a/node/kitra710/debian/9.5/slim/Dockerfile
+++ b/node/kitra710/debian/9.5/slim/Dockerfile
@@ -7,10 +7,10 @@ RUN buildDeps='curl' \
 	&& set -x \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends \
 	&& rm -rf /var/lib/apt/lists/* \
-	&& curl -SLO "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/node-v$NODE_VERSION-linux-armv7hf.tar.gz" \
-	&& echo "6408a233122cd408f081cbd2e4e79d6c46f653e043dc575a675d91493e9843be  node-v9.5.0-linux-armv7hf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "node-v$NODE_VERSION-linux-armv7hf.tar.gz" -C /usr/local --strip-components=1 \
-	&& rm "node-v$NODE_VERSION-linux-armv7hf.tar.gz" \
+	&& curl -SLO "http://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-arm64.tar.gz" \
+	&& echo "08924ad820d6322e17cc0fbbc365000b76408a4f17c3ed3169b44d8c7448a617  node-v9.5.0-linux-arm64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "node-v$NODE_VERSION-linux-arm64.tar.gz" -C /usr/local --strip-components=1 \
+	&& rm "node-v$NODE_VERSION-linux-arm64.tar.gz" \
 	&& apt-get purge -y --auto-remove $buildDeps \
 	&& npm config set unsafe-perm true -g --unsafe-perm \
 	&& rm -rf /tmp/*

--- a/node/kitra710/fedora/4.8/24/Dockerfile
+++ b/node/kitra710/fedora/4.8/24/Dockerfile
@@ -3,10 +3,10 @@ FROM resin/kitra710-fedora-buildpack-deps:24
 
 ENV NODE_VERSION 4.8.7
 
-RUN curl -SLO "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/node-v$NODE_VERSION-linux-armv7hf.tar.gz" \
-	&& echo "d66b71cbb5484ce39c5323bf5c975e17ff813b49255de3b1e947bc8e862a8d5a  node-v4.8.7-linux-armv7hf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "node-v$NODE_VERSION-linux-armv7hf.tar.gz" -C /usr/local --strip-components=1 \
-	&& rm "node-v$NODE_VERSION-linux-armv7hf.tar.gz" \
+RUN curl -SLO "http://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-arm64.tar.gz" \
+	&& echo "2a81bc51d0973c22fe04276cc965dddd162a7e1287b9a1c59306be9c24f37c0f  node-v4.8.7-linux-arm64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "node-v$NODE_VERSION-linux-arm64.tar.gz" -C /usr/local --strip-components=1 \
+	&& rm "node-v$NODE_VERSION-linux-arm64.tar.gz" \
 	&& npm config set unsafe-perm true -g --unsafe-perm \
 	&& rm -rf /tmp/*
 

--- a/node/kitra710/fedora/4.8/Dockerfile
+++ b/node/kitra710/fedora/4.8/Dockerfile
@@ -3,10 +3,10 @@ FROM resin/kitra710-fedora-buildpack-deps:latest
 
 ENV NODE_VERSION 4.8.7
 
-RUN curl -SLO "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/node-v$NODE_VERSION-linux-armv7hf.tar.gz" \
-	&& echo "d66b71cbb5484ce39c5323bf5c975e17ff813b49255de3b1e947bc8e862a8d5a  node-v4.8.7-linux-armv7hf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "node-v$NODE_VERSION-linux-armv7hf.tar.gz" -C /usr/local --strip-components=1 \
-	&& rm "node-v$NODE_VERSION-linux-armv7hf.tar.gz" \
+RUN curl -SLO "http://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-arm64.tar.gz" \
+	&& echo "2a81bc51d0973c22fe04276cc965dddd162a7e1287b9a1c59306be9c24f37c0f  node-v4.8.7-linux-arm64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "node-v$NODE_VERSION-linux-arm64.tar.gz" -C /usr/local --strip-components=1 \
+	&& rm "node-v$NODE_VERSION-linux-arm64.tar.gz" \
 	&& npm config set unsafe-perm true -g --unsafe-perm \
 	&& rm -rf /tmp/*
 

--- a/node/kitra710/fedora/4.8/slim/Dockerfile
+++ b/node/kitra710/fedora/4.8/slim/Dockerfile
@@ -3,10 +3,10 @@ FROM resin/kitra710-fedora:latest
 
 ENV NODE_VERSION 4.8.7
 
-RUN curl -SLO "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/node-v$NODE_VERSION-linux-armv7hf.tar.gz" \
-	&& echo "d66b71cbb5484ce39c5323bf5c975e17ff813b49255de3b1e947bc8e862a8d5a  node-v4.8.7-linux-armv7hf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "node-v$NODE_VERSION-linux-armv7hf.tar.gz" -C /usr/local --strip-components=1 \
-	&& rm "node-v$NODE_VERSION-linux-armv7hf.tar.gz" \
+RUN curl -SLO "http://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-arm64.tar.gz" \
+	&& echo "2a81bc51d0973c22fe04276cc965dddd162a7e1287b9a1c59306be9c24f37c0f  node-v4.8.7-linux-arm64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "node-v$NODE_VERSION-linux-arm64.tar.gz" -C /usr/local --strip-components=1 \
+	&& rm "node-v$NODE_VERSION-linux-arm64.tar.gz" \
 	&& npm config set unsafe-perm true -g --unsafe-perm \
 	&& rm -rf /tmp/*
 

--- a/node/kitra710/fedora/5.12/24/Dockerfile
+++ b/node/kitra710/fedora/5.12/24/Dockerfile
@@ -3,10 +3,10 @@ FROM resin/kitra710-fedora-buildpack-deps:24
 
 ENV NODE_VERSION 5.12.0
 
-RUN curl -SLO "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/node-v$NODE_VERSION-linux-armv7hf.tar.gz" \
-	&& echo "" | sha256sum -c - \
-	&& tar -xzf "node-v$NODE_VERSION-linux-armv7hf.tar.gz" -C /usr/local --strip-components=1 \
-	&& rm "node-v$NODE_VERSION-linux-armv7hf.tar.gz" \
+RUN curl -SLO "http://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-arm64.tar.gz" \
+	&& echo "db02351d2c205a3c60218f937a41a8b8d665f326e7dfa263954ab39f8a8a2bc3  node-v5.12.0-linux-arm64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "node-v$NODE_VERSION-linux-arm64.tar.gz" -C /usr/local --strip-components=1 \
+	&& rm "node-v$NODE_VERSION-linux-arm64.tar.gz" \
 	&& npm config set unsafe-perm true -g --unsafe-perm \
 	&& rm -rf /tmp/*
 

--- a/node/kitra710/fedora/5.12/Dockerfile
+++ b/node/kitra710/fedora/5.12/Dockerfile
@@ -3,10 +3,10 @@ FROM resin/kitra710-fedora-buildpack-deps:latest
 
 ENV NODE_VERSION 5.12.0
 
-RUN curl -SLO "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/node-v$NODE_VERSION-linux-armv7hf.tar.gz" \
-	&& echo "" | sha256sum -c - \
-	&& tar -xzf "node-v$NODE_VERSION-linux-armv7hf.tar.gz" -C /usr/local --strip-components=1 \
-	&& rm "node-v$NODE_VERSION-linux-armv7hf.tar.gz" \
+RUN curl -SLO "http://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-arm64.tar.gz" \
+	&& echo "db02351d2c205a3c60218f937a41a8b8d665f326e7dfa263954ab39f8a8a2bc3  node-v5.12.0-linux-arm64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "node-v$NODE_VERSION-linux-arm64.tar.gz" -C /usr/local --strip-components=1 \
+	&& rm "node-v$NODE_VERSION-linux-arm64.tar.gz" \
 	&& npm config set unsafe-perm true -g --unsafe-perm \
 	&& rm -rf /tmp/*
 

--- a/node/kitra710/fedora/5.12/slim/Dockerfile
+++ b/node/kitra710/fedora/5.12/slim/Dockerfile
@@ -3,10 +3,10 @@ FROM resin/kitra710-fedora:latest
 
 ENV NODE_VERSION 5.12.0
 
-RUN curl -SLO "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/node-v$NODE_VERSION-linux-armv7hf.tar.gz" \
-	&& echo "" | sha256sum -c - \
-	&& tar -xzf "node-v$NODE_VERSION-linux-armv7hf.tar.gz" -C /usr/local --strip-components=1 \
-	&& rm "node-v$NODE_VERSION-linux-armv7hf.tar.gz" \
+RUN curl -SLO "http://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-arm64.tar.gz" \
+	&& echo "db02351d2c205a3c60218f937a41a8b8d665f326e7dfa263954ab39f8a8a2bc3  node-v5.12.0-linux-arm64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "node-v$NODE_VERSION-linux-arm64.tar.gz" -C /usr/local --strip-components=1 \
+	&& rm "node-v$NODE_VERSION-linux-arm64.tar.gz" \
 	&& npm config set unsafe-perm true -g --unsafe-perm \
 	&& rm -rf /tmp/*
 

--- a/node/kitra710/fedora/6.13/24/Dockerfile
+++ b/node/kitra710/fedora/6.13/24/Dockerfile
@@ -3,10 +3,10 @@ FROM resin/kitra710-fedora-buildpack-deps:24
 
 ENV NODE_VERSION 6.13.1
 
-RUN curl -SLO "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/node-v$NODE_VERSION-linux-armv7hf.tar.gz" \
-	&& echo "79a93450c25edfbdc3b705f30269273511416ec9ff71d4e661702034267e8d75  node-v6.13.1-linux-armv7hf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "node-v$NODE_VERSION-linux-armv7hf.tar.gz" -C /usr/local --strip-components=1 \
-	&& rm "node-v$NODE_VERSION-linux-armv7hf.tar.gz" \
+RUN curl -SLO "http://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-arm64.tar.gz" \
+	&& echo "27c9dd1c907f751f073f6d092b72a184a836aac7cac40fdf056edcc1987102b3  node-v6.13.1-linux-arm64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "node-v$NODE_VERSION-linux-arm64.tar.gz" -C /usr/local --strip-components=1 \
+	&& rm "node-v$NODE_VERSION-linux-arm64.tar.gz" \
 	&& npm config set unsafe-perm true -g --unsafe-perm \
 	&& rm -rf /tmp/*
 

--- a/node/kitra710/fedora/6.13/Dockerfile
+++ b/node/kitra710/fedora/6.13/Dockerfile
@@ -3,10 +3,10 @@ FROM resin/kitra710-fedora-buildpack-deps:latest
 
 ENV NODE_VERSION 6.13.1
 
-RUN curl -SLO "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/node-v$NODE_VERSION-linux-armv7hf.tar.gz" \
-	&& echo "79a93450c25edfbdc3b705f30269273511416ec9ff71d4e661702034267e8d75  node-v6.13.1-linux-armv7hf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "node-v$NODE_VERSION-linux-armv7hf.tar.gz" -C /usr/local --strip-components=1 \
-	&& rm "node-v$NODE_VERSION-linux-armv7hf.tar.gz" \
+RUN curl -SLO "http://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-arm64.tar.gz" \
+	&& echo "27c9dd1c907f751f073f6d092b72a184a836aac7cac40fdf056edcc1987102b3  node-v6.13.1-linux-arm64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "node-v$NODE_VERSION-linux-arm64.tar.gz" -C /usr/local --strip-components=1 \
+	&& rm "node-v$NODE_VERSION-linux-arm64.tar.gz" \
 	&& npm config set unsafe-perm true -g --unsafe-perm \
 	&& rm -rf /tmp/*
 

--- a/node/kitra710/fedora/6.13/slim/Dockerfile
+++ b/node/kitra710/fedora/6.13/slim/Dockerfile
@@ -3,10 +3,10 @@ FROM resin/kitra710-fedora:latest
 
 ENV NODE_VERSION 6.13.1
 
-RUN curl -SLO "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/node-v$NODE_VERSION-linux-armv7hf.tar.gz" \
-	&& echo "79a93450c25edfbdc3b705f30269273511416ec9ff71d4e661702034267e8d75  node-v6.13.1-linux-armv7hf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "node-v$NODE_VERSION-linux-armv7hf.tar.gz" -C /usr/local --strip-components=1 \
-	&& rm "node-v$NODE_VERSION-linux-armv7hf.tar.gz" \
+RUN curl -SLO "http://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-arm64.tar.gz" \
+	&& echo "27c9dd1c907f751f073f6d092b72a184a836aac7cac40fdf056edcc1987102b3  node-v6.13.1-linux-arm64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "node-v$NODE_VERSION-linux-arm64.tar.gz" -C /usr/local --strip-components=1 \
+	&& rm "node-v$NODE_VERSION-linux-arm64.tar.gz" \
 	&& npm config set unsafe-perm true -g --unsafe-perm \
 	&& rm -rf /tmp/*
 

--- a/node/kitra710/fedora/7.10/24/Dockerfile
+++ b/node/kitra710/fedora/7.10/24/Dockerfile
@@ -3,10 +3,10 @@ FROM resin/kitra710-fedora-buildpack-deps:24
 
 ENV NODE_VERSION 7.10.1
 
-RUN curl -SLO "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/node-v$NODE_VERSION-linux-armv7hf.tar.gz" \
-	&& echo "819eff8b457d484d407fc11985d013ddae47568f4b3fb0e125bdddc0fba32875  node-v7.10.1-linux-armv7hf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "node-v$NODE_VERSION-linux-armv7hf.tar.gz" -C /usr/local --strip-components=1 \
-	&& rm "node-v$NODE_VERSION-linux-armv7hf.tar.gz" \
+RUN curl -SLO "http://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-arm64.tar.gz" \
+	&& echo "157be398d666b0753d219b9f4cdd3517d4335ddb2c3800242d3934f191932920  node-v7.10.1-linux-arm64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "node-v$NODE_VERSION-linux-arm64.tar.gz" -C /usr/local --strip-components=1 \
+	&& rm "node-v$NODE_VERSION-linux-arm64.tar.gz" \
 	&& npm config set unsafe-perm true -g --unsafe-perm \
 	&& rm -rf /tmp/*
 

--- a/node/kitra710/fedora/7.10/Dockerfile
+++ b/node/kitra710/fedora/7.10/Dockerfile
@@ -3,10 +3,10 @@ FROM resin/kitra710-fedora-buildpack-deps:latest
 
 ENV NODE_VERSION 7.10.1
 
-RUN curl -SLO "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/node-v$NODE_VERSION-linux-armv7hf.tar.gz" \
-	&& echo "819eff8b457d484d407fc11985d013ddae47568f4b3fb0e125bdddc0fba32875  node-v7.10.1-linux-armv7hf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "node-v$NODE_VERSION-linux-armv7hf.tar.gz" -C /usr/local --strip-components=1 \
-	&& rm "node-v$NODE_VERSION-linux-armv7hf.tar.gz" \
+RUN curl -SLO "http://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-arm64.tar.gz" \
+	&& echo "157be398d666b0753d219b9f4cdd3517d4335ddb2c3800242d3934f191932920  node-v7.10.1-linux-arm64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "node-v$NODE_VERSION-linux-arm64.tar.gz" -C /usr/local --strip-components=1 \
+	&& rm "node-v$NODE_VERSION-linux-arm64.tar.gz" \
 	&& npm config set unsafe-perm true -g --unsafe-perm \
 	&& rm -rf /tmp/*
 

--- a/node/kitra710/fedora/7.10/slim/Dockerfile
+++ b/node/kitra710/fedora/7.10/slim/Dockerfile
@@ -3,10 +3,10 @@ FROM resin/kitra710-fedora:latest
 
 ENV NODE_VERSION 7.10.1
 
-RUN curl -SLO "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/node-v$NODE_VERSION-linux-armv7hf.tar.gz" \
-	&& echo "819eff8b457d484d407fc11985d013ddae47568f4b3fb0e125bdddc0fba32875  node-v7.10.1-linux-armv7hf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "node-v$NODE_VERSION-linux-armv7hf.tar.gz" -C /usr/local --strip-components=1 \
-	&& rm "node-v$NODE_VERSION-linux-armv7hf.tar.gz" \
+RUN curl -SLO "http://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-arm64.tar.gz" \
+	&& echo "157be398d666b0753d219b9f4cdd3517d4335ddb2c3800242d3934f191932920  node-v7.10.1-linux-arm64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "node-v$NODE_VERSION-linux-arm64.tar.gz" -C /usr/local --strip-components=1 \
+	&& rm "node-v$NODE_VERSION-linux-arm64.tar.gz" \
 	&& npm config set unsafe-perm true -g --unsafe-perm \
 	&& rm -rf /tmp/*
 

--- a/node/kitra710/fedora/8.9/24/Dockerfile
+++ b/node/kitra710/fedora/8.9/24/Dockerfile
@@ -3,10 +3,10 @@ FROM resin/kitra710-fedora-buildpack-deps:24
 
 ENV NODE_VERSION 8.9.4
 
-RUN curl -SLO "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/node-v$NODE_VERSION-linux-armv7hf.tar.gz" \
-	&& echo "9a5b8591c9884ee88df2b5925f60ae2b9347579ce6012830f2a1e66a7365ed5a  node-v8.9.4-linux-armv7hf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "node-v$NODE_VERSION-linux-armv7hf.tar.gz" -C /usr/local --strip-components=1 \
-	&& rm "node-v$NODE_VERSION-linux-armv7hf.tar.gz" \
+RUN curl -SLO "http://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-arm64.tar.gz" \
+	&& echo "2b133c7d23033fbc2419e66fc08bba35c427a97aba83ed6848b6b4678c0cac65  node-v8.9.4-linux-arm64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "node-v$NODE_VERSION-linux-arm64.tar.gz" -C /usr/local --strip-components=1 \
+	&& rm "node-v$NODE_VERSION-linux-arm64.tar.gz" \
 	&& npm config set unsafe-perm true -g --unsafe-perm \
 	&& rm -rf /tmp/*
 

--- a/node/kitra710/fedora/8.9/Dockerfile
+++ b/node/kitra710/fedora/8.9/Dockerfile
@@ -3,10 +3,10 @@ FROM resin/kitra710-fedora-buildpack-deps:latest
 
 ENV NODE_VERSION 8.9.4
 
-RUN curl -SLO "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/node-v$NODE_VERSION-linux-armv7hf.tar.gz" \
-	&& echo "9a5b8591c9884ee88df2b5925f60ae2b9347579ce6012830f2a1e66a7365ed5a  node-v8.9.4-linux-armv7hf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "node-v$NODE_VERSION-linux-armv7hf.tar.gz" -C /usr/local --strip-components=1 \
-	&& rm "node-v$NODE_VERSION-linux-armv7hf.tar.gz" \
+RUN curl -SLO "http://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-arm64.tar.gz" \
+	&& echo "2b133c7d23033fbc2419e66fc08bba35c427a97aba83ed6848b6b4678c0cac65  node-v8.9.4-linux-arm64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "node-v$NODE_VERSION-linux-arm64.tar.gz" -C /usr/local --strip-components=1 \
+	&& rm "node-v$NODE_VERSION-linux-arm64.tar.gz" \
 	&& npm config set unsafe-perm true -g --unsafe-perm \
 	&& rm -rf /tmp/*
 

--- a/node/kitra710/fedora/8.9/slim/Dockerfile
+++ b/node/kitra710/fedora/8.9/slim/Dockerfile
@@ -3,10 +3,10 @@ FROM resin/kitra710-fedora:latest
 
 ENV NODE_VERSION 8.9.4
 
-RUN curl -SLO "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/node-v$NODE_VERSION-linux-armv7hf.tar.gz" \
-	&& echo "9a5b8591c9884ee88df2b5925f60ae2b9347579ce6012830f2a1e66a7365ed5a  node-v8.9.4-linux-armv7hf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "node-v$NODE_VERSION-linux-armv7hf.tar.gz" -C /usr/local --strip-components=1 \
-	&& rm "node-v$NODE_VERSION-linux-armv7hf.tar.gz" \
+RUN curl -SLO "http://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-arm64.tar.gz" \
+	&& echo "2b133c7d23033fbc2419e66fc08bba35c427a97aba83ed6848b6b4678c0cac65  node-v8.9.4-linux-arm64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "node-v$NODE_VERSION-linux-arm64.tar.gz" -C /usr/local --strip-components=1 \
+	&& rm "node-v$NODE_VERSION-linux-arm64.tar.gz" \
 	&& npm config set unsafe-perm true -g --unsafe-perm \
 	&& rm -rf /tmp/*
 

--- a/node/kitra710/fedora/9.5/24/Dockerfile
+++ b/node/kitra710/fedora/9.5/24/Dockerfile
@@ -3,10 +3,10 @@ FROM resin/kitra710-fedora-buildpack-deps:24
 
 ENV NODE_VERSION 9.5.0
 
-RUN curl -SLO "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/node-v$NODE_VERSION-linux-armv7hf.tar.gz" \
-	&& echo "6408a233122cd408f081cbd2e4e79d6c46f653e043dc575a675d91493e9843be  node-v9.5.0-linux-armv7hf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "node-v$NODE_VERSION-linux-armv7hf.tar.gz" -C /usr/local --strip-components=1 \
-	&& rm "node-v$NODE_VERSION-linux-armv7hf.tar.gz" \
+RUN curl -SLO "http://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-arm64.tar.gz" \
+	&& echo "08924ad820d6322e17cc0fbbc365000b76408a4f17c3ed3169b44d8c7448a617  node-v9.5.0-linux-arm64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "node-v$NODE_VERSION-linux-arm64.tar.gz" -C /usr/local --strip-components=1 \
+	&& rm "node-v$NODE_VERSION-linux-arm64.tar.gz" \
 	&& npm config set unsafe-perm true -g --unsafe-perm \
 	&& rm -rf /tmp/*
 

--- a/node/kitra710/fedora/9.5/Dockerfile
+++ b/node/kitra710/fedora/9.5/Dockerfile
@@ -3,10 +3,10 @@ FROM resin/kitra710-fedora-buildpack-deps:latest
 
 ENV NODE_VERSION 9.5.0
 
-RUN curl -SLO "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/node-v$NODE_VERSION-linux-armv7hf.tar.gz" \
-	&& echo "6408a233122cd408f081cbd2e4e79d6c46f653e043dc575a675d91493e9843be  node-v9.5.0-linux-armv7hf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "node-v$NODE_VERSION-linux-armv7hf.tar.gz" -C /usr/local --strip-components=1 \
-	&& rm "node-v$NODE_VERSION-linux-armv7hf.tar.gz" \
+RUN curl -SLO "http://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-arm64.tar.gz" \
+	&& echo "08924ad820d6322e17cc0fbbc365000b76408a4f17c3ed3169b44d8c7448a617  node-v9.5.0-linux-arm64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "node-v$NODE_VERSION-linux-arm64.tar.gz" -C /usr/local --strip-components=1 \
+	&& rm "node-v$NODE_VERSION-linux-arm64.tar.gz" \
 	&& npm config set unsafe-perm true -g --unsafe-perm \
 	&& rm -rf /tmp/*
 

--- a/node/kitra710/fedora/9.5/slim/Dockerfile
+++ b/node/kitra710/fedora/9.5/slim/Dockerfile
@@ -3,10 +3,10 @@ FROM resin/kitra710-fedora:latest
 
 ENV NODE_VERSION 9.5.0
 
-RUN curl -SLO "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/node-v$NODE_VERSION-linux-armv7hf.tar.gz" \
-	&& echo "6408a233122cd408f081cbd2e4e79d6c46f653e043dc575a675d91493e9843be  node-v9.5.0-linux-armv7hf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "node-v$NODE_VERSION-linux-armv7hf.tar.gz" -C /usr/local --strip-components=1 \
-	&& rm "node-v$NODE_VERSION-linux-armv7hf.tar.gz" \
+RUN curl -SLO "http://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-arm64.tar.gz" \
+	&& echo "08924ad820d6322e17cc0fbbc365000b76408a4f17c3ed3169b44d8c7448a617  node-v9.5.0-linux-arm64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "node-v$NODE_VERSION-linux-arm64.tar.gz" -C /usr/local --strip-components=1 \
+	&& rm "node-v$NODE_VERSION-linux-arm64.tar.gz" \
 	&& npm config set unsafe-perm true -g --unsafe-perm \
 	&& rm -rf /tmp/*
 

--- a/openjdk/generate-dockerfile.sh
+++ b/openjdk/generate-dockerfile.sh
@@ -168,12 +168,6 @@ for target in $targets; do
 		'artik10')
 			targetArch='armhf'
 		;;
-		'artik710')
-			targetArch='armhf'
-		;;
-		'kitra710')
-			targetArch='armhf'
-		;;
 		'kitra520')
 			targetArch='armhf'
 		;;
@@ -183,7 +177,7 @@ for target in $targets; do
 		'ccon-01')
 			targetArch='armhf'
 		;;
-		'jetson-tx2'|'jetson-tx1')
+		'jetson-tx2'|'jetson-tx1'|'kitra710'|'artik710')
 			targetArch='armhf'
 		;;
 		esac

--- a/python/artik710/alpine/2.7/Dockerfile
+++ b/python/artik710/alpine/2.7/Dockerfile
@@ -30,10 +30,10 @@ ENV SETUPTOOLS_VERSION 34.3.3
 ENV SSL_CERT_FILE /etc/ssl/certs/ca-certificates.crt
 
 RUN set -x \
-	&& curl -SLO "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/Python-$PYTHON_VERSION.linux-alpine-armhf.tar.gz" \
-	&& echo "9867d42862f615460edce8f0ead39d8748f857023fb86cb06884e1fbc3d8beb4  Python-2.7.14.linux-alpine-armhf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "Python-$PYTHON_VERSION.linux-alpine-armhf.tar.gz" --strip-components=1 \
-	&& rm -rf "Python-$PYTHON_VERSION.linux-alpine-armhf.tar.gz" \
+	&& curl -SLO "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/Python-$PYTHON_VERSION.linux-alpine-aarch64.tar.gz" \
+	&& echo "a93f6a0ea8affa6933fc8f53f8d0293b4157357dec8948997ce6801cadeb4734  Python-2.7.14.linux-alpine-aarch64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "Python-$PYTHON_VERSION.linux-alpine-aarch64.tar.gz" --strip-components=1 \
+	&& rm -rf "Python-$PYTHON_VERSION.linux-alpine-aarch64.tar.gz" \
 	&& if [ ! -e /usr/local/bin/pip ]; then : \
 		&& curl -SLO "https://raw.githubusercontent.com/pypa/get-pip/430ba37776ae2ad89f794c7a43b90dc23bac334c/get-pip.py" \
 		&& echo "19dae841a150c86e2a09d475b5eb0602861f2a5b7761ec268049a662dbd2bd0c  get-pip.py" | sha256sum -c - \

--- a/python/artik710/alpine/2.7/edge/Dockerfile
+++ b/python/artik710/alpine/2.7/edge/Dockerfile
@@ -30,10 +30,10 @@ ENV SETUPTOOLS_VERSION 34.3.3
 ENV SSL_CERT_FILE /etc/ssl/certs/ca-certificates.crt
 
 RUN set -x \
-	&& curl -SLO "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/Python-$PYTHON_VERSION.linux-alpine-armhf.tar.gz" \
-	&& echo "9867d42862f615460edce8f0ead39d8748f857023fb86cb06884e1fbc3d8beb4  Python-2.7.14.linux-alpine-armhf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "Python-$PYTHON_VERSION.linux-alpine-armhf.tar.gz" --strip-components=1 \
-	&& rm -rf "Python-$PYTHON_VERSION.linux-alpine-armhf.tar.gz" \
+	&& curl -SLO "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/Python-$PYTHON_VERSION.linux-alpine-aarch64.tar.gz" \
+	&& echo "a93f6a0ea8affa6933fc8f53f8d0293b4157357dec8948997ce6801cadeb4734  Python-2.7.14.linux-alpine-aarch64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "Python-$PYTHON_VERSION.linux-alpine-aarch64.tar.gz" --strip-components=1 \
+	&& rm -rf "Python-$PYTHON_VERSION.linux-alpine-aarch64.tar.gz" \
 	&& if [ ! -e /usr/local/bin/pip ]; then : \
 		&& curl -SLO "https://raw.githubusercontent.com/pypa/get-pip/430ba37776ae2ad89f794c7a43b90dc23bac334c/get-pip.py" \
 		&& echo "19dae841a150c86e2a09d475b5eb0602861f2a5b7761ec268049a662dbd2bd0c  get-pip.py" | sha256sum -c - \

--- a/python/artik710/alpine/2.7/slim/Dockerfile
+++ b/python/artik710/alpine/2.7/slim/Dockerfile
@@ -37,10 +37,10 @@ RUN set -x \
 		curl \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
-	&& curl -SLO "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/Python-$PYTHON_VERSION.linux-alpine-armhf.tar.gz" \
-	&& echo "9867d42862f615460edce8f0ead39d8748f857023fb86cb06884e1fbc3d8beb4  Python-2.7.14.linux-alpine-armhf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "Python-$PYTHON_VERSION.linux-alpine-armhf.tar.gz" --strip-components=1 \
-	&& rm -rf "Python-$PYTHON_VERSION.linux-alpine-armhf.tar.gz" \
+	&& curl -SLO "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/Python-$PYTHON_VERSION.linux-alpine-aarch64.tar.gz" \
+	&& echo "a93f6a0ea8affa6933fc8f53f8d0293b4157357dec8948997ce6801cadeb4734  Python-2.7.14.linux-alpine-aarch64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "Python-$PYTHON_VERSION.linux-alpine-aarch64.tar.gz" --strip-components=1 \
+	&& rm -rf "Python-$PYTHON_VERSION.linux-alpine-aarch64.tar.gz" \
 	&& if [ ! -e /usr/local/bin/pip ]; then : \
 		&& curl -SLO "https://raw.githubusercontent.com/pypa/get-pip/430ba37776ae2ad89f794c7a43b90dc23bac334c/get-pip.py" \
 		&& echo "19dae841a150c86e2a09d475b5eb0602861f2a5b7761ec268049a662dbd2bd0c  get-pip.py" | sha256sum -c - \

--- a/python/artik710/alpine/3.3/Dockerfile
+++ b/python/artik710/alpine/3.3/Dockerfile
@@ -30,10 +30,10 @@ ENV SETUPTOOLS_VERSION 34.3.3
 ENV SSL_CERT_FILE /etc/ssl/certs/ca-certificates.crt
 
 RUN set -x \
-	&& curl -SLO "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/Python-$PYTHON_VERSION.linux-alpine-armhf.tar.gz" \
-	&& echo "ee2bee62538584589609361f87ac79d5eeb2b1a2c3d5f625845ac8511074441f  Python-3.3.7.linux-alpine-armhf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "Python-$PYTHON_VERSION.linux-alpine-armhf.tar.gz" --strip-components=1 \
-	&& rm -rf "Python-$PYTHON_VERSION.linux-alpine-armhf.tar.gz" \
+	&& curl -SLO "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/Python-$PYTHON_VERSION.linux-alpine-aarch64.tar.gz" \
+	&& echo "3500ae3502346b53281e54aaacb6b40e38c6fcaf5166dcde8796877648372843  Python-3.3.7.linux-alpine-aarch64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "Python-$PYTHON_VERSION.linux-alpine-aarch64.tar.gz" --strip-components=1 \
+	&& rm -rf "Python-$PYTHON_VERSION.linux-alpine-aarch64.tar.gz" \
 	&& if [ ! -e /usr/local/bin/pip3 ]; then : \
 		&& curl -SLO "https://raw.githubusercontent.com/pypa/get-pip/430ba37776ae2ad89f794c7a43b90dc23bac334c/get-pip.py" \
 		&& echo "19dae841a150c86e2a09d475b5eb0602861f2a5b7761ec268049a662dbd2bd0c  get-pip.py" | sha256sum -c - \

--- a/python/artik710/alpine/3.3/edge/Dockerfile
+++ b/python/artik710/alpine/3.3/edge/Dockerfile
@@ -30,10 +30,10 @@ ENV SETUPTOOLS_VERSION 34.3.3
 ENV SSL_CERT_FILE /etc/ssl/certs/ca-certificates.crt
 
 RUN set -x \
-	&& curl -SLO "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/Python-$PYTHON_VERSION.linux-alpine-armhf.tar.gz" \
-	&& echo "ee2bee62538584589609361f87ac79d5eeb2b1a2c3d5f625845ac8511074441f  Python-3.3.7.linux-alpine-armhf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "Python-$PYTHON_VERSION.linux-alpine-armhf.tar.gz" --strip-components=1 \
-	&& rm -rf "Python-$PYTHON_VERSION.linux-alpine-armhf.tar.gz" \
+	&& curl -SLO "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/Python-$PYTHON_VERSION.linux-alpine-aarch64.tar.gz" \
+	&& echo "3500ae3502346b53281e54aaacb6b40e38c6fcaf5166dcde8796877648372843  Python-3.3.7.linux-alpine-aarch64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "Python-$PYTHON_VERSION.linux-alpine-aarch64.tar.gz" --strip-components=1 \
+	&& rm -rf "Python-$PYTHON_VERSION.linux-alpine-aarch64.tar.gz" \
 	&& if [ ! -e /usr/local/bin/pip3 ]; then : \
 		&& curl -SLO "https://raw.githubusercontent.com/pypa/get-pip/430ba37776ae2ad89f794c7a43b90dc23bac334c/get-pip.py" \
 		&& echo "19dae841a150c86e2a09d475b5eb0602861f2a5b7761ec268049a662dbd2bd0c  get-pip.py" | sha256sum -c - \

--- a/python/artik710/alpine/3.3/slim/Dockerfile
+++ b/python/artik710/alpine/3.3/slim/Dockerfile
@@ -37,10 +37,10 @@ RUN set -x \
 		curl \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
-	&& curl -SLO "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/Python-$PYTHON_VERSION.linux-alpine-armhf.tar.gz" \
-	&& echo "ee2bee62538584589609361f87ac79d5eeb2b1a2c3d5f625845ac8511074441f  Python-3.3.7.linux-alpine-armhf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "Python-$PYTHON_VERSION.linux-alpine-armhf.tar.gz" --strip-components=1 \
-	&& rm -rf "Python-$PYTHON_VERSION.linux-alpine-armhf.tar.gz" \
+	&& curl -SLO "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/Python-$PYTHON_VERSION.linux-alpine-aarch64.tar.gz" \
+	&& echo "3500ae3502346b53281e54aaacb6b40e38c6fcaf5166dcde8796877648372843  Python-3.3.7.linux-alpine-aarch64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "Python-$PYTHON_VERSION.linux-alpine-aarch64.tar.gz" --strip-components=1 \
+	&& rm -rf "Python-$PYTHON_VERSION.linux-alpine-aarch64.tar.gz" \
 	&& if [ ! -e /usr/local/bin/pip3 ]; then : \
 		&& curl -SLO "https://raw.githubusercontent.com/pypa/get-pip/430ba37776ae2ad89f794c7a43b90dc23bac334c/get-pip.py" \
 		&& echo "19dae841a150c86e2a09d475b5eb0602861f2a5b7761ec268049a662dbd2bd0c  get-pip.py" | sha256sum -c - \

--- a/python/artik710/alpine/3.4/Dockerfile
+++ b/python/artik710/alpine/3.4/Dockerfile
@@ -30,10 +30,10 @@ ENV SETUPTOOLS_VERSION 34.3.3
 ENV SSL_CERT_FILE /etc/ssl/certs/ca-certificates.crt
 
 RUN set -x \
-	&& curl -SLO "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/Python-$PYTHON_VERSION.linux-alpine-armhf.tar.gz" \
-	&& echo "ee29c4846b52b82c2ad6245f46e64ebc76506845e8470e85abdf1827d82aff67  Python-3.4.8.linux-alpine-armhf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "Python-$PYTHON_VERSION.linux-alpine-armhf.tar.gz" --strip-components=1 \
-	&& rm -rf "Python-$PYTHON_VERSION.linux-alpine-armhf.tar.gz" \
+	&& curl -SLO "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/Python-$PYTHON_VERSION.linux-alpine-aarch64.tar.gz" \
+	&& echo "be04ba9fdf5590fd02789ebb7686c66a6bac6c6c24a8208fa690701443bd86ab  Python-3.4.8.linux-alpine-aarch64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "Python-$PYTHON_VERSION.linux-alpine-aarch64.tar.gz" --strip-components=1 \
+	&& rm -rf "Python-$PYTHON_VERSION.linux-alpine-aarch64.tar.gz" \
 	&& if [ ! -e /usr/local/bin/pip3 ]; then : \
 		&& curl -SLO "https://raw.githubusercontent.com/pypa/get-pip/430ba37776ae2ad89f794c7a43b90dc23bac334c/get-pip.py" \
 		&& echo "19dae841a150c86e2a09d475b5eb0602861f2a5b7761ec268049a662dbd2bd0c  get-pip.py" | sha256sum -c - \

--- a/python/artik710/alpine/3.4/edge/Dockerfile
+++ b/python/artik710/alpine/3.4/edge/Dockerfile
@@ -30,10 +30,10 @@ ENV SETUPTOOLS_VERSION 34.3.3
 ENV SSL_CERT_FILE /etc/ssl/certs/ca-certificates.crt
 
 RUN set -x \
-	&& curl -SLO "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/Python-$PYTHON_VERSION.linux-alpine-armhf.tar.gz" \
-	&& echo "ee29c4846b52b82c2ad6245f46e64ebc76506845e8470e85abdf1827d82aff67  Python-3.4.8.linux-alpine-armhf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "Python-$PYTHON_VERSION.linux-alpine-armhf.tar.gz" --strip-components=1 \
-	&& rm -rf "Python-$PYTHON_VERSION.linux-alpine-armhf.tar.gz" \
+	&& curl -SLO "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/Python-$PYTHON_VERSION.linux-alpine-aarch64.tar.gz" \
+	&& echo "be04ba9fdf5590fd02789ebb7686c66a6bac6c6c24a8208fa690701443bd86ab  Python-3.4.8.linux-alpine-aarch64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "Python-$PYTHON_VERSION.linux-alpine-aarch64.tar.gz" --strip-components=1 \
+	&& rm -rf "Python-$PYTHON_VERSION.linux-alpine-aarch64.tar.gz" \
 	&& if [ ! -e /usr/local/bin/pip3 ]; then : \
 		&& curl -SLO "https://raw.githubusercontent.com/pypa/get-pip/430ba37776ae2ad89f794c7a43b90dc23bac334c/get-pip.py" \
 		&& echo "19dae841a150c86e2a09d475b5eb0602861f2a5b7761ec268049a662dbd2bd0c  get-pip.py" | sha256sum -c - \

--- a/python/artik710/alpine/3.4/slim/Dockerfile
+++ b/python/artik710/alpine/3.4/slim/Dockerfile
@@ -37,10 +37,10 @@ RUN set -x \
 		curl \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
-	&& curl -SLO "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/Python-$PYTHON_VERSION.linux-alpine-armhf.tar.gz" \
-	&& echo "ee29c4846b52b82c2ad6245f46e64ebc76506845e8470e85abdf1827d82aff67  Python-3.4.8.linux-alpine-armhf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "Python-$PYTHON_VERSION.linux-alpine-armhf.tar.gz" --strip-components=1 \
-	&& rm -rf "Python-$PYTHON_VERSION.linux-alpine-armhf.tar.gz" \
+	&& curl -SLO "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/Python-$PYTHON_VERSION.linux-alpine-aarch64.tar.gz" \
+	&& echo "be04ba9fdf5590fd02789ebb7686c66a6bac6c6c24a8208fa690701443bd86ab  Python-3.4.8.linux-alpine-aarch64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "Python-$PYTHON_VERSION.linux-alpine-aarch64.tar.gz" --strip-components=1 \
+	&& rm -rf "Python-$PYTHON_VERSION.linux-alpine-aarch64.tar.gz" \
 	&& if [ ! -e /usr/local/bin/pip3 ]; then : \
 		&& curl -SLO "https://raw.githubusercontent.com/pypa/get-pip/430ba37776ae2ad89f794c7a43b90dc23bac334c/get-pip.py" \
 		&& echo "19dae841a150c86e2a09d475b5eb0602861f2a5b7761ec268049a662dbd2bd0c  get-pip.py" | sha256sum -c - \

--- a/python/artik710/alpine/3.5/Dockerfile
+++ b/python/artik710/alpine/3.5/Dockerfile
@@ -30,10 +30,10 @@ ENV SETUPTOOLS_VERSION 34.3.3
 ENV SSL_CERT_FILE /etc/ssl/certs/ca-certificates.crt
 
 RUN set -x \
-	&& curl -SLO "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/Python-$PYTHON_VERSION.linux-alpine-armhf.tar.gz" \
-	&& echo "e0dfbc41958ccc5092c58527254bc439d87ef4ba905ecd4c312ea20230ecfddc  Python-3.5.5.linux-alpine-armhf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "Python-$PYTHON_VERSION.linux-alpine-armhf.tar.gz" --strip-components=1 \
-	&& rm -rf "Python-$PYTHON_VERSION.linux-alpine-armhf.tar.gz" \
+	&& curl -SLO "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/Python-$PYTHON_VERSION.linux-alpine-aarch64.tar.gz" \
+	&& echo "895cff316dd17c89f350a4861b8adeac3eee1c1522b3b55bbe18bcdb5ad51e91  Python-3.5.5.linux-alpine-aarch64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "Python-$PYTHON_VERSION.linux-alpine-aarch64.tar.gz" --strip-components=1 \
+	&& rm -rf "Python-$PYTHON_VERSION.linux-alpine-aarch64.tar.gz" \
 	&& if [ ! -e /usr/local/bin/pip3 ]; then : \
 		&& curl -SLO "https://raw.githubusercontent.com/pypa/get-pip/430ba37776ae2ad89f794c7a43b90dc23bac334c/get-pip.py" \
 		&& echo "19dae841a150c86e2a09d475b5eb0602861f2a5b7761ec268049a662dbd2bd0c  get-pip.py" | sha256sum -c - \

--- a/python/artik710/alpine/3.5/edge/Dockerfile
+++ b/python/artik710/alpine/3.5/edge/Dockerfile
@@ -30,10 +30,10 @@ ENV SETUPTOOLS_VERSION 34.3.3
 ENV SSL_CERT_FILE /etc/ssl/certs/ca-certificates.crt
 
 RUN set -x \
-	&& curl -SLO "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/Python-$PYTHON_VERSION.linux-alpine-armhf.tar.gz" \
-	&& echo "e0dfbc41958ccc5092c58527254bc439d87ef4ba905ecd4c312ea20230ecfddc  Python-3.5.5.linux-alpine-armhf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "Python-$PYTHON_VERSION.linux-alpine-armhf.tar.gz" --strip-components=1 \
-	&& rm -rf "Python-$PYTHON_VERSION.linux-alpine-armhf.tar.gz" \
+	&& curl -SLO "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/Python-$PYTHON_VERSION.linux-alpine-aarch64.tar.gz" \
+	&& echo "895cff316dd17c89f350a4861b8adeac3eee1c1522b3b55bbe18bcdb5ad51e91  Python-3.5.5.linux-alpine-aarch64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "Python-$PYTHON_VERSION.linux-alpine-aarch64.tar.gz" --strip-components=1 \
+	&& rm -rf "Python-$PYTHON_VERSION.linux-alpine-aarch64.tar.gz" \
 	&& if [ ! -e /usr/local/bin/pip3 ]; then : \
 		&& curl -SLO "https://raw.githubusercontent.com/pypa/get-pip/430ba37776ae2ad89f794c7a43b90dc23bac334c/get-pip.py" \
 		&& echo "19dae841a150c86e2a09d475b5eb0602861f2a5b7761ec268049a662dbd2bd0c  get-pip.py" | sha256sum -c - \

--- a/python/artik710/alpine/3.5/slim/Dockerfile
+++ b/python/artik710/alpine/3.5/slim/Dockerfile
@@ -37,10 +37,10 @@ RUN set -x \
 		curl \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
-	&& curl -SLO "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/Python-$PYTHON_VERSION.linux-alpine-armhf.tar.gz" \
-	&& echo "e0dfbc41958ccc5092c58527254bc439d87ef4ba905ecd4c312ea20230ecfddc  Python-3.5.5.linux-alpine-armhf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "Python-$PYTHON_VERSION.linux-alpine-armhf.tar.gz" --strip-components=1 \
-	&& rm -rf "Python-$PYTHON_VERSION.linux-alpine-armhf.tar.gz" \
+	&& curl -SLO "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/Python-$PYTHON_VERSION.linux-alpine-aarch64.tar.gz" \
+	&& echo "895cff316dd17c89f350a4861b8adeac3eee1c1522b3b55bbe18bcdb5ad51e91  Python-3.5.5.linux-alpine-aarch64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "Python-$PYTHON_VERSION.linux-alpine-aarch64.tar.gz" --strip-components=1 \
+	&& rm -rf "Python-$PYTHON_VERSION.linux-alpine-aarch64.tar.gz" \
 	&& if [ ! -e /usr/local/bin/pip3 ]; then : \
 		&& curl -SLO "https://raw.githubusercontent.com/pypa/get-pip/430ba37776ae2ad89f794c7a43b90dc23bac334c/get-pip.py" \
 		&& echo "19dae841a150c86e2a09d475b5eb0602861f2a5b7761ec268049a662dbd2bd0c  get-pip.py" | sha256sum -c - \

--- a/python/artik710/alpine/3.6/Dockerfile
+++ b/python/artik710/alpine/3.6/Dockerfile
@@ -30,10 +30,10 @@ ENV SETUPTOOLS_VERSION 34.3.3
 ENV SSL_CERT_FILE /etc/ssl/certs/ca-certificates.crt
 
 RUN set -x \
-	&& curl -SLO "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/Python-$PYTHON_VERSION.linux-alpine-armhf.tar.gz" \
-	&& echo "8b72a20a1190f79fc7ff950e3a75af8fc0dfcb3a63c9220b918264f8d984c837  Python-3.6.4.linux-alpine-armhf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "Python-$PYTHON_VERSION.linux-alpine-armhf.tar.gz" --strip-components=1 \
-	&& rm -rf "Python-$PYTHON_VERSION.linux-alpine-armhf.tar.gz" \
+	&& curl -SLO "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/Python-$PYTHON_VERSION.linux-alpine-aarch64.tar.gz" \
+	&& echo "c02489d4cf97fdf764c371265cb736af8b931fe7a3be04b0d82dbb6940940d2b  Python-3.6.4.linux-alpine-aarch64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "Python-$PYTHON_VERSION.linux-alpine-aarch64.tar.gz" --strip-components=1 \
+	&& rm -rf "Python-$PYTHON_VERSION.linux-alpine-aarch64.tar.gz" \
 	&& if [ ! -e /usr/local/bin/pip3 ]; then : \
 		&& curl -SLO "https://raw.githubusercontent.com/pypa/get-pip/430ba37776ae2ad89f794c7a43b90dc23bac334c/get-pip.py" \
 		&& echo "19dae841a150c86e2a09d475b5eb0602861f2a5b7761ec268049a662dbd2bd0c  get-pip.py" | sha256sum -c - \

--- a/python/artik710/alpine/3.6/edge/Dockerfile
+++ b/python/artik710/alpine/3.6/edge/Dockerfile
@@ -30,10 +30,10 @@ ENV SETUPTOOLS_VERSION 34.3.3
 ENV SSL_CERT_FILE /etc/ssl/certs/ca-certificates.crt
 
 RUN set -x \
-	&& curl -SLO "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/Python-$PYTHON_VERSION.linux-alpine-armhf.tar.gz" \
-	&& echo "8b72a20a1190f79fc7ff950e3a75af8fc0dfcb3a63c9220b918264f8d984c837  Python-3.6.4.linux-alpine-armhf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "Python-$PYTHON_VERSION.linux-alpine-armhf.tar.gz" --strip-components=1 \
-	&& rm -rf "Python-$PYTHON_VERSION.linux-alpine-armhf.tar.gz" \
+	&& curl -SLO "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/Python-$PYTHON_VERSION.linux-alpine-aarch64.tar.gz" \
+	&& echo "c02489d4cf97fdf764c371265cb736af8b931fe7a3be04b0d82dbb6940940d2b  Python-3.6.4.linux-alpine-aarch64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "Python-$PYTHON_VERSION.linux-alpine-aarch64.tar.gz" --strip-components=1 \
+	&& rm -rf "Python-$PYTHON_VERSION.linux-alpine-aarch64.tar.gz" \
 	&& if [ ! -e /usr/local/bin/pip3 ]; then : \
 		&& curl -SLO "https://raw.githubusercontent.com/pypa/get-pip/430ba37776ae2ad89f794c7a43b90dc23bac334c/get-pip.py" \
 		&& echo "19dae841a150c86e2a09d475b5eb0602861f2a5b7761ec268049a662dbd2bd0c  get-pip.py" | sha256sum -c - \

--- a/python/artik710/alpine/3.6/slim/Dockerfile
+++ b/python/artik710/alpine/3.6/slim/Dockerfile
@@ -37,10 +37,10 @@ RUN set -x \
 		curl \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
-	&& curl -SLO "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/Python-$PYTHON_VERSION.linux-alpine-armhf.tar.gz" \
-	&& echo "8b72a20a1190f79fc7ff950e3a75af8fc0dfcb3a63c9220b918264f8d984c837  Python-3.6.4.linux-alpine-armhf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "Python-$PYTHON_VERSION.linux-alpine-armhf.tar.gz" --strip-components=1 \
-	&& rm -rf "Python-$PYTHON_VERSION.linux-alpine-armhf.tar.gz" \
+	&& curl -SLO "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/Python-$PYTHON_VERSION.linux-alpine-aarch64.tar.gz" \
+	&& echo "c02489d4cf97fdf764c371265cb736af8b931fe7a3be04b0d82dbb6940940d2b  Python-3.6.4.linux-alpine-aarch64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "Python-$PYTHON_VERSION.linux-alpine-aarch64.tar.gz" --strip-components=1 \
+	&& rm -rf "Python-$PYTHON_VERSION.linux-alpine-aarch64.tar.gz" \
 	&& if [ ! -e /usr/local/bin/pip3 ]; then : \
 		&& curl -SLO "https://raw.githubusercontent.com/pypa/get-pip/430ba37776ae2ad89f794c7a43b90dc23bac334c/get-pip.py" \
 		&& echo "19dae841a150c86e2a09d475b5eb0602861f2a5b7761ec268049a662dbd2bd0c  get-pip.py" | sha256sum -c - \

--- a/python/artik710/debian/2.7/Dockerfile
+++ b/python/artik710/debian/2.7/Dockerfile
@@ -28,10 +28,10 @@ ENV PYTHON_PIP_VERSION 9.0.1
 ENV SETUPTOOLS_VERSION 34.3.3
 
 RUN set -x \
-	&& curl -SLO "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/Python-$PYTHON_VERSION.linux-armv7hf.tar.gz" \
-	&& echo "dc57b43159fb42c4cc7ea5ddd5791776a5fffe215d707912dededfff978c9475  Python-2.7.14.linux-armv7hf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "Python-$PYTHON_VERSION.linux-armv7hf.tar.gz" --strip-components=1 \
-	&& rm -rf "Python-$PYTHON_VERSION.linux-armv7hf.tar.gz" \
+	&& curl -SLO "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/Python-$PYTHON_VERSION.linux-aarch64.tar.gz" \
+	&& echo "12ec9f5d902c185d60c934eb38b614373d993017071880600ab5af813d2e3fb1  Python-2.7.14.linux-aarch64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "Python-$PYTHON_VERSION.linux-aarch64.tar.gz" --strip-components=1 \
+	&& rm -rf "Python-$PYTHON_VERSION.linux-aarch64.tar.gz" \
 	&& ldconfig \
 	&& if [ ! -e /usr/local/bin/pip ]; then : \
 		&& curl -SLO "https://raw.githubusercontent.com/pypa/get-pip/430ba37776ae2ad89f794c7a43b90dc23bac334c/get-pip.py" \

--- a/python/artik710/debian/2.7/slim/Dockerfile
+++ b/python/artik710/debian/2.7/slim/Dockerfile
@@ -32,10 +32,10 @@ RUN set -x \
 		curl \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
-	&& curl -SLO "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/Python-$PYTHON_VERSION.linux-armv7hf.tar.gz" \
-	&& echo "dc57b43159fb42c4cc7ea5ddd5791776a5fffe215d707912dededfff978c9475  Python-2.7.14.linux-armv7hf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "Python-$PYTHON_VERSION.linux-armv7hf.tar.gz" --strip-components=1 \
-	&& rm -rf "Python-$PYTHON_VERSION.linux-armv7hf.tar.gz" \
+	&& curl -SLO "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/Python-$PYTHON_VERSION.linux-aarch64.tar.gz" \
+	&& echo "12ec9f5d902c185d60c934eb38b614373d993017071880600ab5af813d2e3fb1  Python-2.7.14.linux-aarch64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "Python-$PYTHON_VERSION.linux-aarch64.tar.gz" --strip-components=1 \
+	&& rm -rf "Python-$PYTHON_VERSION.linux-aarch64.tar.gz" \
 	&& ldconfig \
 	&& if [ ! -e /usr/local/bin/pip ]; then : \
 		&& curl -SLO "https://raw.githubusercontent.com/pypa/get-pip/430ba37776ae2ad89f794c7a43b90dc23bac334c/get-pip.py" \

--- a/python/artik710/debian/2.7/wheezy/Dockerfile
+++ b/python/artik710/debian/2.7/wheezy/Dockerfile
@@ -28,10 +28,10 @@ ENV PYTHON_PIP_VERSION 9.0.1
 ENV SETUPTOOLS_VERSION 34.3.3
 
 RUN set -x \
-	&& curl -SLO "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/Python-$PYTHON_VERSION.linux-armv7hf.tar.gz" \
-	&& echo "dc57b43159fb42c4cc7ea5ddd5791776a5fffe215d707912dededfff978c9475  Python-2.7.14.linux-armv7hf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "Python-$PYTHON_VERSION.linux-armv7hf.tar.gz" --strip-components=1 \
-	&& rm -rf "Python-$PYTHON_VERSION.linux-armv7hf.tar.gz" \
+	&& curl -SLO "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/Python-$PYTHON_VERSION.linux-aarch64.tar.gz" \
+	&& echo "12ec9f5d902c185d60c934eb38b614373d993017071880600ab5af813d2e3fb1  Python-2.7.14.linux-aarch64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "Python-$PYTHON_VERSION.linux-aarch64.tar.gz" --strip-components=1 \
+	&& rm -rf "Python-$PYTHON_VERSION.linux-aarch64.tar.gz" \
 	&& ldconfig \
 	&& if [ ! -e /usr/local/bin/pip ]; then : \
 		&& curl -SLO "https://raw.githubusercontent.com/pypa/get-pip/430ba37776ae2ad89f794c7a43b90dc23bac334c/get-pip.py" \

--- a/python/artik710/debian/3.3/Dockerfile
+++ b/python/artik710/debian/3.3/Dockerfile
@@ -28,10 +28,10 @@ ENV PYTHON_PIP_VERSION 9.0.1
 ENV SETUPTOOLS_VERSION 34.3.3
 
 RUN set -x \
-	&& curl -SLO "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/Python-$PYTHON_VERSION.linux-armv7hf.tar.gz" \
-	&& echo "d6f5fac5ab145f0f0c19bea2f83838ac44145d2f70e61dab193c2e9e1efc59aa  Python-3.3.7.linux-armv7hf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "Python-$PYTHON_VERSION.linux-armv7hf.tar.gz" --strip-components=1 \
-	&& rm -rf "Python-$PYTHON_VERSION.linux-armv7hf.tar.gz" \
+	&& curl -SLO "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/Python-$PYTHON_VERSION.linux-aarch64.tar.gz" \
+	&& echo "c5694604efe341062cb6bde8b52f13ea80467b03fa9e7b6f002992ae44ce612e  Python-3.3.7.linux-aarch64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "Python-$PYTHON_VERSION.linux-aarch64.tar.gz" --strip-components=1 \
+	&& rm -rf "Python-$PYTHON_VERSION.linux-aarch64.tar.gz" \
 	&& ldconfig \
 	&& if [ ! -e /usr/local/bin/pip3 ]; then : \
 		&& curl -SLO "https://raw.githubusercontent.com/pypa/get-pip/430ba37776ae2ad89f794c7a43b90dc23bac334c/get-pip.py" \

--- a/python/artik710/debian/3.3/slim/Dockerfile
+++ b/python/artik710/debian/3.3/slim/Dockerfile
@@ -32,10 +32,10 @@ RUN set -x \
 		curl \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
-	&& curl -SLO "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/Python-$PYTHON_VERSION.linux-armv7hf.tar.gz" \
-	&& echo "d6f5fac5ab145f0f0c19bea2f83838ac44145d2f70e61dab193c2e9e1efc59aa  Python-3.3.7.linux-armv7hf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "Python-$PYTHON_VERSION.linux-armv7hf.tar.gz" --strip-components=1 \
-	&& rm -rf "Python-$PYTHON_VERSION.linux-armv7hf.tar.gz" \
+	&& curl -SLO "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/Python-$PYTHON_VERSION.linux-aarch64.tar.gz" \
+	&& echo "c5694604efe341062cb6bde8b52f13ea80467b03fa9e7b6f002992ae44ce612e  Python-3.3.7.linux-aarch64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "Python-$PYTHON_VERSION.linux-aarch64.tar.gz" --strip-components=1 \
+	&& rm -rf "Python-$PYTHON_VERSION.linux-aarch64.tar.gz" \
 	&& ldconfig \
 	&& if [ ! -e /usr/local/bin/pip3 ]; then : \
 		&& curl -SLO "https://raw.githubusercontent.com/pypa/get-pip/430ba37776ae2ad89f794c7a43b90dc23bac334c/get-pip.py" \

--- a/python/artik710/debian/3.3/wheezy/Dockerfile
+++ b/python/artik710/debian/3.3/wheezy/Dockerfile
@@ -28,10 +28,10 @@ ENV PYTHON_PIP_VERSION 9.0.1
 ENV SETUPTOOLS_VERSION 34.3.3
 
 RUN set -x \
-	&& curl -SLO "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/Python-$PYTHON_VERSION.linux-armv7hf.tar.gz" \
-	&& echo "d6f5fac5ab145f0f0c19bea2f83838ac44145d2f70e61dab193c2e9e1efc59aa  Python-3.3.7.linux-armv7hf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "Python-$PYTHON_VERSION.linux-armv7hf.tar.gz" --strip-components=1 \
-	&& rm -rf "Python-$PYTHON_VERSION.linux-armv7hf.tar.gz" \
+	&& curl -SLO "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/Python-$PYTHON_VERSION.linux-aarch64.tar.gz" \
+	&& echo "c5694604efe341062cb6bde8b52f13ea80467b03fa9e7b6f002992ae44ce612e  Python-3.3.7.linux-aarch64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "Python-$PYTHON_VERSION.linux-aarch64.tar.gz" --strip-components=1 \
+	&& rm -rf "Python-$PYTHON_VERSION.linux-aarch64.tar.gz" \
 	&& ldconfig \
 	&& if [ ! -e /usr/local/bin/pip3 ]; then : \
 		&& curl -SLO "https://raw.githubusercontent.com/pypa/get-pip/430ba37776ae2ad89f794c7a43b90dc23bac334c/get-pip.py" \

--- a/python/artik710/debian/3.4/Dockerfile
+++ b/python/artik710/debian/3.4/Dockerfile
@@ -28,10 +28,10 @@ ENV PYTHON_PIP_VERSION 9.0.1
 ENV SETUPTOOLS_VERSION 34.3.3
 
 RUN set -x \
-	&& curl -SLO "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/Python-$PYTHON_VERSION.linux-armv7hf.tar.gz" \
-	&& echo "ee9a38cbdc05a211f0136e382b36b3fbc96ea8186453ee1cbe66255707de6836  Python-3.4.8.linux-armv7hf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "Python-$PYTHON_VERSION.linux-armv7hf.tar.gz" --strip-components=1 \
-	&& rm -rf "Python-$PYTHON_VERSION.linux-armv7hf.tar.gz" \
+	&& curl -SLO "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/Python-$PYTHON_VERSION.linux-aarch64.tar.gz" \
+	&& echo "f131ca817d983aabc10451a012dae8902c983dd24453d3123fb48a3c47e9450c  Python-3.4.8.linux-aarch64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "Python-$PYTHON_VERSION.linux-aarch64.tar.gz" --strip-components=1 \
+	&& rm -rf "Python-$PYTHON_VERSION.linux-aarch64.tar.gz" \
 	&& ldconfig \
 	&& if [ ! -e /usr/local/bin/pip3 ]; then : \
 		&& curl -SLO "https://raw.githubusercontent.com/pypa/get-pip/430ba37776ae2ad89f794c7a43b90dc23bac334c/get-pip.py" \

--- a/python/artik710/debian/3.4/slim/Dockerfile
+++ b/python/artik710/debian/3.4/slim/Dockerfile
@@ -32,10 +32,10 @@ RUN set -x \
 		curl \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
-	&& curl -SLO "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/Python-$PYTHON_VERSION.linux-armv7hf.tar.gz" \
-	&& echo "ee9a38cbdc05a211f0136e382b36b3fbc96ea8186453ee1cbe66255707de6836  Python-3.4.8.linux-armv7hf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "Python-$PYTHON_VERSION.linux-armv7hf.tar.gz" --strip-components=1 \
-	&& rm -rf "Python-$PYTHON_VERSION.linux-armv7hf.tar.gz" \
+	&& curl -SLO "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/Python-$PYTHON_VERSION.linux-aarch64.tar.gz" \
+	&& echo "f131ca817d983aabc10451a012dae8902c983dd24453d3123fb48a3c47e9450c  Python-3.4.8.linux-aarch64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "Python-$PYTHON_VERSION.linux-aarch64.tar.gz" --strip-components=1 \
+	&& rm -rf "Python-$PYTHON_VERSION.linux-aarch64.tar.gz" \
 	&& ldconfig \
 	&& if [ ! -e /usr/local/bin/pip3 ]; then : \
 		&& curl -SLO "https://raw.githubusercontent.com/pypa/get-pip/430ba37776ae2ad89f794c7a43b90dc23bac334c/get-pip.py" \

--- a/python/artik710/debian/3.4/wheezy/Dockerfile
+++ b/python/artik710/debian/3.4/wheezy/Dockerfile
@@ -28,10 +28,10 @@ ENV PYTHON_PIP_VERSION 9.0.1
 ENV SETUPTOOLS_VERSION 34.3.3
 
 RUN set -x \
-	&& curl -SLO "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/Python-$PYTHON_VERSION.linux-armv7hf.tar.gz" \
-	&& echo "ee9a38cbdc05a211f0136e382b36b3fbc96ea8186453ee1cbe66255707de6836  Python-3.4.8.linux-armv7hf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "Python-$PYTHON_VERSION.linux-armv7hf.tar.gz" --strip-components=1 \
-	&& rm -rf "Python-$PYTHON_VERSION.linux-armv7hf.tar.gz" \
+	&& curl -SLO "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/Python-$PYTHON_VERSION.linux-aarch64.tar.gz" \
+	&& echo "f131ca817d983aabc10451a012dae8902c983dd24453d3123fb48a3c47e9450c  Python-3.4.8.linux-aarch64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "Python-$PYTHON_VERSION.linux-aarch64.tar.gz" --strip-components=1 \
+	&& rm -rf "Python-$PYTHON_VERSION.linux-aarch64.tar.gz" \
 	&& ldconfig \
 	&& if [ ! -e /usr/local/bin/pip3 ]; then : \
 		&& curl -SLO "https://raw.githubusercontent.com/pypa/get-pip/430ba37776ae2ad89f794c7a43b90dc23bac334c/get-pip.py" \

--- a/python/artik710/debian/3.5/Dockerfile
+++ b/python/artik710/debian/3.5/Dockerfile
@@ -28,10 +28,10 @@ ENV PYTHON_PIP_VERSION 9.0.1
 ENV SETUPTOOLS_VERSION 34.3.3
 
 RUN set -x \
-	&& curl -SLO "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/Python-$PYTHON_VERSION.linux-armv7hf.tar.gz" \
-	&& echo "44d5922736ba415e80c267b74e8e801a18c0404427a49f89286189dee8dee293  Python-3.5.5.linux-armv7hf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "Python-$PYTHON_VERSION.linux-armv7hf.tar.gz" --strip-components=1 \
-	&& rm -rf "Python-$PYTHON_VERSION.linux-armv7hf.tar.gz" \
+	&& curl -SLO "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/Python-$PYTHON_VERSION.linux-aarch64.tar.gz" \
+	&& echo "ffb4700b85d85af13b24bd62cc518eace78e96be6b2c4d400f6c96ad58a18b82  Python-3.5.5.linux-aarch64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "Python-$PYTHON_VERSION.linux-aarch64.tar.gz" --strip-components=1 \
+	&& rm -rf "Python-$PYTHON_VERSION.linux-aarch64.tar.gz" \
 	&& ldconfig \
 	&& if [ ! -e /usr/local/bin/pip3 ]; then : \
 		&& curl -SLO "https://raw.githubusercontent.com/pypa/get-pip/430ba37776ae2ad89f794c7a43b90dc23bac334c/get-pip.py" \

--- a/python/artik710/debian/3.5/slim/Dockerfile
+++ b/python/artik710/debian/3.5/slim/Dockerfile
@@ -32,10 +32,10 @@ RUN set -x \
 		curl \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
-	&& curl -SLO "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/Python-$PYTHON_VERSION.linux-armv7hf.tar.gz" \
-	&& echo "44d5922736ba415e80c267b74e8e801a18c0404427a49f89286189dee8dee293  Python-3.5.5.linux-armv7hf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "Python-$PYTHON_VERSION.linux-armv7hf.tar.gz" --strip-components=1 \
-	&& rm -rf "Python-$PYTHON_VERSION.linux-armv7hf.tar.gz" \
+	&& curl -SLO "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/Python-$PYTHON_VERSION.linux-aarch64.tar.gz" \
+	&& echo "ffb4700b85d85af13b24bd62cc518eace78e96be6b2c4d400f6c96ad58a18b82  Python-3.5.5.linux-aarch64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "Python-$PYTHON_VERSION.linux-aarch64.tar.gz" --strip-components=1 \
+	&& rm -rf "Python-$PYTHON_VERSION.linux-aarch64.tar.gz" \
 	&& ldconfig \
 	&& if [ ! -e /usr/local/bin/pip3 ]; then : \
 		&& curl -SLO "https://raw.githubusercontent.com/pypa/get-pip/430ba37776ae2ad89f794c7a43b90dc23bac334c/get-pip.py" \

--- a/python/artik710/debian/3.5/wheezy/Dockerfile
+++ b/python/artik710/debian/3.5/wheezy/Dockerfile
@@ -28,10 +28,10 @@ ENV PYTHON_PIP_VERSION 9.0.1
 ENV SETUPTOOLS_VERSION 34.3.3
 
 RUN set -x \
-	&& curl -SLO "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/Python-$PYTHON_VERSION.linux-armv7hf.tar.gz" \
-	&& echo "44d5922736ba415e80c267b74e8e801a18c0404427a49f89286189dee8dee293  Python-3.5.5.linux-armv7hf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "Python-$PYTHON_VERSION.linux-armv7hf.tar.gz" --strip-components=1 \
-	&& rm -rf "Python-$PYTHON_VERSION.linux-armv7hf.tar.gz" \
+	&& curl -SLO "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/Python-$PYTHON_VERSION.linux-aarch64.tar.gz" \
+	&& echo "ffb4700b85d85af13b24bd62cc518eace78e96be6b2c4d400f6c96ad58a18b82  Python-3.5.5.linux-aarch64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "Python-$PYTHON_VERSION.linux-aarch64.tar.gz" --strip-components=1 \
+	&& rm -rf "Python-$PYTHON_VERSION.linux-aarch64.tar.gz" \
 	&& ldconfig \
 	&& if [ ! -e /usr/local/bin/pip3 ]; then : \
 		&& curl -SLO "https://raw.githubusercontent.com/pypa/get-pip/430ba37776ae2ad89f794c7a43b90dc23bac334c/get-pip.py" \

--- a/python/artik710/debian/3.6/Dockerfile
+++ b/python/artik710/debian/3.6/Dockerfile
@@ -28,10 +28,10 @@ ENV PYTHON_PIP_VERSION 9.0.1
 ENV SETUPTOOLS_VERSION 34.3.3
 
 RUN set -x \
-	&& curl -SLO "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/Python-$PYTHON_VERSION.linux-armv7hf.tar.gz" \
-	&& echo "285adb4a4d677698e5e1d8da9c43335fec1bd62305a52f12a91e5f79769a80c4  Python-3.6.4.linux-armv7hf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "Python-$PYTHON_VERSION.linux-armv7hf.tar.gz" --strip-components=1 \
-	&& rm -rf "Python-$PYTHON_VERSION.linux-armv7hf.tar.gz" \
+	&& curl -SLO "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/Python-$PYTHON_VERSION.linux-aarch64.tar.gz" \
+	&& echo "4f0e74a10d0ba094f8608a78895a6f4a5c307ce0f6dbcda2768277300e0935d8  Python-3.6.4.linux-aarch64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "Python-$PYTHON_VERSION.linux-aarch64.tar.gz" --strip-components=1 \
+	&& rm -rf "Python-$PYTHON_VERSION.linux-aarch64.tar.gz" \
 	&& ldconfig \
 	&& if [ ! -e /usr/local/bin/pip3 ]; then : \
 		&& curl -SLO "https://raw.githubusercontent.com/pypa/get-pip/430ba37776ae2ad89f794c7a43b90dc23bac334c/get-pip.py" \

--- a/python/artik710/debian/3.6/slim/Dockerfile
+++ b/python/artik710/debian/3.6/slim/Dockerfile
@@ -32,10 +32,10 @@ RUN set -x \
 		curl \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
-	&& curl -SLO "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/Python-$PYTHON_VERSION.linux-armv7hf.tar.gz" \
-	&& echo "285adb4a4d677698e5e1d8da9c43335fec1bd62305a52f12a91e5f79769a80c4  Python-3.6.4.linux-armv7hf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "Python-$PYTHON_VERSION.linux-armv7hf.tar.gz" --strip-components=1 \
-	&& rm -rf "Python-$PYTHON_VERSION.linux-armv7hf.tar.gz" \
+	&& curl -SLO "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/Python-$PYTHON_VERSION.linux-aarch64.tar.gz" \
+	&& echo "4f0e74a10d0ba094f8608a78895a6f4a5c307ce0f6dbcda2768277300e0935d8  Python-3.6.4.linux-aarch64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "Python-$PYTHON_VERSION.linux-aarch64.tar.gz" --strip-components=1 \
+	&& rm -rf "Python-$PYTHON_VERSION.linux-aarch64.tar.gz" \
 	&& ldconfig \
 	&& if [ ! -e /usr/local/bin/pip3 ]; then : \
 		&& curl -SLO "https://raw.githubusercontent.com/pypa/get-pip/430ba37776ae2ad89f794c7a43b90dc23bac334c/get-pip.py" \

--- a/python/artik710/debian/3.6/wheezy/Dockerfile
+++ b/python/artik710/debian/3.6/wheezy/Dockerfile
@@ -28,10 +28,10 @@ ENV PYTHON_PIP_VERSION 9.0.1
 ENV SETUPTOOLS_VERSION 34.3.3
 
 RUN set -x \
-	&& curl -SLO "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/Python-$PYTHON_VERSION.linux-armv7hf.tar.gz" \
-	&& echo "285adb4a4d677698e5e1d8da9c43335fec1bd62305a52f12a91e5f79769a80c4  Python-3.6.4.linux-armv7hf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "Python-$PYTHON_VERSION.linux-armv7hf.tar.gz" --strip-components=1 \
-	&& rm -rf "Python-$PYTHON_VERSION.linux-armv7hf.tar.gz" \
+	&& curl -SLO "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/Python-$PYTHON_VERSION.linux-aarch64.tar.gz" \
+	&& echo "4f0e74a10d0ba094f8608a78895a6f4a5c307ce0f6dbcda2768277300e0935d8  Python-3.6.4.linux-aarch64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "Python-$PYTHON_VERSION.linux-aarch64.tar.gz" --strip-components=1 \
+	&& rm -rf "Python-$PYTHON_VERSION.linux-aarch64.tar.gz" \
 	&& ldconfig \
 	&& if [ ! -e /usr/local/bin/pip3 ]; then : \
 		&& curl -SLO "https://raw.githubusercontent.com/pypa/get-pip/430ba37776ae2ad89f794c7a43b90dc23bac334c/get-pip.py" \

--- a/python/generate-dockerfile.sh
+++ b/python/generate-dockerfile.sh
@@ -223,16 +223,6 @@ for target in $targets; do
 		alpine_binary_arch='alpine-armhf'
 		fedora_binary_arch='fedora-armhf'
 	;;
-	'artik710')
-		binary_arch='armv7hf'
-		alpine_binary_arch='alpine-armhf'
-		fedora_binary_arch='fedora-armhf'
-	;;
-	'kitra710')
-		binary_arch='armv7hf'
-		alpine_binary_arch='alpine-armhf'
-		fedora_binary_arch='fedora-armhf'
-	;;
 	'kitra520')
 		binary_arch='armv7hf'
 		alpine_binary_arch='alpine-armhf'
@@ -248,7 +238,7 @@ for target in $targets; do
 		alpine_binary_arch='alpine-armhf'
 		fedora_binary_arch='fedora-armhf'
 	;;
-	'jetson-tx2'|'jetson-tx1')
+	'jetson-tx2'|'jetson-tx1'|'artik710'|'kitra710')
 		binary_arch='aarch64'
 		alpine_binary_arch='alpine-aarch64'
 		fedora_binary_arch='fedora-aarch64'

--- a/python/kitra710/alpine/2.7/Dockerfile
+++ b/python/kitra710/alpine/2.7/Dockerfile
@@ -30,10 +30,10 @@ ENV SETUPTOOLS_VERSION 34.3.3
 ENV SSL_CERT_FILE /etc/ssl/certs/ca-certificates.crt
 
 RUN set -x \
-	&& curl -SLO "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/Python-$PYTHON_VERSION.linux-alpine-armhf.tar.gz" \
-	&& echo "9867d42862f615460edce8f0ead39d8748f857023fb86cb06884e1fbc3d8beb4  Python-2.7.14.linux-alpine-armhf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "Python-$PYTHON_VERSION.linux-alpine-armhf.tar.gz" --strip-components=1 \
-	&& rm -rf "Python-$PYTHON_VERSION.linux-alpine-armhf.tar.gz" \
+	&& curl -SLO "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/Python-$PYTHON_VERSION.linux-alpine-aarch64.tar.gz" \
+	&& echo "a93f6a0ea8affa6933fc8f53f8d0293b4157357dec8948997ce6801cadeb4734  Python-2.7.14.linux-alpine-aarch64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "Python-$PYTHON_VERSION.linux-alpine-aarch64.tar.gz" --strip-components=1 \
+	&& rm -rf "Python-$PYTHON_VERSION.linux-alpine-aarch64.tar.gz" \
 	&& if [ ! -e /usr/local/bin/pip ]; then : \
 		&& curl -SLO "https://raw.githubusercontent.com/pypa/get-pip/430ba37776ae2ad89f794c7a43b90dc23bac334c/get-pip.py" \
 		&& echo "19dae841a150c86e2a09d475b5eb0602861f2a5b7761ec268049a662dbd2bd0c  get-pip.py" | sha256sum -c - \

--- a/python/kitra710/alpine/2.7/edge/Dockerfile
+++ b/python/kitra710/alpine/2.7/edge/Dockerfile
@@ -30,10 +30,10 @@ ENV SETUPTOOLS_VERSION 34.3.3
 ENV SSL_CERT_FILE /etc/ssl/certs/ca-certificates.crt
 
 RUN set -x \
-	&& curl -SLO "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/Python-$PYTHON_VERSION.linux-alpine-armhf.tar.gz" \
-	&& echo "9867d42862f615460edce8f0ead39d8748f857023fb86cb06884e1fbc3d8beb4  Python-2.7.14.linux-alpine-armhf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "Python-$PYTHON_VERSION.linux-alpine-armhf.tar.gz" --strip-components=1 \
-	&& rm -rf "Python-$PYTHON_VERSION.linux-alpine-armhf.tar.gz" \
+	&& curl -SLO "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/Python-$PYTHON_VERSION.linux-alpine-aarch64.tar.gz" \
+	&& echo "a93f6a0ea8affa6933fc8f53f8d0293b4157357dec8948997ce6801cadeb4734  Python-2.7.14.linux-alpine-aarch64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "Python-$PYTHON_VERSION.linux-alpine-aarch64.tar.gz" --strip-components=1 \
+	&& rm -rf "Python-$PYTHON_VERSION.linux-alpine-aarch64.tar.gz" \
 	&& if [ ! -e /usr/local/bin/pip ]; then : \
 		&& curl -SLO "https://raw.githubusercontent.com/pypa/get-pip/430ba37776ae2ad89f794c7a43b90dc23bac334c/get-pip.py" \
 		&& echo "19dae841a150c86e2a09d475b5eb0602861f2a5b7761ec268049a662dbd2bd0c  get-pip.py" | sha256sum -c - \

--- a/python/kitra710/alpine/2.7/slim/Dockerfile
+++ b/python/kitra710/alpine/2.7/slim/Dockerfile
@@ -37,10 +37,10 @@ RUN set -x \
 		curl \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
-	&& curl -SLO "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/Python-$PYTHON_VERSION.linux-alpine-armhf.tar.gz" \
-	&& echo "9867d42862f615460edce8f0ead39d8748f857023fb86cb06884e1fbc3d8beb4  Python-2.7.14.linux-alpine-armhf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "Python-$PYTHON_VERSION.linux-alpine-armhf.tar.gz" --strip-components=1 \
-	&& rm -rf "Python-$PYTHON_VERSION.linux-alpine-armhf.tar.gz" \
+	&& curl -SLO "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/Python-$PYTHON_VERSION.linux-alpine-aarch64.tar.gz" \
+	&& echo "a93f6a0ea8affa6933fc8f53f8d0293b4157357dec8948997ce6801cadeb4734  Python-2.7.14.linux-alpine-aarch64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "Python-$PYTHON_VERSION.linux-alpine-aarch64.tar.gz" --strip-components=1 \
+	&& rm -rf "Python-$PYTHON_VERSION.linux-alpine-aarch64.tar.gz" \
 	&& if [ ! -e /usr/local/bin/pip ]; then : \
 		&& curl -SLO "https://raw.githubusercontent.com/pypa/get-pip/430ba37776ae2ad89f794c7a43b90dc23bac334c/get-pip.py" \
 		&& echo "19dae841a150c86e2a09d475b5eb0602861f2a5b7761ec268049a662dbd2bd0c  get-pip.py" | sha256sum -c - \

--- a/python/kitra710/alpine/3.3/Dockerfile
+++ b/python/kitra710/alpine/3.3/Dockerfile
@@ -30,10 +30,10 @@ ENV SETUPTOOLS_VERSION 34.3.3
 ENV SSL_CERT_FILE /etc/ssl/certs/ca-certificates.crt
 
 RUN set -x \
-	&& curl -SLO "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/Python-$PYTHON_VERSION.linux-alpine-armhf.tar.gz" \
-	&& echo "ee2bee62538584589609361f87ac79d5eeb2b1a2c3d5f625845ac8511074441f  Python-3.3.7.linux-alpine-armhf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "Python-$PYTHON_VERSION.linux-alpine-armhf.tar.gz" --strip-components=1 \
-	&& rm -rf "Python-$PYTHON_VERSION.linux-alpine-armhf.tar.gz" \
+	&& curl -SLO "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/Python-$PYTHON_VERSION.linux-alpine-aarch64.tar.gz" \
+	&& echo "3500ae3502346b53281e54aaacb6b40e38c6fcaf5166dcde8796877648372843  Python-3.3.7.linux-alpine-aarch64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "Python-$PYTHON_VERSION.linux-alpine-aarch64.tar.gz" --strip-components=1 \
+	&& rm -rf "Python-$PYTHON_VERSION.linux-alpine-aarch64.tar.gz" \
 	&& if [ ! -e /usr/local/bin/pip3 ]; then : \
 		&& curl -SLO "https://raw.githubusercontent.com/pypa/get-pip/430ba37776ae2ad89f794c7a43b90dc23bac334c/get-pip.py" \
 		&& echo "19dae841a150c86e2a09d475b5eb0602861f2a5b7761ec268049a662dbd2bd0c  get-pip.py" | sha256sum -c - \

--- a/python/kitra710/alpine/3.3/edge/Dockerfile
+++ b/python/kitra710/alpine/3.3/edge/Dockerfile
@@ -30,10 +30,10 @@ ENV SETUPTOOLS_VERSION 34.3.3
 ENV SSL_CERT_FILE /etc/ssl/certs/ca-certificates.crt
 
 RUN set -x \
-	&& curl -SLO "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/Python-$PYTHON_VERSION.linux-alpine-armhf.tar.gz" \
-	&& echo "ee2bee62538584589609361f87ac79d5eeb2b1a2c3d5f625845ac8511074441f  Python-3.3.7.linux-alpine-armhf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "Python-$PYTHON_VERSION.linux-alpine-armhf.tar.gz" --strip-components=1 \
-	&& rm -rf "Python-$PYTHON_VERSION.linux-alpine-armhf.tar.gz" \
+	&& curl -SLO "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/Python-$PYTHON_VERSION.linux-alpine-aarch64.tar.gz" \
+	&& echo "3500ae3502346b53281e54aaacb6b40e38c6fcaf5166dcde8796877648372843  Python-3.3.7.linux-alpine-aarch64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "Python-$PYTHON_VERSION.linux-alpine-aarch64.tar.gz" --strip-components=1 \
+	&& rm -rf "Python-$PYTHON_VERSION.linux-alpine-aarch64.tar.gz" \
 	&& if [ ! -e /usr/local/bin/pip3 ]; then : \
 		&& curl -SLO "https://raw.githubusercontent.com/pypa/get-pip/430ba37776ae2ad89f794c7a43b90dc23bac334c/get-pip.py" \
 		&& echo "19dae841a150c86e2a09d475b5eb0602861f2a5b7761ec268049a662dbd2bd0c  get-pip.py" | sha256sum -c - \

--- a/python/kitra710/alpine/3.3/slim/Dockerfile
+++ b/python/kitra710/alpine/3.3/slim/Dockerfile
@@ -37,10 +37,10 @@ RUN set -x \
 		curl \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
-	&& curl -SLO "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/Python-$PYTHON_VERSION.linux-alpine-armhf.tar.gz" \
-	&& echo "ee2bee62538584589609361f87ac79d5eeb2b1a2c3d5f625845ac8511074441f  Python-3.3.7.linux-alpine-armhf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "Python-$PYTHON_VERSION.linux-alpine-armhf.tar.gz" --strip-components=1 \
-	&& rm -rf "Python-$PYTHON_VERSION.linux-alpine-armhf.tar.gz" \
+	&& curl -SLO "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/Python-$PYTHON_VERSION.linux-alpine-aarch64.tar.gz" \
+	&& echo "3500ae3502346b53281e54aaacb6b40e38c6fcaf5166dcde8796877648372843  Python-3.3.7.linux-alpine-aarch64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "Python-$PYTHON_VERSION.linux-alpine-aarch64.tar.gz" --strip-components=1 \
+	&& rm -rf "Python-$PYTHON_VERSION.linux-alpine-aarch64.tar.gz" \
 	&& if [ ! -e /usr/local/bin/pip3 ]; then : \
 		&& curl -SLO "https://raw.githubusercontent.com/pypa/get-pip/430ba37776ae2ad89f794c7a43b90dc23bac334c/get-pip.py" \
 		&& echo "19dae841a150c86e2a09d475b5eb0602861f2a5b7761ec268049a662dbd2bd0c  get-pip.py" | sha256sum -c - \

--- a/python/kitra710/alpine/3.4/Dockerfile
+++ b/python/kitra710/alpine/3.4/Dockerfile
@@ -30,10 +30,10 @@ ENV SETUPTOOLS_VERSION 34.3.3
 ENV SSL_CERT_FILE /etc/ssl/certs/ca-certificates.crt
 
 RUN set -x \
-	&& curl -SLO "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/Python-$PYTHON_VERSION.linux-alpine-armhf.tar.gz" \
-	&& echo "ee29c4846b52b82c2ad6245f46e64ebc76506845e8470e85abdf1827d82aff67  Python-3.4.8.linux-alpine-armhf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "Python-$PYTHON_VERSION.linux-alpine-armhf.tar.gz" --strip-components=1 \
-	&& rm -rf "Python-$PYTHON_VERSION.linux-alpine-armhf.tar.gz" \
+	&& curl -SLO "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/Python-$PYTHON_VERSION.linux-alpine-aarch64.tar.gz" \
+	&& echo "be04ba9fdf5590fd02789ebb7686c66a6bac6c6c24a8208fa690701443bd86ab  Python-3.4.8.linux-alpine-aarch64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "Python-$PYTHON_VERSION.linux-alpine-aarch64.tar.gz" --strip-components=1 \
+	&& rm -rf "Python-$PYTHON_VERSION.linux-alpine-aarch64.tar.gz" \
 	&& if [ ! -e /usr/local/bin/pip3 ]; then : \
 		&& curl -SLO "https://raw.githubusercontent.com/pypa/get-pip/430ba37776ae2ad89f794c7a43b90dc23bac334c/get-pip.py" \
 		&& echo "19dae841a150c86e2a09d475b5eb0602861f2a5b7761ec268049a662dbd2bd0c  get-pip.py" | sha256sum -c - \

--- a/python/kitra710/alpine/3.4/edge/Dockerfile
+++ b/python/kitra710/alpine/3.4/edge/Dockerfile
@@ -30,10 +30,10 @@ ENV SETUPTOOLS_VERSION 34.3.3
 ENV SSL_CERT_FILE /etc/ssl/certs/ca-certificates.crt
 
 RUN set -x \
-	&& curl -SLO "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/Python-$PYTHON_VERSION.linux-alpine-armhf.tar.gz" \
-	&& echo "ee29c4846b52b82c2ad6245f46e64ebc76506845e8470e85abdf1827d82aff67  Python-3.4.8.linux-alpine-armhf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "Python-$PYTHON_VERSION.linux-alpine-armhf.tar.gz" --strip-components=1 \
-	&& rm -rf "Python-$PYTHON_VERSION.linux-alpine-armhf.tar.gz" \
+	&& curl -SLO "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/Python-$PYTHON_VERSION.linux-alpine-aarch64.tar.gz" \
+	&& echo "be04ba9fdf5590fd02789ebb7686c66a6bac6c6c24a8208fa690701443bd86ab  Python-3.4.8.linux-alpine-aarch64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "Python-$PYTHON_VERSION.linux-alpine-aarch64.tar.gz" --strip-components=1 \
+	&& rm -rf "Python-$PYTHON_VERSION.linux-alpine-aarch64.tar.gz" \
 	&& if [ ! -e /usr/local/bin/pip3 ]; then : \
 		&& curl -SLO "https://raw.githubusercontent.com/pypa/get-pip/430ba37776ae2ad89f794c7a43b90dc23bac334c/get-pip.py" \
 		&& echo "19dae841a150c86e2a09d475b5eb0602861f2a5b7761ec268049a662dbd2bd0c  get-pip.py" | sha256sum -c - \

--- a/python/kitra710/alpine/3.4/slim/Dockerfile
+++ b/python/kitra710/alpine/3.4/slim/Dockerfile
@@ -37,10 +37,10 @@ RUN set -x \
 		curl \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
-	&& curl -SLO "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/Python-$PYTHON_VERSION.linux-alpine-armhf.tar.gz" \
-	&& echo "ee29c4846b52b82c2ad6245f46e64ebc76506845e8470e85abdf1827d82aff67  Python-3.4.8.linux-alpine-armhf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "Python-$PYTHON_VERSION.linux-alpine-armhf.tar.gz" --strip-components=1 \
-	&& rm -rf "Python-$PYTHON_VERSION.linux-alpine-armhf.tar.gz" \
+	&& curl -SLO "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/Python-$PYTHON_VERSION.linux-alpine-aarch64.tar.gz" \
+	&& echo "be04ba9fdf5590fd02789ebb7686c66a6bac6c6c24a8208fa690701443bd86ab  Python-3.4.8.linux-alpine-aarch64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "Python-$PYTHON_VERSION.linux-alpine-aarch64.tar.gz" --strip-components=1 \
+	&& rm -rf "Python-$PYTHON_VERSION.linux-alpine-aarch64.tar.gz" \
 	&& if [ ! -e /usr/local/bin/pip3 ]; then : \
 		&& curl -SLO "https://raw.githubusercontent.com/pypa/get-pip/430ba37776ae2ad89f794c7a43b90dc23bac334c/get-pip.py" \
 		&& echo "19dae841a150c86e2a09d475b5eb0602861f2a5b7761ec268049a662dbd2bd0c  get-pip.py" | sha256sum -c - \

--- a/python/kitra710/alpine/3.5/Dockerfile
+++ b/python/kitra710/alpine/3.5/Dockerfile
@@ -30,10 +30,10 @@ ENV SETUPTOOLS_VERSION 34.3.3
 ENV SSL_CERT_FILE /etc/ssl/certs/ca-certificates.crt
 
 RUN set -x \
-	&& curl -SLO "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/Python-$PYTHON_VERSION.linux-alpine-armhf.tar.gz" \
-	&& echo "e0dfbc41958ccc5092c58527254bc439d87ef4ba905ecd4c312ea20230ecfddc  Python-3.5.5.linux-alpine-armhf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "Python-$PYTHON_VERSION.linux-alpine-armhf.tar.gz" --strip-components=1 \
-	&& rm -rf "Python-$PYTHON_VERSION.linux-alpine-armhf.tar.gz" \
+	&& curl -SLO "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/Python-$PYTHON_VERSION.linux-alpine-aarch64.tar.gz" \
+	&& echo "895cff316dd17c89f350a4861b8adeac3eee1c1522b3b55bbe18bcdb5ad51e91  Python-3.5.5.linux-alpine-aarch64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "Python-$PYTHON_VERSION.linux-alpine-aarch64.tar.gz" --strip-components=1 \
+	&& rm -rf "Python-$PYTHON_VERSION.linux-alpine-aarch64.tar.gz" \
 	&& if [ ! -e /usr/local/bin/pip3 ]; then : \
 		&& curl -SLO "https://raw.githubusercontent.com/pypa/get-pip/430ba37776ae2ad89f794c7a43b90dc23bac334c/get-pip.py" \
 		&& echo "19dae841a150c86e2a09d475b5eb0602861f2a5b7761ec268049a662dbd2bd0c  get-pip.py" | sha256sum -c - \

--- a/python/kitra710/alpine/3.5/edge/Dockerfile
+++ b/python/kitra710/alpine/3.5/edge/Dockerfile
@@ -30,10 +30,10 @@ ENV SETUPTOOLS_VERSION 34.3.3
 ENV SSL_CERT_FILE /etc/ssl/certs/ca-certificates.crt
 
 RUN set -x \
-	&& curl -SLO "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/Python-$PYTHON_VERSION.linux-alpine-armhf.tar.gz" \
-	&& echo "e0dfbc41958ccc5092c58527254bc439d87ef4ba905ecd4c312ea20230ecfddc  Python-3.5.5.linux-alpine-armhf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "Python-$PYTHON_VERSION.linux-alpine-armhf.tar.gz" --strip-components=1 \
-	&& rm -rf "Python-$PYTHON_VERSION.linux-alpine-armhf.tar.gz" \
+	&& curl -SLO "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/Python-$PYTHON_VERSION.linux-alpine-aarch64.tar.gz" \
+	&& echo "895cff316dd17c89f350a4861b8adeac3eee1c1522b3b55bbe18bcdb5ad51e91  Python-3.5.5.linux-alpine-aarch64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "Python-$PYTHON_VERSION.linux-alpine-aarch64.tar.gz" --strip-components=1 \
+	&& rm -rf "Python-$PYTHON_VERSION.linux-alpine-aarch64.tar.gz" \
 	&& if [ ! -e /usr/local/bin/pip3 ]; then : \
 		&& curl -SLO "https://raw.githubusercontent.com/pypa/get-pip/430ba37776ae2ad89f794c7a43b90dc23bac334c/get-pip.py" \
 		&& echo "19dae841a150c86e2a09d475b5eb0602861f2a5b7761ec268049a662dbd2bd0c  get-pip.py" | sha256sum -c - \

--- a/python/kitra710/alpine/3.5/slim/Dockerfile
+++ b/python/kitra710/alpine/3.5/slim/Dockerfile
@@ -37,10 +37,10 @@ RUN set -x \
 		curl \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
-	&& curl -SLO "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/Python-$PYTHON_VERSION.linux-alpine-armhf.tar.gz" \
-	&& echo "e0dfbc41958ccc5092c58527254bc439d87ef4ba905ecd4c312ea20230ecfddc  Python-3.5.5.linux-alpine-armhf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "Python-$PYTHON_VERSION.linux-alpine-armhf.tar.gz" --strip-components=1 \
-	&& rm -rf "Python-$PYTHON_VERSION.linux-alpine-armhf.tar.gz" \
+	&& curl -SLO "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/Python-$PYTHON_VERSION.linux-alpine-aarch64.tar.gz" \
+	&& echo "895cff316dd17c89f350a4861b8adeac3eee1c1522b3b55bbe18bcdb5ad51e91  Python-3.5.5.linux-alpine-aarch64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "Python-$PYTHON_VERSION.linux-alpine-aarch64.tar.gz" --strip-components=1 \
+	&& rm -rf "Python-$PYTHON_VERSION.linux-alpine-aarch64.tar.gz" \
 	&& if [ ! -e /usr/local/bin/pip3 ]; then : \
 		&& curl -SLO "https://raw.githubusercontent.com/pypa/get-pip/430ba37776ae2ad89f794c7a43b90dc23bac334c/get-pip.py" \
 		&& echo "19dae841a150c86e2a09d475b5eb0602861f2a5b7761ec268049a662dbd2bd0c  get-pip.py" | sha256sum -c - \

--- a/python/kitra710/alpine/3.6/Dockerfile
+++ b/python/kitra710/alpine/3.6/Dockerfile
@@ -30,10 +30,10 @@ ENV SETUPTOOLS_VERSION 34.3.3
 ENV SSL_CERT_FILE /etc/ssl/certs/ca-certificates.crt
 
 RUN set -x \
-	&& curl -SLO "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/Python-$PYTHON_VERSION.linux-alpine-armhf.tar.gz" \
-	&& echo "8b72a20a1190f79fc7ff950e3a75af8fc0dfcb3a63c9220b918264f8d984c837  Python-3.6.4.linux-alpine-armhf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "Python-$PYTHON_VERSION.linux-alpine-armhf.tar.gz" --strip-components=1 \
-	&& rm -rf "Python-$PYTHON_VERSION.linux-alpine-armhf.tar.gz" \
+	&& curl -SLO "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/Python-$PYTHON_VERSION.linux-alpine-aarch64.tar.gz" \
+	&& echo "c02489d4cf97fdf764c371265cb736af8b931fe7a3be04b0d82dbb6940940d2b  Python-3.6.4.linux-alpine-aarch64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "Python-$PYTHON_VERSION.linux-alpine-aarch64.tar.gz" --strip-components=1 \
+	&& rm -rf "Python-$PYTHON_VERSION.linux-alpine-aarch64.tar.gz" \
 	&& if [ ! -e /usr/local/bin/pip3 ]; then : \
 		&& curl -SLO "https://raw.githubusercontent.com/pypa/get-pip/430ba37776ae2ad89f794c7a43b90dc23bac334c/get-pip.py" \
 		&& echo "19dae841a150c86e2a09d475b5eb0602861f2a5b7761ec268049a662dbd2bd0c  get-pip.py" | sha256sum -c - \

--- a/python/kitra710/alpine/3.6/edge/Dockerfile
+++ b/python/kitra710/alpine/3.6/edge/Dockerfile
@@ -30,10 +30,10 @@ ENV SETUPTOOLS_VERSION 34.3.3
 ENV SSL_CERT_FILE /etc/ssl/certs/ca-certificates.crt
 
 RUN set -x \
-	&& curl -SLO "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/Python-$PYTHON_VERSION.linux-alpine-armhf.tar.gz" \
-	&& echo "8b72a20a1190f79fc7ff950e3a75af8fc0dfcb3a63c9220b918264f8d984c837  Python-3.6.4.linux-alpine-armhf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "Python-$PYTHON_VERSION.linux-alpine-armhf.tar.gz" --strip-components=1 \
-	&& rm -rf "Python-$PYTHON_VERSION.linux-alpine-armhf.tar.gz" \
+	&& curl -SLO "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/Python-$PYTHON_VERSION.linux-alpine-aarch64.tar.gz" \
+	&& echo "c02489d4cf97fdf764c371265cb736af8b931fe7a3be04b0d82dbb6940940d2b  Python-3.6.4.linux-alpine-aarch64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "Python-$PYTHON_VERSION.linux-alpine-aarch64.tar.gz" --strip-components=1 \
+	&& rm -rf "Python-$PYTHON_VERSION.linux-alpine-aarch64.tar.gz" \
 	&& if [ ! -e /usr/local/bin/pip3 ]; then : \
 		&& curl -SLO "https://raw.githubusercontent.com/pypa/get-pip/430ba37776ae2ad89f794c7a43b90dc23bac334c/get-pip.py" \
 		&& echo "19dae841a150c86e2a09d475b5eb0602861f2a5b7761ec268049a662dbd2bd0c  get-pip.py" | sha256sum -c - \

--- a/python/kitra710/alpine/3.6/slim/Dockerfile
+++ b/python/kitra710/alpine/3.6/slim/Dockerfile
@@ -37,10 +37,10 @@ RUN set -x \
 		curl \
 	' \
 	&& apk add --no-cache --virtual .build-deps $buildDeps \
-	&& curl -SLO "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/Python-$PYTHON_VERSION.linux-alpine-armhf.tar.gz" \
-	&& echo "8b72a20a1190f79fc7ff950e3a75af8fc0dfcb3a63c9220b918264f8d984c837  Python-3.6.4.linux-alpine-armhf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "Python-$PYTHON_VERSION.linux-alpine-armhf.tar.gz" --strip-components=1 \
-	&& rm -rf "Python-$PYTHON_VERSION.linux-alpine-armhf.tar.gz" \
+	&& curl -SLO "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/Python-$PYTHON_VERSION.linux-alpine-aarch64.tar.gz" \
+	&& echo "c02489d4cf97fdf764c371265cb736af8b931fe7a3be04b0d82dbb6940940d2b  Python-3.6.4.linux-alpine-aarch64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "Python-$PYTHON_VERSION.linux-alpine-aarch64.tar.gz" --strip-components=1 \
+	&& rm -rf "Python-$PYTHON_VERSION.linux-alpine-aarch64.tar.gz" \
 	&& if [ ! -e /usr/local/bin/pip3 ]; then : \
 		&& curl -SLO "https://raw.githubusercontent.com/pypa/get-pip/430ba37776ae2ad89f794c7a43b90dc23bac334c/get-pip.py" \
 		&& echo "19dae841a150c86e2a09d475b5eb0602861f2a5b7761ec268049a662dbd2bd0c  get-pip.py" | sha256sum -c - \

--- a/python/kitra710/debian/2.7/Dockerfile
+++ b/python/kitra710/debian/2.7/Dockerfile
@@ -28,10 +28,10 @@ ENV PYTHON_PIP_VERSION 9.0.1
 ENV SETUPTOOLS_VERSION 34.3.3
 
 RUN set -x \
-	&& curl -SLO "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/Python-$PYTHON_VERSION.linux-armv7hf.tar.gz" \
-	&& echo "dc57b43159fb42c4cc7ea5ddd5791776a5fffe215d707912dededfff978c9475  Python-2.7.14.linux-armv7hf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "Python-$PYTHON_VERSION.linux-armv7hf.tar.gz" --strip-components=1 \
-	&& rm -rf "Python-$PYTHON_VERSION.linux-armv7hf.tar.gz" \
+	&& curl -SLO "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/Python-$PYTHON_VERSION.linux-aarch64.tar.gz" \
+	&& echo "12ec9f5d902c185d60c934eb38b614373d993017071880600ab5af813d2e3fb1  Python-2.7.14.linux-aarch64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "Python-$PYTHON_VERSION.linux-aarch64.tar.gz" --strip-components=1 \
+	&& rm -rf "Python-$PYTHON_VERSION.linux-aarch64.tar.gz" \
 	&& ldconfig \
 	&& if [ ! -e /usr/local/bin/pip ]; then : \
 		&& curl -SLO "https://raw.githubusercontent.com/pypa/get-pip/430ba37776ae2ad89f794c7a43b90dc23bac334c/get-pip.py" \

--- a/python/kitra710/debian/2.7/slim/Dockerfile
+++ b/python/kitra710/debian/2.7/slim/Dockerfile
@@ -32,10 +32,10 @@ RUN set -x \
 		curl \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
-	&& curl -SLO "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/Python-$PYTHON_VERSION.linux-armv7hf.tar.gz" \
-	&& echo "dc57b43159fb42c4cc7ea5ddd5791776a5fffe215d707912dededfff978c9475  Python-2.7.14.linux-armv7hf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "Python-$PYTHON_VERSION.linux-armv7hf.tar.gz" --strip-components=1 \
-	&& rm -rf "Python-$PYTHON_VERSION.linux-armv7hf.tar.gz" \
+	&& curl -SLO "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/Python-$PYTHON_VERSION.linux-aarch64.tar.gz" \
+	&& echo "12ec9f5d902c185d60c934eb38b614373d993017071880600ab5af813d2e3fb1  Python-2.7.14.linux-aarch64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "Python-$PYTHON_VERSION.linux-aarch64.tar.gz" --strip-components=1 \
+	&& rm -rf "Python-$PYTHON_VERSION.linux-aarch64.tar.gz" \
 	&& ldconfig \
 	&& if [ ! -e /usr/local/bin/pip ]; then : \
 		&& curl -SLO "https://raw.githubusercontent.com/pypa/get-pip/430ba37776ae2ad89f794c7a43b90dc23bac334c/get-pip.py" \

--- a/python/kitra710/debian/2.7/wheezy/Dockerfile
+++ b/python/kitra710/debian/2.7/wheezy/Dockerfile
@@ -28,10 +28,10 @@ ENV PYTHON_PIP_VERSION 9.0.1
 ENV SETUPTOOLS_VERSION 34.3.3
 
 RUN set -x \
-	&& curl -SLO "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/Python-$PYTHON_VERSION.linux-armv7hf.tar.gz" \
-	&& echo "dc57b43159fb42c4cc7ea5ddd5791776a5fffe215d707912dededfff978c9475  Python-2.7.14.linux-armv7hf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "Python-$PYTHON_VERSION.linux-armv7hf.tar.gz" --strip-components=1 \
-	&& rm -rf "Python-$PYTHON_VERSION.linux-armv7hf.tar.gz" \
+	&& curl -SLO "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/Python-$PYTHON_VERSION.linux-aarch64.tar.gz" \
+	&& echo "12ec9f5d902c185d60c934eb38b614373d993017071880600ab5af813d2e3fb1  Python-2.7.14.linux-aarch64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "Python-$PYTHON_VERSION.linux-aarch64.tar.gz" --strip-components=1 \
+	&& rm -rf "Python-$PYTHON_VERSION.linux-aarch64.tar.gz" \
 	&& ldconfig \
 	&& if [ ! -e /usr/local/bin/pip ]; then : \
 		&& curl -SLO "https://raw.githubusercontent.com/pypa/get-pip/430ba37776ae2ad89f794c7a43b90dc23bac334c/get-pip.py" \

--- a/python/kitra710/debian/3.3/Dockerfile
+++ b/python/kitra710/debian/3.3/Dockerfile
@@ -28,10 +28,10 @@ ENV PYTHON_PIP_VERSION 9.0.1
 ENV SETUPTOOLS_VERSION 34.3.3
 
 RUN set -x \
-	&& curl -SLO "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/Python-$PYTHON_VERSION.linux-armv7hf.tar.gz" \
-	&& echo "d6f5fac5ab145f0f0c19bea2f83838ac44145d2f70e61dab193c2e9e1efc59aa  Python-3.3.7.linux-armv7hf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "Python-$PYTHON_VERSION.linux-armv7hf.tar.gz" --strip-components=1 \
-	&& rm -rf "Python-$PYTHON_VERSION.linux-armv7hf.tar.gz" \
+	&& curl -SLO "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/Python-$PYTHON_VERSION.linux-aarch64.tar.gz" \
+	&& echo "c5694604efe341062cb6bde8b52f13ea80467b03fa9e7b6f002992ae44ce612e  Python-3.3.7.linux-aarch64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "Python-$PYTHON_VERSION.linux-aarch64.tar.gz" --strip-components=1 \
+	&& rm -rf "Python-$PYTHON_VERSION.linux-aarch64.tar.gz" \
 	&& ldconfig \
 	&& if [ ! -e /usr/local/bin/pip3 ]; then : \
 		&& curl -SLO "https://raw.githubusercontent.com/pypa/get-pip/430ba37776ae2ad89f794c7a43b90dc23bac334c/get-pip.py" \

--- a/python/kitra710/debian/3.3/slim/Dockerfile
+++ b/python/kitra710/debian/3.3/slim/Dockerfile
@@ -32,10 +32,10 @@ RUN set -x \
 		curl \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
-	&& curl -SLO "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/Python-$PYTHON_VERSION.linux-armv7hf.tar.gz" \
-	&& echo "d6f5fac5ab145f0f0c19bea2f83838ac44145d2f70e61dab193c2e9e1efc59aa  Python-3.3.7.linux-armv7hf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "Python-$PYTHON_VERSION.linux-armv7hf.tar.gz" --strip-components=1 \
-	&& rm -rf "Python-$PYTHON_VERSION.linux-armv7hf.tar.gz" \
+	&& curl -SLO "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/Python-$PYTHON_VERSION.linux-aarch64.tar.gz" \
+	&& echo "c5694604efe341062cb6bde8b52f13ea80467b03fa9e7b6f002992ae44ce612e  Python-3.3.7.linux-aarch64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "Python-$PYTHON_VERSION.linux-aarch64.tar.gz" --strip-components=1 \
+	&& rm -rf "Python-$PYTHON_VERSION.linux-aarch64.tar.gz" \
 	&& ldconfig \
 	&& if [ ! -e /usr/local/bin/pip3 ]; then : \
 		&& curl -SLO "https://raw.githubusercontent.com/pypa/get-pip/430ba37776ae2ad89f794c7a43b90dc23bac334c/get-pip.py" \

--- a/python/kitra710/debian/3.3/wheezy/Dockerfile
+++ b/python/kitra710/debian/3.3/wheezy/Dockerfile
@@ -28,10 +28,10 @@ ENV PYTHON_PIP_VERSION 9.0.1
 ENV SETUPTOOLS_VERSION 34.3.3
 
 RUN set -x \
-	&& curl -SLO "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/Python-$PYTHON_VERSION.linux-armv7hf.tar.gz" \
-	&& echo "d6f5fac5ab145f0f0c19bea2f83838ac44145d2f70e61dab193c2e9e1efc59aa  Python-3.3.7.linux-armv7hf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "Python-$PYTHON_VERSION.linux-armv7hf.tar.gz" --strip-components=1 \
-	&& rm -rf "Python-$PYTHON_VERSION.linux-armv7hf.tar.gz" \
+	&& curl -SLO "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/Python-$PYTHON_VERSION.linux-aarch64.tar.gz" \
+	&& echo "c5694604efe341062cb6bde8b52f13ea80467b03fa9e7b6f002992ae44ce612e  Python-3.3.7.linux-aarch64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "Python-$PYTHON_VERSION.linux-aarch64.tar.gz" --strip-components=1 \
+	&& rm -rf "Python-$PYTHON_VERSION.linux-aarch64.tar.gz" \
 	&& ldconfig \
 	&& if [ ! -e /usr/local/bin/pip3 ]; then : \
 		&& curl -SLO "https://raw.githubusercontent.com/pypa/get-pip/430ba37776ae2ad89f794c7a43b90dc23bac334c/get-pip.py" \

--- a/python/kitra710/debian/3.4/Dockerfile
+++ b/python/kitra710/debian/3.4/Dockerfile
@@ -28,10 +28,10 @@ ENV PYTHON_PIP_VERSION 9.0.1
 ENV SETUPTOOLS_VERSION 34.3.3
 
 RUN set -x \
-	&& curl -SLO "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/Python-$PYTHON_VERSION.linux-armv7hf.tar.gz" \
-	&& echo "ee9a38cbdc05a211f0136e382b36b3fbc96ea8186453ee1cbe66255707de6836  Python-3.4.8.linux-armv7hf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "Python-$PYTHON_VERSION.linux-armv7hf.tar.gz" --strip-components=1 \
-	&& rm -rf "Python-$PYTHON_VERSION.linux-armv7hf.tar.gz" \
+	&& curl -SLO "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/Python-$PYTHON_VERSION.linux-aarch64.tar.gz" \
+	&& echo "f131ca817d983aabc10451a012dae8902c983dd24453d3123fb48a3c47e9450c  Python-3.4.8.linux-aarch64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "Python-$PYTHON_VERSION.linux-aarch64.tar.gz" --strip-components=1 \
+	&& rm -rf "Python-$PYTHON_VERSION.linux-aarch64.tar.gz" \
 	&& ldconfig \
 	&& if [ ! -e /usr/local/bin/pip3 ]; then : \
 		&& curl -SLO "https://raw.githubusercontent.com/pypa/get-pip/430ba37776ae2ad89f794c7a43b90dc23bac334c/get-pip.py" \

--- a/python/kitra710/debian/3.4/slim/Dockerfile
+++ b/python/kitra710/debian/3.4/slim/Dockerfile
@@ -32,10 +32,10 @@ RUN set -x \
 		curl \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
-	&& curl -SLO "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/Python-$PYTHON_VERSION.linux-armv7hf.tar.gz" \
-	&& echo "ee9a38cbdc05a211f0136e382b36b3fbc96ea8186453ee1cbe66255707de6836  Python-3.4.8.linux-armv7hf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "Python-$PYTHON_VERSION.linux-armv7hf.tar.gz" --strip-components=1 \
-	&& rm -rf "Python-$PYTHON_VERSION.linux-armv7hf.tar.gz" \
+	&& curl -SLO "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/Python-$PYTHON_VERSION.linux-aarch64.tar.gz" \
+	&& echo "f131ca817d983aabc10451a012dae8902c983dd24453d3123fb48a3c47e9450c  Python-3.4.8.linux-aarch64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "Python-$PYTHON_VERSION.linux-aarch64.tar.gz" --strip-components=1 \
+	&& rm -rf "Python-$PYTHON_VERSION.linux-aarch64.tar.gz" \
 	&& ldconfig \
 	&& if [ ! -e /usr/local/bin/pip3 ]; then : \
 		&& curl -SLO "https://raw.githubusercontent.com/pypa/get-pip/430ba37776ae2ad89f794c7a43b90dc23bac334c/get-pip.py" \

--- a/python/kitra710/debian/3.4/wheezy/Dockerfile
+++ b/python/kitra710/debian/3.4/wheezy/Dockerfile
@@ -28,10 +28,10 @@ ENV PYTHON_PIP_VERSION 9.0.1
 ENV SETUPTOOLS_VERSION 34.3.3
 
 RUN set -x \
-	&& curl -SLO "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/Python-$PYTHON_VERSION.linux-armv7hf.tar.gz" \
-	&& echo "ee9a38cbdc05a211f0136e382b36b3fbc96ea8186453ee1cbe66255707de6836  Python-3.4.8.linux-armv7hf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "Python-$PYTHON_VERSION.linux-armv7hf.tar.gz" --strip-components=1 \
-	&& rm -rf "Python-$PYTHON_VERSION.linux-armv7hf.tar.gz" \
+	&& curl -SLO "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/Python-$PYTHON_VERSION.linux-aarch64.tar.gz" \
+	&& echo "f131ca817d983aabc10451a012dae8902c983dd24453d3123fb48a3c47e9450c  Python-3.4.8.linux-aarch64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "Python-$PYTHON_VERSION.linux-aarch64.tar.gz" --strip-components=1 \
+	&& rm -rf "Python-$PYTHON_VERSION.linux-aarch64.tar.gz" \
 	&& ldconfig \
 	&& if [ ! -e /usr/local/bin/pip3 ]; then : \
 		&& curl -SLO "https://raw.githubusercontent.com/pypa/get-pip/430ba37776ae2ad89f794c7a43b90dc23bac334c/get-pip.py" \

--- a/python/kitra710/debian/3.5/Dockerfile
+++ b/python/kitra710/debian/3.5/Dockerfile
@@ -28,10 +28,10 @@ ENV PYTHON_PIP_VERSION 9.0.1
 ENV SETUPTOOLS_VERSION 34.3.3
 
 RUN set -x \
-	&& curl -SLO "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/Python-$PYTHON_VERSION.linux-armv7hf.tar.gz" \
-	&& echo "44d5922736ba415e80c267b74e8e801a18c0404427a49f89286189dee8dee293  Python-3.5.5.linux-armv7hf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "Python-$PYTHON_VERSION.linux-armv7hf.tar.gz" --strip-components=1 \
-	&& rm -rf "Python-$PYTHON_VERSION.linux-armv7hf.tar.gz" \
+	&& curl -SLO "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/Python-$PYTHON_VERSION.linux-aarch64.tar.gz" \
+	&& echo "ffb4700b85d85af13b24bd62cc518eace78e96be6b2c4d400f6c96ad58a18b82  Python-3.5.5.linux-aarch64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "Python-$PYTHON_VERSION.linux-aarch64.tar.gz" --strip-components=1 \
+	&& rm -rf "Python-$PYTHON_VERSION.linux-aarch64.tar.gz" \
 	&& ldconfig \
 	&& if [ ! -e /usr/local/bin/pip3 ]; then : \
 		&& curl -SLO "https://raw.githubusercontent.com/pypa/get-pip/430ba37776ae2ad89f794c7a43b90dc23bac334c/get-pip.py" \

--- a/python/kitra710/debian/3.5/slim/Dockerfile
+++ b/python/kitra710/debian/3.5/slim/Dockerfile
@@ -32,10 +32,10 @@ RUN set -x \
 		curl \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
-	&& curl -SLO "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/Python-$PYTHON_VERSION.linux-armv7hf.tar.gz" \
-	&& echo "44d5922736ba415e80c267b74e8e801a18c0404427a49f89286189dee8dee293  Python-3.5.5.linux-armv7hf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "Python-$PYTHON_VERSION.linux-armv7hf.tar.gz" --strip-components=1 \
-	&& rm -rf "Python-$PYTHON_VERSION.linux-armv7hf.tar.gz" \
+	&& curl -SLO "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/Python-$PYTHON_VERSION.linux-aarch64.tar.gz" \
+	&& echo "ffb4700b85d85af13b24bd62cc518eace78e96be6b2c4d400f6c96ad58a18b82  Python-3.5.5.linux-aarch64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "Python-$PYTHON_VERSION.linux-aarch64.tar.gz" --strip-components=1 \
+	&& rm -rf "Python-$PYTHON_VERSION.linux-aarch64.tar.gz" \
 	&& ldconfig \
 	&& if [ ! -e /usr/local/bin/pip3 ]; then : \
 		&& curl -SLO "https://raw.githubusercontent.com/pypa/get-pip/430ba37776ae2ad89f794c7a43b90dc23bac334c/get-pip.py" \

--- a/python/kitra710/debian/3.5/wheezy/Dockerfile
+++ b/python/kitra710/debian/3.5/wheezy/Dockerfile
@@ -28,10 +28,10 @@ ENV PYTHON_PIP_VERSION 9.0.1
 ENV SETUPTOOLS_VERSION 34.3.3
 
 RUN set -x \
-	&& curl -SLO "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/Python-$PYTHON_VERSION.linux-armv7hf.tar.gz" \
-	&& echo "44d5922736ba415e80c267b74e8e801a18c0404427a49f89286189dee8dee293  Python-3.5.5.linux-armv7hf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "Python-$PYTHON_VERSION.linux-armv7hf.tar.gz" --strip-components=1 \
-	&& rm -rf "Python-$PYTHON_VERSION.linux-armv7hf.tar.gz" \
+	&& curl -SLO "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/Python-$PYTHON_VERSION.linux-aarch64.tar.gz" \
+	&& echo "ffb4700b85d85af13b24bd62cc518eace78e96be6b2c4d400f6c96ad58a18b82  Python-3.5.5.linux-aarch64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "Python-$PYTHON_VERSION.linux-aarch64.tar.gz" --strip-components=1 \
+	&& rm -rf "Python-$PYTHON_VERSION.linux-aarch64.tar.gz" \
 	&& ldconfig \
 	&& if [ ! -e /usr/local/bin/pip3 ]; then : \
 		&& curl -SLO "https://raw.githubusercontent.com/pypa/get-pip/430ba37776ae2ad89f794c7a43b90dc23bac334c/get-pip.py" \

--- a/python/kitra710/debian/3.6/Dockerfile
+++ b/python/kitra710/debian/3.6/Dockerfile
@@ -28,10 +28,10 @@ ENV PYTHON_PIP_VERSION 9.0.1
 ENV SETUPTOOLS_VERSION 34.3.3
 
 RUN set -x \
-	&& curl -SLO "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/Python-$PYTHON_VERSION.linux-armv7hf.tar.gz" \
-	&& echo "285adb4a4d677698e5e1d8da9c43335fec1bd62305a52f12a91e5f79769a80c4  Python-3.6.4.linux-armv7hf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "Python-$PYTHON_VERSION.linux-armv7hf.tar.gz" --strip-components=1 \
-	&& rm -rf "Python-$PYTHON_VERSION.linux-armv7hf.tar.gz" \
+	&& curl -SLO "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/Python-$PYTHON_VERSION.linux-aarch64.tar.gz" \
+	&& echo "4f0e74a10d0ba094f8608a78895a6f4a5c307ce0f6dbcda2768277300e0935d8  Python-3.6.4.linux-aarch64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "Python-$PYTHON_VERSION.linux-aarch64.tar.gz" --strip-components=1 \
+	&& rm -rf "Python-$PYTHON_VERSION.linux-aarch64.tar.gz" \
 	&& ldconfig \
 	&& if [ ! -e /usr/local/bin/pip3 ]; then : \
 		&& curl -SLO "https://raw.githubusercontent.com/pypa/get-pip/430ba37776ae2ad89f794c7a43b90dc23bac334c/get-pip.py" \

--- a/python/kitra710/debian/3.6/slim/Dockerfile
+++ b/python/kitra710/debian/3.6/slim/Dockerfile
@@ -32,10 +32,10 @@ RUN set -x \
 		curl \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
-	&& curl -SLO "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/Python-$PYTHON_VERSION.linux-armv7hf.tar.gz" \
-	&& echo "285adb4a4d677698e5e1d8da9c43335fec1bd62305a52f12a91e5f79769a80c4  Python-3.6.4.linux-armv7hf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "Python-$PYTHON_VERSION.linux-armv7hf.tar.gz" --strip-components=1 \
-	&& rm -rf "Python-$PYTHON_VERSION.linux-armv7hf.tar.gz" \
+	&& curl -SLO "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/Python-$PYTHON_VERSION.linux-aarch64.tar.gz" \
+	&& echo "4f0e74a10d0ba094f8608a78895a6f4a5c307ce0f6dbcda2768277300e0935d8  Python-3.6.4.linux-aarch64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "Python-$PYTHON_VERSION.linux-aarch64.tar.gz" --strip-components=1 \
+	&& rm -rf "Python-$PYTHON_VERSION.linux-aarch64.tar.gz" \
 	&& ldconfig \
 	&& if [ ! -e /usr/local/bin/pip3 ]; then : \
 		&& curl -SLO "https://raw.githubusercontent.com/pypa/get-pip/430ba37776ae2ad89f794c7a43b90dc23bac334c/get-pip.py" \

--- a/python/kitra710/debian/3.6/wheezy/Dockerfile
+++ b/python/kitra710/debian/3.6/wheezy/Dockerfile
@@ -28,10 +28,10 @@ ENV PYTHON_PIP_VERSION 9.0.1
 ENV SETUPTOOLS_VERSION 34.3.3
 
 RUN set -x \
-	&& curl -SLO "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/Python-$PYTHON_VERSION.linux-armv7hf.tar.gz" \
-	&& echo "285adb4a4d677698e5e1d8da9c43335fec1bd62305a52f12a91e5f79769a80c4  Python-3.6.4.linux-armv7hf.tar.gz" | sha256sum -c - \
-	&& tar -xzf "Python-$PYTHON_VERSION.linux-armv7hf.tar.gz" --strip-components=1 \
-	&& rm -rf "Python-$PYTHON_VERSION.linux-armv7hf.tar.gz" \
+	&& curl -SLO "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/Python-$PYTHON_VERSION.linux-aarch64.tar.gz" \
+	&& echo "4f0e74a10d0ba094f8608a78895a6f4a5c307ce0f6dbcda2768277300e0935d8  Python-3.6.4.linux-aarch64.tar.gz" | sha256sum -c - \
+	&& tar -xzf "Python-$PYTHON_VERSION.linux-aarch64.tar.gz" --strip-components=1 \
+	&& rm -rf "Python-$PYTHON_VERSION.linux-aarch64.tar.gz" \
 	&& ldconfig \
 	&& if [ ! -e /usr/local/bin/pip3 ]; then : \
 		&& curl -SLO "https://raw.githubusercontent.com/pypa/get-pip/430ba37776ae2ad89f794c7a43b90dc23bac334c/get-pip.py" \


### PR DESCRIPTION
We have users hit `illegal instruction` error when running kitra710 alpine base images (it's based on `resin/armhf-alpine`) so we need to change the base images for all aarch64 devices to the right architecture.

Connects to https://github.com/resin-io/hq/issues/1260