### PR TITLE
 Redirecting all outputs from privilege check to /dev/null (not just stdout)

### DIFF
--- a/alpine/aarch64/3.5/entry.sh
+++ b/alpine/aarch64/3.5/entry.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 
-hostname "$HOSTNAME" > /dev/null
+hostname "$HOSTNAME" &> /dev/null
 if [[ $? == 0 ]]; then
 	PRIVILEGED=true
 else

--- a/alpine/aarch64/3.6/entry.sh
+++ b/alpine/aarch64/3.6/entry.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 
-hostname "$HOSTNAME" > /dev/null
+hostname "$HOSTNAME" &> /dev/null
 if [[ $? == 0 ]]; then
 	PRIVILEGED=true
 else

--- a/alpine/aarch64/3.7/entry.sh
+++ b/alpine/aarch64/3.7/entry.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 
-hostname "$HOSTNAME" > /dev/null
+hostname "$HOSTNAME" &> /dev/null
 if [[ $? == 0 ]]; then
 	PRIVILEGED=true
 else

--- a/alpine/aarch64/edge/entry.sh
+++ b/alpine/aarch64/edge/entry.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 
-hostname "$HOSTNAME" > /dev/null
+hostname "$HOSTNAME" &> /dev/null
 if [[ $? == 0 ]]; then
 	PRIVILEGED=true
 else

--- a/alpine/amd64/3.5/entry.sh
+++ b/alpine/amd64/3.5/entry.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 
-hostname "$HOSTNAME" > /dev/null
+hostname "$HOSTNAME" &> /dev/null
 if [[ $? == 0 ]]; then
 	PRIVILEGED=true
 else

--- a/alpine/amd64/3.6/entry.sh
+++ b/alpine/amd64/3.6/entry.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 
-hostname "$HOSTNAME" > /dev/null
+hostname "$HOSTNAME" &> /dev/null
 if [[ $? == 0 ]]; then
 	PRIVILEGED=true
 else

--- a/alpine/amd64/3.7/entry.sh
+++ b/alpine/amd64/3.7/entry.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 
-hostname "$HOSTNAME" > /dev/null
+hostname "$HOSTNAME" &> /dev/null
 if [[ $? == 0 ]]; then
 	PRIVILEGED=true
 else

--- a/alpine/amd64/edge/entry.sh
+++ b/alpine/amd64/edge/entry.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 
-hostname "$HOSTNAME" > /dev/null
+hostname "$HOSTNAME" &> /dev/null
 if [[ $? == 0 ]]; then
 	PRIVILEGED=true
 else

--- a/alpine/armhf/3.5/entry.sh
+++ b/alpine/armhf/3.5/entry.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 
-hostname "$HOSTNAME" > /dev/null
+hostname "$HOSTNAME" &> /dev/null
 if [[ $? == 0 ]]; then
 	PRIVILEGED=true
 else

--- a/alpine/armhf/3.6/entry.sh
+++ b/alpine/armhf/3.6/entry.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 
-hostname "$HOSTNAME" > /dev/null
+hostname "$HOSTNAME" &> /dev/null
 if [[ $? == 0 ]]; then
 	PRIVILEGED=true
 else

--- a/alpine/armhf/3.7/entry.sh
+++ b/alpine/armhf/3.7/entry.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 
-hostname "$HOSTNAME" > /dev/null
+hostname "$HOSTNAME" &> /dev/null
 if [[ $? == 0 ]]; then
 	PRIVILEGED=true
 else

--- a/alpine/armhf/edge/entry.sh
+++ b/alpine/armhf/edge/entry.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 
-hostname "$HOSTNAME" > /dev/null
+hostname "$HOSTNAME" &> /dev/null
 if [[ $? == 0 ]]; then
 	PRIVILEGED=true
 else

--- a/alpine/entry.sh
+++ b/alpine/entry.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 
-hostname "$HOSTNAME" > /dev/null
+hostname "$HOSTNAME" &> /dev/null
 if [[ $? == 0 ]]; then
 	PRIVILEGED=true
 else

--- a/alpine/i386/3.5/entry.sh
+++ b/alpine/i386/3.5/entry.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 
-hostname "$HOSTNAME" > /dev/null
+hostname "$HOSTNAME" &> /dev/null
 if [[ $? == 0 ]]; then
 	PRIVILEGED=true
 else

--- a/alpine/i386/3.6/entry.sh
+++ b/alpine/i386/3.6/entry.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 
-hostname "$HOSTNAME" > /dev/null
+hostname "$HOSTNAME" &> /dev/null
 if [[ $? == 0 ]]; then
 	PRIVILEGED=true
 else

--- a/alpine/i386/3.7/entry.sh
+++ b/alpine/i386/3.7/entry.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 
-hostname "$HOSTNAME" > /dev/null
+hostname "$HOSTNAME" &> /dev/null
 if [[ $? == 0 ]]; then
 	PRIVILEGED=true
 else

--- a/alpine/i386/edge/entry.sh
+++ b/alpine/i386/edge/entry.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 
-hostname "$HOSTNAME" > /dev/null
+hostname "$HOSTNAME" &> /dev/null
 if [[ $? == 0 ]]; then
 	PRIVILEGED=true
 else

--- a/debian/aarch64/buster/entry.sh
+++ b/debian/aarch64/buster/entry.sh
@@ -2,7 +2,7 @@
 
 set -m
 
-hostname "$HOSTNAME" > /dev/null
+hostname "$HOSTNAME" &> /dev/null
 if [[ $? == 0 ]]; then
 	PRIVILEGED=true
 else

--- a/debian/aarch64/jessie/entry.sh
+++ b/debian/aarch64/jessie/entry.sh
@@ -2,7 +2,7 @@
 
 set -m
 
-hostname "$HOSTNAME" > /dev/null
+hostname "$HOSTNAME" &> /dev/null
 if [[ $? == 0 ]]; then
 	PRIVILEGED=true
 else

--- a/debian/aarch64/stretch/entry.sh
+++ b/debian/aarch64/stretch/entry.sh
@@ -2,7 +2,7 @@
 
 set -m
 
-hostname "$HOSTNAME" > /dev/null
+hostname "$HOSTNAME" &> /dev/null
 if [[ $? == 0 ]]; then
 	PRIVILEGED=true
 else

--- a/debian/amd64/buster/entry.sh
+++ b/debian/amd64/buster/entry.sh
@@ -2,7 +2,7 @@
 
 set -m
 
-hostname "$HOSTNAME" > /dev/null
+hostname "$HOSTNAME" &> /dev/null
 if [[ $? == 0 ]]; then
 	PRIVILEGED=true
 else

--- a/debian/amd64/jessie/entry.sh
+++ b/debian/amd64/jessie/entry.sh
@@ -2,7 +2,7 @@
 
 set -m
 
-hostname "$HOSTNAME" > /dev/null
+hostname "$HOSTNAME" &> /dev/null
 if [[ $? == 0 ]]; then
 	PRIVILEGED=true
 else

--- a/debian/amd64/stretch/entry.sh
+++ b/debian/amd64/stretch/entry.sh
@@ -2,7 +2,7 @@
 
 set -m
 
-hostname "$HOSTNAME" > /dev/null
+hostname "$HOSTNAME" &> /dev/null
 if [[ $? == 0 ]]; then
 	PRIVILEGED=true
 else

--- a/debian/amd64/wheezy/entry.sh
+++ b/debian/amd64/wheezy/entry.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-hostname "$HOSTNAME" > /dev/null
+hostname "$HOSTNAME" &> /dev/null
 if [[ $? == 0 ]]; then
 	PRIVILEGED=true
 else

--- a/debian/armel/buster/entry.sh
+++ b/debian/armel/buster/entry.sh
@@ -2,7 +2,7 @@
 
 set -m
 
-hostname "$HOSTNAME" > /dev/null
+hostname "$HOSTNAME" &> /dev/null
 if [[ $? == 0 ]]; then
 	PRIVILEGED=true
 else

--- a/debian/armel/jessie/entry.sh
+++ b/debian/armel/jessie/entry.sh
@@ -2,7 +2,7 @@
 
 set -m
 
-hostname "$HOSTNAME" > /dev/null
+hostname "$HOSTNAME" &> /dev/null
 if [[ $? == 0 ]]; then
 	PRIVILEGED=true
 else

--- a/debian/armel/stretch/entry.sh
+++ b/debian/armel/stretch/entry.sh
@@ -2,7 +2,7 @@
 
 set -m
 
-hostname "$HOSTNAME" > /dev/null
+hostname "$HOSTNAME" &> /dev/null
 if [[ $? == 0 ]]; then
 	PRIVILEGED=true
 else

--- a/debian/armel/wheezy/entry.sh
+++ b/debian/armel/wheezy/entry.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-hostname "$HOSTNAME" > /dev/null
+hostname "$HOSTNAME" &> /dev/null
 if [[ $? == 0 ]]; then
 	PRIVILEGED=true
 else

--- a/debian/armv7hf/buster/entry.sh
+++ b/debian/armv7hf/buster/entry.sh
@@ -2,7 +2,7 @@
 
 set -m
 
-hostname "$HOSTNAME" > /dev/null
+hostname "$HOSTNAME" &> /dev/null
 if [[ $? == 0 ]]; then
 	PRIVILEGED=true
 else

--- a/debian/armv7hf/jessie/entry.sh
+++ b/debian/armv7hf/jessie/entry.sh
@@ -2,7 +2,7 @@
 
 set -m
 
-hostname "$HOSTNAME" > /dev/null
+hostname "$HOSTNAME" &> /dev/null
 if [[ $? == 0 ]]; then
 	PRIVILEGED=true
 else

--- a/debian/armv7hf/sid/entry.sh
+++ b/debian/armv7hf/sid/entry.sh
@@ -2,7 +2,7 @@
 
 set -m
 
-hostname "$HOSTNAME" > /dev/null
+hostname "$HOSTNAME" &> /dev/null
 if [[ $? == 0 ]]; then
 	PRIVILEGED=true
 else

--- a/debian/armv7hf/stretch/entry.sh
+++ b/debian/armv7hf/stretch/entry.sh
@@ -2,7 +2,7 @@
 
 set -m
 
-hostname "$HOSTNAME" > /dev/null
+hostname "$HOSTNAME" &> /dev/null
 if [[ $? == 0 ]]; then
 	PRIVILEGED=true
 else

--- a/debian/armv7hf/wheezy/entry.sh
+++ b/debian/armv7hf/wheezy/entry.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-hostname "$HOSTNAME" > /dev/null
+hostname "$HOSTNAME" &> /dev/null
 if [[ $? == 0 ]]; then
 	PRIVILEGED=true
 else

--- a/debian/entry-nosystemd.sh
+++ b/debian/entry-nosystemd.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-hostname "$HOSTNAME" > /dev/null
+hostname "$HOSTNAME" &> /dev/null
 if [[ $? == 0 ]]; then
 	PRIVILEGED=true
 else

--- a/debian/entry.sh
+++ b/debian/entry.sh
@@ -2,7 +2,7 @@
 
 set -m
 
-hostname "$HOSTNAME" > /dev/null
+hostname "$HOSTNAME" &> /dev/null
 if [[ $? == 0 ]]; then
 	PRIVILEGED=true
 else

--- a/debian/i386/buster/entry.sh
+++ b/debian/i386/buster/entry.sh
@@ -2,7 +2,7 @@
 
 set -m
 
-hostname "$HOSTNAME" > /dev/null
+hostname "$HOSTNAME" &> /dev/null
 if [[ $? == 0 ]]; then
 	PRIVILEGED=true
 else

--- a/debian/i386/jessie/entry.sh
+++ b/debian/i386/jessie/entry.sh
@@ -2,7 +2,7 @@
 
 set -m
 
-hostname "$HOSTNAME" > /dev/null
+hostname "$HOSTNAME" &> /dev/null
 if [[ $? == 0 ]]; then
 	PRIVILEGED=true
 else

--- a/debian/i386/stretch/entry.sh
+++ b/debian/i386/stretch/entry.sh
@@ -2,7 +2,7 @@
 
 set -m
 
-hostname "$HOSTNAME" > /dev/null
+hostname "$HOSTNAME" &> /dev/null
 if [[ $? == 0 ]]; then
 	PRIVILEGED=true
 else

--- a/debian/i386/wheezy/entry.sh
+++ b/debian/i386/wheezy/entry.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-hostname "$HOSTNAME" > /dev/null
+hostname "$HOSTNAME" &> /dev/null
 if [[ $? == 0 ]]; then
 	PRIVILEGED=true
 else

--- a/fedora/aarch64/24/entry.sh
+++ b/fedora/aarch64/24/entry.sh
@@ -2,7 +2,7 @@
 
 set -m
 
-hostname "$HOSTNAME" > /dev/null
+hostname "$HOSTNAME" &> /dev/null
 if [[ $? == 0 ]]; then
 	PRIVILEGED=true
 else

--- a/fedora/aarch64/25/entry.sh
+++ b/fedora/aarch64/25/entry.sh
@@ -2,7 +2,7 @@
 
 set -m
 
-hostname "$HOSTNAME" > /dev/null
+hostname "$HOSTNAME" &> /dev/null
 if [[ $? == 0 ]]; then
 	PRIVILEGED=true
 else

--- a/fedora/aarch64/26/entry.sh
+++ b/fedora/aarch64/26/entry.sh
@@ -2,7 +2,7 @@
 
 set -m
 
-hostname "$HOSTNAME" > /dev/null
+hostname "$HOSTNAME" &> /dev/null
 if [[ $? == 0 ]]; then
 	PRIVILEGED=true
 else

--- a/fedora/amd64/24/entry.sh
+++ b/fedora/amd64/24/entry.sh
@@ -2,7 +2,7 @@
 
 set -m
 
-hostname "$HOSTNAME" > /dev/null
+hostname "$HOSTNAME" &> /dev/null
 if [[ $? == 0 ]]; then
 	PRIVILEGED=true
 else

--- a/fedora/amd64/25/entry.sh
+++ b/fedora/amd64/25/entry.sh
@@ -2,7 +2,7 @@
 
 set -m
 
-hostname "$HOSTNAME" > /dev/null
+hostname "$HOSTNAME" &> /dev/null
 if [[ $? == 0 ]]; then
 	PRIVILEGED=true
 else

--- a/fedora/amd64/26/entry.sh
+++ b/fedora/amd64/26/entry.sh
@@ -2,7 +2,7 @@
 
 set -m
 
-hostname "$HOSTNAME" > /dev/null
+hostname "$HOSTNAME" &> /dev/null
 if [[ $? == 0 ]]; then
 	PRIVILEGED=true
 else

--- a/fedora/armv7hf/24/entry.sh
+++ b/fedora/armv7hf/24/entry.sh
@@ -2,7 +2,7 @@
 
 set -m
 
-hostname "$HOSTNAME" > /dev/null
+hostname "$HOSTNAME" &> /dev/null
 if [[ $? == 0 ]]; then
 	PRIVILEGED=true
 else

--- a/fedora/armv7hf/25/entry.sh
+++ b/fedora/armv7hf/25/entry.sh
@@ -2,7 +2,7 @@
 
 set -m
 
-hostname "$HOSTNAME" > /dev/null
+hostname "$HOSTNAME" &> /dev/null
 if [[ $? == 0 ]]; then
 	PRIVILEGED=true
 else

--- a/fedora/armv7hf/26/entry.sh
+++ b/fedora/armv7hf/26/entry.sh
@@ -2,7 +2,7 @@
 
 set -m
 
-hostname "$HOSTNAME" > /dev/null
+hostname "$HOSTNAME" &> /dev/null
 if [[ $? == 0 ]]; then
 	PRIVILEGED=true
 else

--- a/fedora/entry.sh
+++ b/fedora/entry.sh
@@ -2,7 +2,7 @@
 
 set -m
 
-hostname "$HOSTNAME" > /dev/null
+hostname "$HOSTNAME" &> /dev/null
 if [[ $? == 0 ]]; then
 	PRIVILEGED=true
 else


### PR DESCRIPTION
To make sure users won't see any noisy logs.