### PR TITLE
Every blueprint should define the output path itself

### DIFF
--- a/scripts/blueprints/os-arch.yaml
+++ b/scripts/blueprints/os-arch.yaml
@@ -6,6 +6,7 @@ output:
   filename: Dockerfile
   type: sw.docker-image.os-arch
   slug: "{{children.arch.sw.slug}}-{{children.sw.os.slug}}:{{children.sw.os.version}}"
+  path: "{{children.sw.os.slug}}/{{children.arch.sw.slug}}/{{children.sw.os.version}}"
   requires:
     - type: hw.device-type
       arch: "{{children.arch.sw.slug}}"

--- a/scripts/generate-dockerfiles.js
+++ b/scripts/generate-dockerfiles.js
@@ -22,13 +22,6 @@ const path = require('path')
 const contrato = require('@resin.io/contrato')
 const yaml = require('js-yaml')
 
-const swapArrElements = (a, x, y) => {
-  // Swap array element from index x to y
-  if (a.length === 1) return a
-  a.splice(y, 1, a.splice(x, 1, a[y])[0])
-  return a
-}
-
 const DEST_DIR = path.join(__dirname, '../resin-base-images')
 const BLUEPRINT_PATHS = {
   'os-arch': path.join(__dirname, 'blueprints/os-arch.yaml')
@@ -91,7 +84,7 @@ for (const type of types) {
     const json = context.toJSON()
     const destination = path.join(
       DEST_DIR,
-      swapArrElements(json.slug.split(/:|-/g), 0, 1).join('/'),
+      json.path,
       query.output.filename
     )
 


### PR DESCRIPTION
The output path shouldn't be produced from slug as the script does.