### PR TITLE
entry-script: Use latest entry script when generates Dockerfile

### DIFF
--- a/resin-base-images/alpine/aarch64/3.5/entry.sh
+++ b/resin-base-images/alpine/aarch64/3.5/entry.sh
@@ -1,5 +1,13 @@
 #!/bin/bash
 
+
+hostname "$HOSTNAME" &> /dev/null
+if [[ $? == 0 ]]; then
+	PRIVILEGED=true
+else
+	PRIVILEGED=false
+fi
+
 function start_udev()
 {
 	if [ "$UDEV" == "on" ]; then
@@ -97,8 +105,12 @@ esac
 
 if [ ! -z "$RESIN_SUPERVISOR_API_KEY" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 	# run this on resin device only
-	update_hostname
-	mount_dev
+
+	if $PRIVILEGED; then
+		# Only run this in privileged container
+		update_hostname
+		mount_dev
+	fi
 	start_udev
 fi 
 

--- a/resin-base-images/alpine/aarch64/3.6/entry.sh
+++ b/resin-base-images/alpine/aarch64/3.6/entry.sh
@@ -1,5 +1,13 @@
 #!/bin/bash
 
+
+hostname "$HOSTNAME" &> /dev/null
+if [[ $? == 0 ]]; then
+	PRIVILEGED=true
+else
+	PRIVILEGED=false
+fi
+
 function start_udev()
 {
 	if [ "$UDEV" == "on" ]; then
@@ -97,8 +105,12 @@ esac
 
 if [ ! -z "$RESIN_SUPERVISOR_API_KEY" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 	# run this on resin device only
-	update_hostname
-	mount_dev
+
+	if $PRIVILEGED; then
+		# Only run this in privileged container
+		update_hostname
+		mount_dev
+	fi
 	start_udev
 fi 
 

--- a/resin-base-images/alpine/aarch64/3.7/entry.sh
+++ b/resin-base-images/alpine/aarch64/3.7/entry.sh
@@ -1,5 +1,13 @@
 #!/bin/bash
 
+
+hostname "$HOSTNAME" &> /dev/null
+if [[ $? == 0 ]]; then
+	PRIVILEGED=true
+else
+	PRIVILEGED=false
+fi
+
 function start_udev()
 {
 	if [ "$UDEV" == "on" ]; then
@@ -97,8 +105,12 @@ esac
 
 if [ ! -z "$RESIN_SUPERVISOR_API_KEY" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 	# run this on resin device only
-	update_hostname
-	mount_dev
+
+	if $PRIVILEGED; then
+		# Only run this in privileged container
+		update_hostname
+		mount_dev
+	fi
 	start_udev
 fi 
 

--- a/resin-base-images/alpine/aarch64/3.8/entry.sh
+++ b/resin-base-images/alpine/aarch64/3.8/entry.sh
@@ -1,5 +1,13 @@
 #!/bin/bash
 
+
+hostname "$HOSTNAME" &> /dev/null
+if [[ $? == 0 ]]; then
+	PRIVILEGED=true
+else
+	PRIVILEGED=false
+fi
+
 function start_udev()
 {
 	if [ "$UDEV" == "on" ]; then
@@ -97,8 +105,12 @@ esac
 
 if [ ! -z "$RESIN_SUPERVISOR_API_KEY" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 	# run this on resin device only
-	update_hostname
-	mount_dev
+
+	if $PRIVILEGED; then
+		# Only run this in privileged container
+		update_hostname
+		mount_dev
+	fi
 	start_udev
 fi 
 

--- a/resin-base-images/alpine/aarch64/edge/entry.sh
+++ b/resin-base-images/alpine/aarch64/edge/entry.sh
@@ -1,5 +1,13 @@
 #!/bin/bash
 
+
+hostname "$HOSTNAME" &> /dev/null
+if [[ $? == 0 ]]; then
+	PRIVILEGED=true
+else
+	PRIVILEGED=false
+fi
+
 function start_udev()
 {
 	if [ "$UDEV" == "on" ]; then
@@ -97,8 +105,12 @@ esac
 
 if [ ! -z "$RESIN_SUPERVISOR_API_KEY" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 	# run this on resin device only
-	update_hostname
-	mount_dev
+
+	if $PRIVILEGED; then
+		# Only run this in privileged container
+		update_hostname
+		mount_dev
+	fi
 	start_udev
 fi 
 

--- a/resin-base-images/alpine/amd64/3.5/entry.sh
+++ b/resin-base-images/alpine/amd64/3.5/entry.sh
@@ -1,5 +1,13 @@
 #!/bin/bash
 
+
+hostname "$HOSTNAME" &> /dev/null
+if [[ $? == 0 ]]; then
+	PRIVILEGED=true
+else
+	PRIVILEGED=false
+fi
+
 function start_udev()
 {
 	if [ "$UDEV" == "on" ]; then
@@ -97,8 +105,12 @@ esac
 
 if [ ! -z "$RESIN_SUPERVISOR_API_KEY" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 	# run this on resin device only
-	update_hostname
-	mount_dev
+
+	if $PRIVILEGED; then
+		# Only run this in privileged container
+		update_hostname
+		mount_dev
+	fi
 	start_udev
 fi 
 

--- a/resin-base-images/alpine/amd64/3.6/entry.sh
+++ b/resin-base-images/alpine/amd64/3.6/entry.sh
@@ -1,5 +1,13 @@
 #!/bin/bash
 
+
+hostname "$HOSTNAME" &> /dev/null
+if [[ $? == 0 ]]; then
+	PRIVILEGED=true
+else
+	PRIVILEGED=false
+fi
+
 function start_udev()
 {
 	if [ "$UDEV" == "on" ]; then
@@ -97,8 +105,12 @@ esac
 
 if [ ! -z "$RESIN_SUPERVISOR_API_KEY" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 	# run this on resin device only
-	update_hostname
-	mount_dev
+
+	if $PRIVILEGED; then
+		# Only run this in privileged container
+		update_hostname
+		mount_dev
+	fi
 	start_udev
 fi 
 

--- a/resin-base-images/alpine/amd64/3.7/entry.sh
+++ b/resin-base-images/alpine/amd64/3.7/entry.sh
@@ -1,5 +1,13 @@
 #!/bin/bash
 
+
+hostname "$HOSTNAME" &> /dev/null
+if [[ $? == 0 ]]; then
+	PRIVILEGED=true
+else
+	PRIVILEGED=false
+fi
+
 function start_udev()
 {
 	if [ "$UDEV" == "on" ]; then
@@ -97,8 +105,12 @@ esac
 
 if [ ! -z "$RESIN_SUPERVISOR_API_KEY" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 	# run this on resin device only
-	update_hostname
-	mount_dev
+
+	if $PRIVILEGED; then
+		# Only run this in privileged container
+		update_hostname
+		mount_dev
+	fi
 	start_udev
 fi 
 

--- a/resin-base-images/alpine/amd64/3.8/entry.sh
+++ b/resin-base-images/alpine/amd64/3.8/entry.sh
@@ -1,5 +1,13 @@
 #!/bin/bash
 
+
+hostname "$HOSTNAME" &> /dev/null
+if [[ $? == 0 ]]; then
+	PRIVILEGED=true
+else
+	PRIVILEGED=false
+fi
+
 function start_udev()
 {
 	if [ "$UDEV" == "on" ]; then
@@ -97,8 +105,12 @@ esac
 
 if [ ! -z "$RESIN_SUPERVISOR_API_KEY" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 	# run this on resin device only
-	update_hostname
-	mount_dev
+
+	if $PRIVILEGED; then
+		# Only run this in privileged container
+		update_hostname
+		mount_dev
+	fi
 	start_udev
 fi 
 

--- a/resin-base-images/alpine/amd64/edge/entry.sh
+++ b/resin-base-images/alpine/amd64/edge/entry.sh
@@ -1,5 +1,13 @@
 #!/bin/bash
 
+
+hostname "$HOSTNAME" &> /dev/null
+if [[ $? == 0 ]]; then
+	PRIVILEGED=true
+else
+	PRIVILEGED=false
+fi
+
 function start_udev()
 {
 	if [ "$UDEV" == "on" ]; then
@@ -97,8 +105,12 @@ esac
 
 if [ ! -z "$RESIN_SUPERVISOR_API_KEY" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 	# run this on resin device only
-	update_hostname
-	mount_dev
+
+	if $PRIVILEGED; then
+		# Only run this in privileged container
+		update_hostname
+		mount_dev
+	fi
 	start_udev
 fi 
 

--- a/resin-base-images/alpine/armv7hf/3.5/entry.sh
+++ b/resin-base-images/alpine/armv7hf/3.5/entry.sh
@@ -1,5 +1,13 @@
 #!/bin/bash
 
+
+hostname "$HOSTNAME" &> /dev/null
+if [[ $? == 0 ]]; then
+	PRIVILEGED=true
+else
+	PRIVILEGED=false
+fi
+
 function start_udev()
 {
 	if [ "$UDEV" == "on" ]; then
@@ -97,8 +105,12 @@ esac
 
 if [ ! -z "$RESIN_SUPERVISOR_API_KEY" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 	# run this on resin device only
-	update_hostname
-	mount_dev
+
+	if $PRIVILEGED; then
+		# Only run this in privileged container
+		update_hostname
+		mount_dev
+	fi
 	start_udev
 fi 
 

--- a/resin-base-images/alpine/armv7hf/3.6/entry.sh
+++ b/resin-base-images/alpine/armv7hf/3.6/entry.sh
@@ -1,5 +1,13 @@
 #!/bin/bash
 
+
+hostname "$HOSTNAME" &> /dev/null
+if [[ $? == 0 ]]; then
+	PRIVILEGED=true
+else
+	PRIVILEGED=false
+fi
+
 function start_udev()
 {
 	if [ "$UDEV" == "on" ]; then
@@ -97,8 +105,12 @@ esac
 
 if [ ! -z "$RESIN_SUPERVISOR_API_KEY" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 	# run this on resin device only
-	update_hostname
-	mount_dev
+
+	if $PRIVILEGED; then
+		# Only run this in privileged container
+		update_hostname
+		mount_dev
+	fi
 	start_udev
 fi 
 

--- a/resin-base-images/alpine/armv7hf/3.7/entry.sh
+++ b/resin-base-images/alpine/armv7hf/3.7/entry.sh
@@ -1,5 +1,13 @@
 #!/bin/bash
 
+
+hostname "$HOSTNAME" &> /dev/null
+if [[ $? == 0 ]]; then
+	PRIVILEGED=true
+else
+	PRIVILEGED=false
+fi
+
 function start_udev()
 {
 	if [ "$UDEV" == "on" ]; then
@@ -97,8 +105,12 @@ esac
 
 if [ ! -z "$RESIN_SUPERVISOR_API_KEY" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 	# run this on resin device only
-	update_hostname
-	mount_dev
+
+	if $PRIVILEGED; then
+		# Only run this in privileged container
+		update_hostname
+		mount_dev
+	fi
 	start_udev
 fi 
 

--- a/resin-base-images/alpine/armv7hf/3.8/entry.sh
+++ b/resin-base-images/alpine/armv7hf/3.8/entry.sh
@@ -1,5 +1,13 @@
 #!/bin/bash
 
+
+hostname "$HOSTNAME" &> /dev/null
+if [[ $? == 0 ]]; then
+	PRIVILEGED=true
+else
+	PRIVILEGED=false
+fi
+
 function start_udev()
 {
 	if [ "$UDEV" == "on" ]; then
@@ -97,8 +105,12 @@ esac
 
 if [ ! -z "$RESIN_SUPERVISOR_API_KEY" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 	# run this on resin device only
-	update_hostname
-	mount_dev
+
+	if $PRIVILEGED; then
+		# Only run this in privileged container
+		update_hostname
+		mount_dev
+	fi
 	start_udev
 fi 
 

--- a/resin-base-images/alpine/armv7hf/edge/entry.sh
+++ b/resin-base-images/alpine/armv7hf/edge/entry.sh
@@ -1,5 +1,13 @@
 #!/bin/bash
 
+
+hostname "$HOSTNAME" &> /dev/null
+if [[ $? == 0 ]]; then
+	PRIVILEGED=true
+else
+	PRIVILEGED=false
+fi
+
 function start_udev()
 {
 	if [ "$UDEV" == "on" ]; then
@@ -97,8 +105,12 @@ esac
 
 if [ ! -z "$RESIN_SUPERVISOR_API_KEY" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 	# run this on resin device only
-	update_hostname
-	mount_dev
+
+	if $PRIVILEGED; then
+		# Only run this in privileged container
+		update_hostname
+		mount_dev
+	fi
 	start_udev
 fi 
 

--- a/resin-base-images/alpine/i386-nlp/3.5/entry.sh
+++ b/resin-base-images/alpine/i386-nlp/3.5/entry.sh
@@ -1,5 +1,13 @@
 #!/bin/bash
 
+
+hostname "$HOSTNAME" &> /dev/null
+if [[ $? == 0 ]]; then
+	PRIVILEGED=true
+else
+	PRIVILEGED=false
+fi
+
 function start_udev()
 {
 	if [ "$UDEV" == "on" ]; then
@@ -97,8 +105,12 @@ esac
 
 if [ ! -z "$RESIN_SUPERVISOR_API_KEY" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 	# run this on resin device only
-	update_hostname
-	mount_dev
+
+	if $PRIVILEGED; then
+		# Only run this in privileged container
+		update_hostname
+		mount_dev
+	fi
 	start_udev
 fi 
 

--- a/resin-base-images/alpine/i386-nlp/3.6/entry.sh
+++ b/resin-base-images/alpine/i386-nlp/3.6/entry.sh
@@ -1,5 +1,13 @@
 #!/bin/bash
 
+
+hostname "$HOSTNAME" &> /dev/null
+if [[ $? == 0 ]]; then
+	PRIVILEGED=true
+else
+	PRIVILEGED=false
+fi
+
 function start_udev()
 {
 	if [ "$UDEV" == "on" ]; then
@@ -97,8 +105,12 @@ esac
 
 if [ ! -z "$RESIN_SUPERVISOR_API_KEY" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 	# run this on resin device only
-	update_hostname
-	mount_dev
+
+	if $PRIVILEGED; then
+		# Only run this in privileged container
+		update_hostname
+		mount_dev
+	fi
 	start_udev
 fi 
 

--- a/resin-base-images/alpine/i386-nlp/3.7/entry.sh
+++ b/resin-base-images/alpine/i386-nlp/3.7/entry.sh
@@ -1,5 +1,13 @@
 #!/bin/bash
 
+
+hostname "$HOSTNAME" &> /dev/null
+if [[ $? == 0 ]]; then
+	PRIVILEGED=true
+else
+	PRIVILEGED=false
+fi
+
 function start_udev()
 {
 	if [ "$UDEV" == "on" ]; then
@@ -97,8 +105,12 @@ esac
 
 if [ ! -z "$RESIN_SUPERVISOR_API_KEY" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 	# run this on resin device only
-	update_hostname
-	mount_dev
+
+	if $PRIVILEGED; then
+		# Only run this in privileged container
+		update_hostname
+		mount_dev
+	fi
 	start_udev
 fi 
 

--- a/resin-base-images/alpine/i386-nlp/3.8/entry.sh
+++ b/resin-base-images/alpine/i386-nlp/3.8/entry.sh
@@ -1,5 +1,13 @@
 #!/bin/bash
 
+
+hostname "$HOSTNAME" &> /dev/null
+if [[ $? == 0 ]]; then
+	PRIVILEGED=true
+else
+	PRIVILEGED=false
+fi
+
 function start_udev()
 {
 	if [ "$UDEV" == "on" ]; then
@@ -97,8 +105,12 @@ esac
 
 if [ ! -z "$RESIN_SUPERVISOR_API_KEY" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 	# run this on resin device only
-	update_hostname
-	mount_dev
+
+	if $PRIVILEGED; then
+		# Only run this in privileged container
+		update_hostname
+		mount_dev
+	fi
 	start_udev
 fi 
 

--- a/resin-base-images/alpine/i386-nlp/edge/entry.sh
+++ b/resin-base-images/alpine/i386-nlp/edge/entry.sh
@@ -1,5 +1,13 @@
 #!/bin/bash
 
+
+hostname "$HOSTNAME" &> /dev/null
+if [[ $? == 0 ]]; then
+	PRIVILEGED=true
+else
+	PRIVILEGED=false
+fi
+
 function start_udev()
 {
 	if [ "$UDEV" == "on" ]; then
@@ -97,8 +105,12 @@ esac
 
 if [ ! -z "$RESIN_SUPERVISOR_API_KEY" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 	# run this on resin device only
-	update_hostname
-	mount_dev
+
+	if $PRIVILEGED; then
+		# Only run this in privileged container
+		update_hostname
+		mount_dev
+	fi
 	start_udev
 fi 
 

--- a/resin-base-images/alpine/i386/3.5/entry.sh
+++ b/resin-base-images/alpine/i386/3.5/entry.sh
@@ -1,5 +1,13 @@
 #!/bin/bash
 
+
+hostname "$HOSTNAME" &> /dev/null
+if [[ $? == 0 ]]; then
+	PRIVILEGED=true
+else
+	PRIVILEGED=false
+fi
+
 function start_udev()
 {
 	if [ "$UDEV" == "on" ]; then
@@ -97,8 +105,12 @@ esac
 
 if [ ! -z "$RESIN_SUPERVISOR_API_KEY" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 	# run this on resin device only
-	update_hostname
-	mount_dev
+
+	if $PRIVILEGED; then
+		# Only run this in privileged container
+		update_hostname
+		mount_dev
+	fi
 	start_udev
 fi 
 

--- a/resin-base-images/alpine/i386/3.6/entry.sh
+++ b/resin-base-images/alpine/i386/3.6/entry.sh
@@ -1,5 +1,13 @@
 #!/bin/bash
 
+
+hostname "$HOSTNAME" &> /dev/null
+if [[ $? == 0 ]]; then
+	PRIVILEGED=true
+else
+	PRIVILEGED=false
+fi
+
 function start_udev()
 {
 	if [ "$UDEV" == "on" ]; then
@@ -97,8 +105,12 @@ esac
 
 if [ ! -z "$RESIN_SUPERVISOR_API_KEY" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 	# run this on resin device only
-	update_hostname
-	mount_dev
+
+	if $PRIVILEGED; then
+		# Only run this in privileged container
+		update_hostname
+		mount_dev
+	fi
 	start_udev
 fi 
 

--- a/resin-base-images/alpine/i386/3.7/entry.sh
+++ b/resin-base-images/alpine/i386/3.7/entry.sh
@@ -1,5 +1,13 @@
 #!/bin/bash
 
+
+hostname "$HOSTNAME" &> /dev/null
+if [[ $? == 0 ]]; then
+	PRIVILEGED=true
+else
+	PRIVILEGED=false
+fi
+
 function start_udev()
 {
 	if [ "$UDEV" == "on" ]; then
@@ -97,8 +105,12 @@ esac
 
 if [ ! -z "$RESIN_SUPERVISOR_API_KEY" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 	# run this on resin device only
-	update_hostname
-	mount_dev
+
+	if $PRIVILEGED; then
+		# Only run this in privileged container
+		update_hostname
+		mount_dev
+	fi
 	start_udev
 fi 
 

--- a/resin-base-images/alpine/i386/3.8/entry.sh
+++ b/resin-base-images/alpine/i386/3.8/entry.sh
@@ -1,5 +1,13 @@
 #!/bin/bash
 
+
+hostname "$HOSTNAME" &> /dev/null
+if [[ $? == 0 ]]; then
+	PRIVILEGED=true
+else
+	PRIVILEGED=false
+fi
+
 function start_udev()
 {
 	if [ "$UDEV" == "on" ]; then
@@ -97,8 +105,12 @@ esac
 
 if [ ! -z "$RESIN_SUPERVISOR_API_KEY" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 	# run this on resin device only
-	update_hostname
-	mount_dev
+
+	if $PRIVILEGED; then
+		# Only run this in privileged container
+		update_hostname
+		mount_dev
+	fi
 	start_udev
 fi 
 

--- a/resin-base-images/alpine/i386/edge/entry.sh
+++ b/resin-base-images/alpine/i386/edge/entry.sh
@@ -1,5 +1,13 @@
 #!/bin/bash
 
+
+hostname "$HOSTNAME" &> /dev/null
+if [[ $? == 0 ]]; then
+	PRIVILEGED=true
+else
+	PRIVILEGED=false
+fi
+
 function start_udev()
 {
 	if [ "$UDEV" == "on" ]; then
@@ -97,8 +105,12 @@ esac
 
 if [ ! -z "$RESIN_SUPERVISOR_API_KEY" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 	# run this on resin device only
-	update_hostname
-	mount_dev
+
+	if $PRIVILEGED; then
+		# Only run this in privileged container
+		update_hostname
+		mount_dev
+	fi
 	start_udev
 fi 
 

--- a/resin-base-images/alpine/rpi/3.5/entry.sh
+++ b/resin-base-images/alpine/rpi/3.5/entry.sh
@@ -1,5 +1,13 @@
 #!/bin/bash
 
+
+hostname "$HOSTNAME" &> /dev/null
+if [[ $? == 0 ]]; then
+	PRIVILEGED=true
+else
+	PRIVILEGED=false
+fi
+
 function start_udev()
 {
 	if [ "$UDEV" == "on" ]; then
@@ -97,8 +105,12 @@ esac
 
 if [ ! -z "$RESIN_SUPERVISOR_API_KEY" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 	# run this on resin device only
-	update_hostname
-	mount_dev
+
+	if $PRIVILEGED; then
+		# Only run this in privileged container
+		update_hostname
+		mount_dev
+	fi
 	start_udev
 fi 
 

--- a/resin-base-images/alpine/rpi/3.6/entry.sh
+++ b/resin-base-images/alpine/rpi/3.6/entry.sh
@@ -1,5 +1,13 @@
 #!/bin/bash
 
+
+hostname "$HOSTNAME" &> /dev/null
+if [[ $? == 0 ]]; then
+	PRIVILEGED=true
+else
+	PRIVILEGED=false
+fi
+
 function start_udev()
 {
 	if [ "$UDEV" == "on" ]; then
@@ -97,8 +105,12 @@ esac
 
 if [ ! -z "$RESIN_SUPERVISOR_API_KEY" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 	# run this on resin device only
-	update_hostname
-	mount_dev
+
+	if $PRIVILEGED; then
+		# Only run this in privileged container
+		update_hostname
+		mount_dev
+	fi
 	start_udev
 fi 
 

--- a/resin-base-images/alpine/rpi/3.7/entry.sh
+++ b/resin-base-images/alpine/rpi/3.7/entry.sh
@@ -1,5 +1,13 @@
 #!/bin/bash
 
+
+hostname "$HOSTNAME" &> /dev/null
+if [[ $? == 0 ]]; then
+	PRIVILEGED=true
+else
+	PRIVILEGED=false
+fi
+
 function start_udev()
 {
 	if [ "$UDEV" == "on" ]; then
@@ -97,8 +105,12 @@ esac
 
 if [ ! -z "$RESIN_SUPERVISOR_API_KEY" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 	# run this on resin device only
-	update_hostname
-	mount_dev
+
+	if $PRIVILEGED; then
+		# Only run this in privileged container
+		update_hostname
+		mount_dev
+	fi
 	start_udev
 fi 
 

--- a/resin-base-images/alpine/rpi/3.8/entry.sh
+++ b/resin-base-images/alpine/rpi/3.8/entry.sh
@@ -1,5 +1,13 @@
 #!/bin/bash
 
+
+hostname "$HOSTNAME" &> /dev/null
+if [[ $? == 0 ]]; then
+	PRIVILEGED=true
+else
+	PRIVILEGED=false
+fi
+
 function start_udev()
 {
 	if [ "$UDEV" == "on" ]; then
@@ -97,8 +105,12 @@ esac
 
 if [ ! -z "$RESIN_SUPERVISOR_API_KEY" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 	# run this on resin device only
-	update_hostname
-	mount_dev
+
+	if $PRIVILEGED; then
+		# Only run this in privileged container
+		update_hostname
+		mount_dev
+	fi
 	start_udev
 fi 
 

--- a/resin-base-images/alpine/rpi/edge/entry.sh
+++ b/resin-base-images/alpine/rpi/edge/entry.sh
@@ -1,5 +1,13 @@
 #!/bin/bash
 
+
+hostname "$HOSTNAME" &> /dev/null
+if [[ $? == 0 ]]; then
+	PRIVILEGED=true
+else
+	PRIVILEGED=false
+fi
+
 function start_udev()
 {
 	if [ "$UDEV" == "on" ]; then
@@ -97,8 +105,12 @@ esac
 
 if [ ! -z "$RESIN_SUPERVISOR_API_KEY" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 	# run this on resin device only
-	update_hostname
-	mount_dev
+
+	if $PRIVILEGED; then
+		# Only run this in privileged container
+		update_hostname
+		mount_dev
+	fi
 	start_udev
 fi 
 

--- a/resin-base-images/debian/aarch64/buster/entry.sh
+++ b/resin-base-images/debian/aarch64/buster/entry.sh
@@ -2,6 +2,13 @@
 
 set -m
 
+hostname "$HOSTNAME" &> /dev/null
+if [[ $? == 0 ]]; then
+	PRIVILEGED=true
+else
+	PRIVILEGED=false
+fi
+
 function start_udev()
 {
 	if [ "$UDEV" == "on" ]; then
@@ -127,8 +134,12 @@ esac
 
 if [ ! -z "$RESIN" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 	# run this on resin device only
-	update_hostname
-	mount_dev
+
+	if $PRIVILEGED; then
+		# Only run this in privileged container
+		update_hostname
+		mount_dev
+	fi
 	start_udev
 fi 
 

--- a/resin-base-images/debian/aarch64/jessie/entry.sh
+++ b/resin-base-images/debian/aarch64/jessie/entry.sh
@@ -2,6 +2,13 @@
 
 set -m
 
+hostname "$HOSTNAME" &> /dev/null
+if [[ $? == 0 ]]; then
+	PRIVILEGED=true
+else
+	PRIVILEGED=false
+fi
+
 function start_udev()
 {
 	if [ "$UDEV" == "on" ]; then
@@ -127,8 +134,12 @@ esac
 
 if [ ! -z "$RESIN" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 	# run this on resin device only
-	update_hostname
-	mount_dev
+
+	if $PRIVILEGED; then
+		# Only run this in privileged container
+		update_hostname
+		mount_dev
+	fi
 	start_udev
 fi 
 

--- a/resin-base-images/debian/aarch64/sid/entry.sh
+++ b/resin-base-images/debian/aarch64/sid/entry.sh
@@ -2,6 +2,13 @@
 
 set -m
 
+hostname "$HOSTNAME" &> /dev/null
+if [[ $? == 0 ]]; then
+	PRIVILEGED=true
+else
+	PRIVILEGED=false
+fi
+
 function start_udev()
 {
 	if [ "$UDEV" == "on" ]; then
@@ -127,8 +134,12 @@ esac
 
 if [ ! -z "$RESIN" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 	# run this on resin device only
-	update_hostname
-	mount_dev
+
+	if $PRIVILEGED; then
+		# Only run this in privileged container
+		update_hostname
+		mount_dev
+	fi
 	start_udev
 fi 
 

--- a/resin-base-images/debian/aarch64/stretch/entry.sh
+++ b/resin-base-images/debian/aarch64/stretch/entry.sh
@@ -2,6 +2,13 @@
 
 set -m
 
+hostname "$HOSTNAME" &> /dev/null
+if [[ $? == 0 ]]; then
+	PRIVILEGED=true
+else
+	PRIVILEGED=false
+fi
+
 function start_udev()
 {
 	if [ "$UDEV" == "on" ]; then
@@ -127,8 +134,12 @@ esac
 
 if [ ! -z "$RESIN" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 	# run this on resin device only
-	update_hostname
-	mount_dev
+
+	if $PRIVILEGED; then
+		# Only run this in privileged container
+		update_hostname
+		mount_dev
+	fi
 	start_udev
 fi 
 

--- a/resin-base-images/debian/amd64/buster/entry.sh
+++ b/resin-base-images/debian/amd64/buster/entry.sh
@@ -2,6 +2,13 @@
 
 set -m
 
+hostname "$HOSTNAME" &> /dev/null
+if [[ $? == 0 ]]; then
+	PRIVILEGED=true
+else
+	PRIVILEGED=false
+fi
+
 function start_udev()
 {
 	if [ "$UDEV" == "on" ]; then
@@ -127,8 +134,12 @@ esac
 
 if [ ! -z "$RESIN" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 	# run this on resin device only
-	update_hostname
-	mount_dev
+
+	if $PRIVILEGED; then
+		# Only run this in privileged container
+		update_hostname
+		mount_dev
+	fi
 	start_udev
 fi 
 

--- a/resin-base-images/debian/amd64/jessie/entry.sh
+++ b/resin-base-images/debian/amd64/jessie/entry.sh
@@ -2,6 +2,13 @@
 
 set -m
 
+hostname "$HOSTNAME" &> /dev/null
+if [[ $? == 0 ]]; then
+	PRIVILEGED=true
+else
+	PRIVILEGED=false
+fi
+
 function start_udev()
 {
 	if [ "$UDEV" == "on" ]; then
@@ -127,8 +134,12 @@ esac
 
 if [ ! -z "$RESIN" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 	# run this on resin device only
-	update_hostname
-	mount_dev
+
+	if $PRIVILEGED; then
+		# Only run this in privileged container
+		update_hostname
+		mount_dev
+	fi
 	start_udev
 fi 
 

--- a/resin-base-images/debian/amd64/sid/entry.sh
+++ b/resin-base-images/debian/amd64/sid/entry.sh
@@ -2,6 +2,13 @@
 
 set -m
 
+hostname "$HOSTNAME" &> /dev/null
+if [[ $? == 0 ]]; then
+	PRIVILEGED=true
+else
+	PRIVILEGED=false
+fi
+
 function start_udev()
 {
 	if [ "$UDEV" == "on" ]; then
@@ -127,8 +134,12 @@ esac
 
 if [ ! -z "$RESIN" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 	# run this on resin device only
-	update_hostname
-	mount_dev
+
+	if $PRIVILEGED; then
+		# Only run this in privileged container
+		update_hostname
+		mount_dev
+	fi
 	start_udev
 fi 
 

--- a/resin-base-images/debian/amd64/stretch/entry.sh
+++ b/resin-base-images/debian/amd64/stretch/entry.sh
@@ -2,6 +2,13 @@
 
 set -m
 
+hostname "$HOSTNAME" &> /dev/null
+if [[ $? == 0 ]]; then
+	PRIVILEGED=true
+else
+	PRIVILEGED=false
+fi
+
 function start_udev()
 {
 	if [ "$UDEV" == "on" ]; then
@@ -127,8 +134,12 @@ esac
 
 if [ ! -z "$RESIN" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 	# run this on resin device only
-	update_hostname
-	mount_dev
+
+	if $PRIVILEGED; then
+		# Only run this in privileged container
+		update_hostname
+		mount_dev
+	fi
 	start_udev
 fi 
 

--- a/resin-base-images/debian/amd64/wheezy/entry.sh
+++ b/resin-base-images/debian/amd64/wheezy/entry.sh
@@ -1,5 +1,12 @@
 #!/bin/bash
 
+hostname "$HOSTNAME" &> /dev/null
+if [[ $? == 0 ]]; then
+	PRIVILEGED=true
+else
+	PRIVILEGED=false
+fi
+
 function start_udev()
 {
 	if [ "$UDEV" == "on" ]; then
@@ -88,8 +95,12 @@ esac
 
 if [ ! -z "$RESIN_SUPERVISOR_API_KEY" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 	# run this on resin device only
-	update_hostname
-	mount_dev
+
+	if $PRIVILEGED; then
+		# Only run this in privileged container
+		update_hostname
+		mount_dev
+	fi
 	start_udev
 fi 
 

--- a/resin-base-images/debian/armv5e/buster/entry.sh
+++ b/resin-base-images/debian/armv5e/buster/entry.sh
@@ -2,6 +2,13 @@
 
 set -m
 
+hostname "$HOSTNAME" &> /dev/null
+if [[ $? == 0 ]]; then
+	PRIVILEGED=true
+else
+	PRIVILEGED=false
+fi
+
 function start_udev()
 {
 	if [ "$UDEV" == "on" ]; then
@@ -127,8 +134,12 @@ esac
 
 if [ ! -z "$RESIN" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 	# run this on resin device only
-	update_hostname
-	mount_dev
+
+	if $PRIVILEGED; then
+		# Only run this in privileged container
+		update_hostname
+		mount_dev
+	fi
 	start_udev
 fi 
 

--- a/resin-base-images/debian/armv5e/jessie/entry.sh
+++ b/resin-base-images/debian/armv5e/jessie/entry.sh
@@ -2,6 +2,13 @@
 
 set -m
 
+hostname "$HOSTNAME" &> /dev/null
+if [[ $? == 0 ]]; then
+	PRIVILEGED=true
+else
+	PRIVILEGED=false
+fi
+
 function start_udev()
 {
 	if [ "$UDEV" == "on" ]; then
@@ -127,8 +134,12 @@ esac
 
 if [ ! -z "$RESIN" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 	# run this on resin device only
-	update_hostname
-	mount_dev
+
+	if $PRIVILEGED; then
+		# Only run this in privileged container
+		update_hostname
+		mount_dev
+	fi
 	start_udev
 fi 
 

--- a/resin-base-images/debian/armv5e/sid/entry.sh
+++ b/resin-base-images/debian/armv5e/sid/entry.sh
@@ -2,6 +2,13 @@
 
 set -m
 
+hostname "$HOSTNAME" &> /dev/null
+if [[ $? == 0 ]]; then
+	PRIVILEGED=true
+else
+	PRIVILEGED=false
+fi
+
 function start_udev()
 {
 	if [ "$UDEV" == "on" ]; then
@@ -127,8 +134,12 @@ esac
 
 if [ ! -z "$RESIN" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 	# run this on resin device only
-	update_hostname
-	mount_dev
+
+	if $PRIVILEGED; then
+		# Only run this in privileged container
+		update_hostname
+		mount_dev
+	fi
 	start_udev
 fi 
 

--- a/resin-base-images/debian/armv5e/stretch/entry.sh
+++ b/resin-base-images/debian/armv5e/stretch/entry.sh
@@ -2,6 +2,13 @@
 
 set -m
 
+hostname "$HOSTNAME" &> /dev/null
+if [[ $? == 0 ]]; then
+	PRIVILEGED=true
+else
+	PRIVILEGED=false
+fi
+
 function start_udev()
 {
 	if [ "$UDEV" == "on" ]; then
@@ -127,8 +134,12 @@ esac
 
 if [ ! -z "$RESIN" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 	# run this on resin device only
-	update_hostname
-	mount_dev
+
+	if $PRIVILEGED; then
+		# Only run this in privileged container
+		update_hostname
+		mount_dev
+	fi
 	start_udev
 fi 
 

--- a/resin-base-images/debian/armv5e/wheezy/entry.sh
+++ b/resin-base-images/debian/armv5e/wheezy/entry.sh
@@ -1,5 +1,12 @@
 #!/bin/bash
 
+hostname "$HOSTNAME" &> /dev/null
+if [[ $? == 0 ]]; then
+	PRIVILEGED=true
+else
+	PRIVILEGED=false
+fi
+
 function start_udev()
 {
 	if [ "$UDEV" == "on" ]; then
@@ -88,8 +95,12 @@ esac
 
 if [ ! -z "$RESIN_SUPERVISOR_API_KEY" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 	# run this on resin device only
-	update_hostname
-	mount_dev
+
+	if $PRIVILEGED; then
+		# Only run this in privileged container
+		update_hostname
+		mount_dev
+	fi
 	start_udev
 fi 
 

--- a/resin-base-images/debian/armv7hf/buster/entry.sh
+++ b/resin-base-images/debian/armv7hf/buster/entry.sh
@@ -2,6 +2,13 @@
 
 set -m
 
+hostname "$HOSTNAME" &> /dev/null
+if [[ $? == 0 ]]; then
+	PRIVILEGED=true
+else
+	PRIVILEGED=false
+fi
+
 function start_udev()
 {
 	if [ "$UDEV" == "on" ]; then
@@ -127,8 +134,12 @@ esac
 
 if [ ! -z "$RESIN" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 	# run this on resin device only
-	update_hostname
-	mount_dev
+
+	if $PRIVILEGED; then
+		# Only run this in privileged container
+		update_hostname
+		mount_dev
+	fi
 	start_udev
 fi 
 

--- a/resin-base-images/debian/armv7hf/jessie/entry.sh
+++ b/resin-base-images/debian/armv7hf/jessie/entry.sh
@@ -2,6 +2,13 @@
 
 set -m
 
+hostname "$HOSTNAME" &> /dev/null
+if [[ $? == 0 ]]; then
+	PRIVILEGED=true
+else
+	PRIVILEGED=false
+fi
+
 function start_udev()
 {
 	if [ "$UDEV" == "on" ]; then
@@ -127,8 +134,12 @@ esac
 
 if [ ! -z "$RESIN" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 	# run this on resin device only
-	update_hostname
-	mount_dev
+
+	if $PRIVILEGED; then
+		# Only run this in privileged container
+		update_hostname
+		mount_dev
+	fi
 	start_udev
 fi 
 

--- a/resin-base-images/debian/armv7hf/sid/entry.sh
+++ b/resin-base-images/debian/armv7hf/sid/entry.sh
@@ -2,6 +2,13 @@
 
 set -m
 
+hostname "$HOSTNAME" &> /dev/null
+if [[ $? == 0 ]]; then
+	PRIVILEGED=true
+else
+	PRIVILEGED=false
+fi
+
 function start_udev()
 {
 	if [ "$UDEV" == "on" ]; then
@@ -127,8 +134,12 @@ esac
 
 if [ ! -z "$RESIN" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 	# run this on resin device only
-	update_hostname
-	mount_dev
+
+	if $PRIVILEGED; then
+		# Only run this in privileged container
+		update_hostname
+		mount_dev
+	fi
 	start_udev
 fi 
 

--- a/resin-base-images/debian/armv7hf/stretch/entry.sh
+++ b/resin-base-images/debian/armv7hf/stretch/entry.sh
@@ -2,6 +2,13 @@
 
 set -m
 
+hostname "$HOSTNAME" &> /dev/null
+if [[ $? == 0 ]]; then
+	PRIVILEGED=true
+else
+	PRIVILEGED=false
+fi
+
 function start_udev()
 {
 	if [ "$UDEV" == "on" ]; then
@@ -127,8 +134,12 @@ esac
 
 if [ ! -z "$RESIN" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 	# run this on resin device only
-	update_hostname
-	mount_dev
+
+	if $PRIVILEGED; then
+		# Only run this in privileged container
+		update_hostname
+		mount_dev
+	fi
 	start_udev
 fi 
 

--- a/resin-base-images/debian/armv7hf/wheezy/entry.sh
+++ b/resin-base-images/debian/armv7hf/wheezy/entry.sh
@@ -1,5 +1,12 @@
 #!/bin/bash
 
+hostname "$HOSTNAME" &> /dev/null
+if [[ $? == 0 ]]; then
+	PRIVILEGED=true
+else
+	PRIVILEGED=false
+fi
+
 function start_udev()
 {
 	if [ "$UDEV" == "on" ]; then
@@ -88,8 +95,12 @@ esac
 
 if [ ! -z "$RESIN_SUPERVISOR_API_KEY" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 	# run this on resin device only
-	update_hostname
-	mount_dev
+
+	if $PRIVILEGED; then
+		# Only run this in privileged container
+		update_hostname
+		mount_dev
+	fi
 	start_udev
 fi 
 

--- a/resin-base-images/debian/i386-nlp/buster/entry.sh
+++ b/resin-base-images/debian/i386-nlp/buster/entry.sh
@@ -2,6 +2,13 @@
 
 set -m
 
+hostname "$HOSTNAME" &> /dev/null
+if [[ $? == 0 ]]; then
+	PRIVILEGED=true
+else
+	PRIVILEGED=false
+fi
+
 function start_udev()
 {
 	if [ "$UDEV" == "on" ]; then
@@ -127,8 +134,12 @@ esac
 
 if [ ! -z "$RESIN" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 	# run this on resin device only
-	update_hostname
-	mount_dev
+
+	if $PRIVILEGED; then
+		# Only run this in privileged container
+		update_hostname
+		mount_dev
+	fi
 	start_udev
 fi 
 

--- a/resin-base-images/debian/i386-nlp/jessie/entry.sh
+++ b/resin-base-images/debian/i386-nlp/jessie/entry.sh
@@ -2,6 +2,13 @@
 
 set -m
 
+hostname "$HOSTNAME" &> /dev/null
+if [[ $? == 0 ]]; then
+	PRIVILEGED=true
+else
+	PRIVILEGED=false
+fi
+
 function start_udev()
 {
 	if [ "$UDEV" == "on" ]; then
@@ -127,8 +134,12 @@ esac
 
 if [ ! -z "$RESIN" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 	# run this on resin device only
-	update_hostname
-	mount_dev
+
+	if $PRIVILEGED; then
+		# Only run this in privileged container
+		update_hostname
+		mount_dev
+	fi
 	start_udev
 fi 
 

--- a/resin-base-images/debian/i386-nlp/sid/entry.sh
+++ b/resin-base-images/debian/i386-nlp/sid/entry.sh
@@ -2,6 +2,13 @@
 
 set -m
 
+hostname "$HOSTNAME" &> /dev/null
+if [[ $? == 0 ]]; then
+	PRIVILEGED=true
+else
+	PRIVILEGED=false
+fi
+
 function start_udev()
 {
 	if [ "$UDEV" == "on" ]; then
@@ -127,8 +134,12 @@ esac
 
 if [ ! -z "$RESIN" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 	# run this on resin device only
-	update_hostname
-	mount_dev
+
+	if $PRIVILEGED; then
+		# Only run this in privileged container
+		update_hostname
+		mount_dev
+	fi
 	start_udev
 fi 
 

--- a/resin-base-images/debian/i386-nlp/stretch/entry.sh
+++ b/resin-base-images/debian/i386-nlp/stretch/entry.sh
@@ -2,6 +2,13 @@
 
 set -m
 
+hostname "$HOSTNAME" &> /dev/null
+if [[ $? == 0 ]]; then
+	PRIVILEGED=true
+else
+	PRIVILEGED=false
+fi
+
 function start_udev()
 {
 	if [ "$UDEV" == "on" ]; then
@@ -127,8 +134,12 @@ esac
 
 if [ ! -z "$RESIN" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 	# run this on resin device only
-	update_hostname
-	mount_dev
+
+	if $PRIVILEGED; then
+		# Only run this in privileged container
+		update_hostname
+		mount_dev
+	fi
 	start_udev
 fi 
 

--- a/resin-base-images/debian/i386-nlp/wheezy/entry.sh
+++ b/resin-base-images/debian/i386-nlp/wheezy/entry.sh
@@ -1,5 +1,12 @@
 #!/bin/bash
 
+hostname "$HOSTNAME" &> /dev/null
+if [[ $? == 0 ]]; then
+	PRIVILEGED=true
+else
+	PRIVILEGED=false
+fi
+
 function start_udev()
 {
 	if [ "$UDEV" == "on" ]; then
@@ -88,8 +95,12 @@ esac
 
 if [ ! -z "$RESIN_SUPERVISOR_API_KEY" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 	# run this on resin device only
-	update_hostname
-	mount_dev
+
+	if $PRIVILEGED; then
+		# Only run this in privileged container
+		update_hostname
+		mount_dev
+	fi
 	start_udev
 fi 
 

--- a/resin-base-images/debian/i386/buster/entry.sh
+++ b/resin-base-images/debian/i386/buster/entry.sh
@@ -2,6 +2,13 @@
 
 set -m
 
+hostname "$HOSTNAME" &> /dev/null
+if [[ $? == 0 ]]; then
+	PRIVILEGED=true
+else
+	PRIVILEGED=false
+fi
+
 function start_udev()
 {
 	if [ "$UDEV" == "on" ]; then
@@ -127,8 +134,12 @@ esac
 
 if [ ! -z "$RESIN" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 	# run this on resin device only
-	update_hostname
-	mount_dev
+
+	if $PRIVILEGED; then
+		# Only run this in privileged container
+		update_hostname
+		mount_dev
+	fi
 	start_udev
 fi 
 

--- a/resin-base-images/debian/i386/jessie/entry.sh
+++ b/resin-base-images/debian/i386/jessie/entry.sh
@@ -2,6 +2,13 @@
 
 set -m
 
+hostname "$HOSTNAME" &> /dev/null
+if [[ $? == 0 ]]; then
+	PRIVILEGED=true
+else
+	PRIVILEGED=false
+fi
+
 function start_udev()
 {
 	if [ "$UDEV" == "on" ]; then
@@ -127,8 +134,12 @@ esac
 
 if [ ! -z "$RESIN" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 	# run this on resin device only
-	update_hostname
-	mount_dev
+
+	if $PRIVILEGED; then
+		# Only run this in privileged container
+		update_hostname
+		mount_dev
+	fi
 	start_udev
 fi 
 

--- a/resin-base-images/debian/i386/sid/entry.sh
+++ b/resin-base-images/debian/i386/sid/entry.sh
@@ -2,6 +2,13 @@
 
 set -m
 
+hostname "$HOSTNAME" &> /dev/null
+if [[ $? == 0 ]]; then
+	PRIVILEGED=true
+else
+	PRIVILEGED=false
+fi
+
 function start_udev()
 {
 	if [ "$UDEV" == "on" ]; then
@@ -127,8 +134,12 @@ esac
 
 if [ ! -z "$RESIN" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 	# run this on resin device only
-	update_hostname
-	mount_dev
+
+	if $PRIVILEGED; then
+		# Only run this in privileged container
+		update_hostname
+		mount_dev
+	fi
 	start_udev
 fi 
 

--- a/resin-base-images/debian/i386/stretch/entry.sh
+++ b/resin-base-images/debian/i386/stretch/entry.sh
@@ -2,6 +2,13 @@
 
 set -m
 
+hostname "$HOSTNAME" &> /dev/null
+if [[ $? == 0 ]]; then
+	PRIVILEGED=true
+else
+	PRIVILEGED=false
+fi
+
 function start_udev()
 {
 	if [ "$UDEV" == "on" ]; then
@@ -127,8 +134,12 @@ esac
 
 if [ ! -z "$RESIN" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 	# run this on resin device only
-	update_hostname
-	mount_dev
+
+	if $PRIVILEGED; then
+		# Only run this in privileged container
+		update_hostname
+		mount_dev
+	fi
 	start_udev
 fi 
 

--- a/resin-base-images/debian/i386/wheezy/entry.sh
+++ b/resin-base-images/debian/i386/wheezy/entry.sh
@@ -1,5 +1,12 @@
 #!/bin/bash
 
+hostname "$HOSTNAME" &> /dev/null
+if [[ $? == 0 ]]; then
+	PRIVILEGED=true
+else
+	PRIVILEGED=false
+fi
+
 function start_udev()
 {
 	if [ "$UDEV" == "on" ]; then
@@ -88,8 +95,12 @@ esac
 
 if [ ! -z "$RESIN_SUPERVISOR_API_KEY" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 	# run this on resin device only
-	update_hostname
-	mount_dev
+
+	if $PRIVILEGED; then
+		# Only run this in privileged container
+		update_hostname
+		mount_dev
+	fi
 	start_udev
 fi 
 

--- a/resin-base-images/fedora/aarch64/24/entry.sh
+++ b/resin-base-images/fedora/aarch64/24/entry.sh
@@ -2,6 +2,13 @@
 
 set -m
 
+hostname "$HOSTNAME" &> /dev/null
+if [[ $? == 0 ]]; then
+	PRIVILEGED=true
+else
+	PRIVILEGED=false
+fi
+
 function start_udev()
 {
 	if [ "$UDEV" == "on" ]; then
@@ -129,8 +136,12 @@ esac
 
 if [ ! -z "$RESIN" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 	# run this on resin device only
-	update_hostname
-	mount_dev
+
+	if $PRIVILEGED; then
+		# Only run this in privileged container
+		update_hostname
+		mount_dev
+	fi
 	start_udev
 fi 
 

--- a/resin-base-images/fedora/aarch64/25/entry.sh
+++ b/resin-base-images/fedora/aarch64/25/entry.sh
@@ -2,6 +2,13 @@
 
 set -m
 
+hostname "$HOSTNAME" &> /dev/null
+if [[ $? == 0 ]]; then
+	PRIVILEGED=true
+else
+	PRIVILEGED=false
+fi
+
 function start_udev()
 {
 	if [ "$UDEV" == "on" ]; then
@@ -129,8 +136,12 @@ esac
 
 if [ ! -z "$RESIN" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 	# run this on resin device only
-	update_hostname
-	mount_dev
+
+	if $PRIVILEGED; then
+		# Only run this in privileged container
+		update_hostname
+		mount_dev
+	fi
 	start_udev
 fi 
 

--- a/resin-base-images/fedora/aarch64/26/entry.sh
+++ b/resin-base-images/fedora/aarch64/26/entry.sh
@@ -2,6 +2,13 @@
 
 set -m
 
+hostname "$HOSTNAME" &> /dev/null
+if [[ $? == 0 ]]; then
+	PRIVILEGED=true
+else
+	PRIVILEGED=false
+fi
+
 function start_udev()
 {
 	if [ "$UDEV" == "on" ]; then
@@ -129,8 +136,12 @@ esac
 
 if [ ! -z "$RESIN" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 	# run this on resin device only
-	update_hostname
-	mount_dev
+
+	if $PRIVILEGED; then
+		# Only run this in privileged container
+		update_hostname
+		mount_dev
+	fi
 	start_udev
 fi 
 

--- a/resin-base-images/fedora/amd64/24/entry.sh
+++ b/resin-base-images/fedora/amd64/24/entry.sh
@@ -2,6 +2,13 @@
 
 set -m
 
+hostname "$HOSTNAME" &> /dev/null
+if [[ $? == 0 ]]; then
+	PRIVILEGED=true
+else
+	PRIVILEGED=false
+fi
+
 function start_udev()
 {
 	if [ "$UDEV" == "on" ]; then
@@ -129,8 +136,12 @@ esac
 
 if [ ! -z "$RESIN" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 	# run this on resin device only
-	update_hostname
-	mount_dev
+
+	if $PRIVILEGED; then
+		# Only run this in privileged container
+		update_hostname
+		mount_dev
+	fi
 	start_udev
 fi 
 

--- a/resin-base-images/fedora/amd64/25/entry.sh
+++ b/resin-base-images/fedora/amd64/25/entry.sh
@@ -2,6 +2,13 @@
 
 set -m
 
+hostname "$HOSTNAME" &> /dev/null
+if [[ $? == 0 ]]; then
+	PRIVILEGED=true
+else
+	PRIVILEGED=false
+fi
+
 function start_udev()
 {
 	if [ "$UDEV" == "on" ]; then
@@ -129,8 +136,12 @@ esac
 
 if [ ! -z "$RESIN" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 	# run this on resin device only
-	update_hostname
-	mount_dev
+
+	if $PRIVILEGED; then
+		# Only run this in privileged container
+		update_hostname
+		mount_dev
+	fi
 	start_udev
 fi 
 

--- a/resin-base-images/fedora/amd64/26/entry.sh
+++ b/resin-base-images/fedora/amd64/26/entry.sh
@@ -2,6 +2,13 @@
 
 set -m
 
+hostname "$HOSTNAME" &> /dev/null
+if [[ $? == 0 ]]; then
+	PRIVILEGED=true
+else
+	PRIVILEGED=false
+fi
+
 function start_udev()
 {
 	if [ "$UDEV" == "on" ]; then
@@ -129,8 +136,12 @@ esac
 
 if [ ! -z "$RESIN" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 	# run this on resin device only
-	update_hostname
-	mount_dev
+
+	if $PRIVILEGED; then
+		# Only run this in privileged container
+		update_hostname
+		mount_dev
+	fi
 	start_udev
 fi 
 

--- a/resin-base-images/fedora/armv7hf/24/entry.sh
+++ b/resin-base-images/fedora/armv7hf/24/entry.sh
@@ -2,6 +2,13 @@
 
 set -m
 
+hostname "$HOSTNAME" &> /dev/null
+if [[ $? == 0 ]]; then
+	PRIVILEGED=true
+else
+	PRIVILEGED=false
+fi
+
 function start_udev()
 {
 	if [ "$UDEV" == "on" ]; then
@@ -129,8 +136,12 @@ esac
 
 if [ ! -z "$RESIN" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 	# run this on resin device only
-	update_hostname
-	mount_dev
+
+	if $PRIVILEGED; then
+		# Only run this in privileged container
+		update_hostname
+		mount_dev
+	fi
 	start_udev
 fi 
 

--- a/resin-base-images/fedora/armv7hf/25/entry.sh
+++ b/resin-base-images/fedora/armv7hf/25/entry.sh
@@ -2,6 +2,13 @@
 
 set -m
 
+hostname "$HOSTNAME" &> /dev/null
+if [[ $? == 0 ]]; then
+	PRIVILEGED=true
+else
+	PRIVILEGED=false
+fi
+
 function start_udev()
 {
 	if [ "$UDEV" == "on" ]; then
@@ -129,8 +136,12 @@ esac
 
 if [ ! -z "$RESIN" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 	# run this on resin device only
-	update_hostname
-	mount_dev
+
+	if $PRIVILEGED; then
+		# Only run this in privileged container
+		update_hostname
+		mount_dev
+	fi
 	start_udev
 fi 
 

--- a/resin-base-images/fedora/armv7hf/26/entry.sh
+++ b/resin-base-images/fedora/armv7hf/26/entry.sh
@@ -2,6 +2,13 @@
 
 set -m
 
+hostname "$HOSTNAME" &> /dev/null
+if [[ $? == 0 ]]; then
+	PRIVILEGED=true
+else
+	PRIVILEGED=false
+fi
+
 function start_udev()
 {
 	if [ "$UDEV" == "on" ]; then
@@ -129,8 +136,12 @@ esac
 
 if [ ! -z "$RESIN" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 	# run this on resin device only
-	update_hostname
-	mount_dev
+
+	if $PRIVILEGED; then
+		# Only run this in privileged container
+		update_hostname
+		mount_dev
+	fi
 	start_udev
 fi 
 

--- a/resin-base-images/ubuntu/aarch64/artful/entry.sh
+++ b/resin-base-images/ubuntu/aarch64/artful/entry.sh
@@ -2,6 +2,13 @@
 
 set -m
 
+hostname "$HOSTNAME" &> /dev/null
+if [[ $? == 0 ]]; then
+	PRIVILEGED=true
+else
+	PRIVILEGED=false
+fi
+
 function start_udev()
 {
 	if [ "$UDEV" == "on" ]; then
@@ -127,8 +134,12 @@ esac
 
 if [ ! -z "$RESIN" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 	# run this on resin device only
-	update_hostname
-	mount_dev
+
+	if $PRIVILEGED; then
+		# Only run this in privileged container
+		update_hostname
+		mount_dev
+	fi
 	start_udev
 fi 
 

--- a/resin-base-images/ubuntu/aarch64/bionic/entry.sh
+++ b/resin-base-images/ubuntu/aarch64/bionic/entry.sh
@@ -2,6 +2,13 @@
 
 set -m
 
+hostname "$HOSTNAME" &> /dev/null
+if [[ $? == 0 ]]; then
+	PRIVILEGED=true
+else
+	PRIVILEGED=false
+fi
+
 function start_udev()
 {
 	if [ "$UDEV" == "on" ]; then
@@ -127,8 +134,12 @@ esac
 
 if [ ! -z "$RESIN" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 	# run this on resin device only
-	update_hostname
-	mount_dev
+
+	if $PRIVILEGED; then
+		# Only run this in privileged container
+		update_hostname
+		mount_dev
+	fi
 	start_udev
 fi 
 

--- a/resin-base-images/ubuntu/aarch64/cosmic/entry.sh
+++ b/resin-base-images/ubuntu/aarch64/cosmic/entry.sh
@@ -2,6 +2,13 @@
 
 set -m
 
+hostname "$HOSTNAME" &> /dev/null
+if [[ $? == 0 ]]; then
+	PRIVILEGED=true
+else
+	PRIVILEGED=false
+fi
+
 function start_udev()
 {
 	if [ "$UDEV" == "on" ]; then
@@ -127,8 +134,12 @@ esac
 
 if [ ! -z "$RESIN" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 	# run this on resin device only
-	update_hostname
-	mount_dev
+
+	if $PRIVILEGED; then
+		# Only run this in privileged container
+		update_hostname
+		mount_dev
+	fi
 	start_udev
 fi 
 

--- a/resin-base-images/ubuntu/aarch64/trusty/entry.sh
+++ b/resin-base-images/ubuntu/aarch64/trusty/entry.sh
@@ -2,6 +2,13 @@
 
 set -m
 
+hostname "$HOSTNAME" &> /dev/null
+if [[ $? == 0 ]]; then
+	PRIVILEGED=true
+else
+	PRIVILEGED=false
+fi
+
 function start_udev()
 {
 	if [ "$UDEV" == "on" ]; then
@@ -127,8 +134,12 @@ esac
 
 if [ ! -z "$RESIN" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 	# run this on resin device only
-	update_hostname
-	mount_dev
+
+	if $PRIVILEGED; then
+		# Only run this in privileged container
+		update_hostname
+		mount_dev
+	fi
 	start_udev
 fi 
 

--- a/resin-base-images/ubuntu/aarch64/xenial/entry.sh
+++ b/resin-base-images/ubuntu/aarch64/xenial/entry.sh
@@ -2,6 +2,13 @@
 
 set -m
 
+hostname "$HOSTNAME" &> /dev/null
+if [[ $? == 0 ]]; then
+	PRIVILEGED=true
+else
+	PRIVILEGED=false
+fi
+
 function start_udev()
 {
 	if [ "$UDEV" == "on" ]; then
@@ -127,8 +134,12 @@ esac
 
 if [ ! -z "$RESIN" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 	# run this on resin device only
-	update_hostname
-	mount_dev
+
+	if $PRIVILEGED; then
+		# Only run this in privileged container
+		update_hostname
+		mount_dev
+	fi
 	start_udev
 fi 
 

--- a/resin-base-images/ubuntu/amd64/artful/entry.sh
+++ b/resin-base-images/ubuntu/amd64/artful/entry.sh
@@ -2,6 +2,13 @@
 
 set -m
 
+hostname "$HOSTNAME" &> /dev/null
+if [[ $? == 0 ]]; then
+	PRIVILEGED=true
+else
+	PRIVILEGED=false
+fi
+
 function start_udev()
 {
 	if [ "$UDEV" == "on" ]; then
@@ -127,8 +134,12 @@ esac
 
 if [ ! -z "$RESIN" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 	# run this on resin device only
-	update_hostname
-	mount_dev
+
+	if $PRIVILEGED; then
+		# Only run this in privileged container
+		update_hostname
+		mount_dev
+	fi
 	start_udev
 fi 
 

--- a/resin-base-images/ubuntu/amd64/bionic/entry.sh
+++ b/resin-base-images/ubuntu/amd64/bionic/entry.sh
@@ -2,6 +2,13 @@
 
 set -m
 
+hostname "$HOSTNAME" &> /dev/null
+if [[ $? == 0 ]]; then
+	PRIVILEGED=true
+else
+	PRIVILEGED=false
+fi
+
 function start_udev()
 {
 	if [ "$UDEV" == "on" ]; then
@@ -127,8 +134,12 @@ esac
 
 if [ ! -z "$RESIN" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 	# run this on resin device only
-	update_hostname
-	mount_dev
+
+	if $PRIVILEGED; then
+		# Only run this in privileged container
+		update_hostname
+		mount_dev
+	fi
 	start_udev
 fi 
 

--- a/resin-base-images/ubuntu/amd64/cosmic/entry.sh
+++ b/resin-base-images/ubuntu/amd64/cosmic/entry.sh
@@ -2,6 +2,13 @@
 
 set -m
 
+hostname "$HOSTNAME" &> /dev/null
+if [[ $? == 0 ]]; then
+	PRIVILEGED=true
+else
+	PRIVILEGED=false
+fi
+
 function start_udev()
 {
 	if [ "$UDEV" == "on" ]; then
@@ -127,8 +134,12 @@ esac
 
 if [ ! -z "$RESIN" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 	# run this on resin device only
-	update_hostname
-	mount_dev
+
+	if $PRIVILEGED; then
+		# Only run this in privileged container
+		update_hostname
+		mount_dev
+	fi
 	start_udev
 fi 
 

--- a/resin-base-images/ubuntu/amd64/trusty/entry.sh
+++ b/resin-base-images/ubuntu/amd64/trusty/entry.sh
@@ -2,6 +2,13 @@
 
 set -m
 
+hostname "$HOSTNAME" &> /dev/null
+if [[ $? == 0 ]]; then
+	PRIVILEGED=true
+else
+	PRIVILEGED=false
+fi
+
 function start_udev()
 {
 	if [ "$UDEV" == "on" ]; then
@@ -127,8 +134,12 @@ esac
 
 if [ ! -z "$RESIN" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 	# run this on resin device only
-	update_hostname
-	mount_dev
+
+	if $PRIVILEGED; then
+		# Only run this in privileged container
+		update_hostname
+		mount_dev
+	fi
 	start_udev
 fi 
 

--- a/resin-base-images/ubuntu/amd64/xenial/entry.sh
+++ b/resin-base-images/ubuntu/amd64/xenial/entry.sh
@@ -2,6 +2,13 @@
 
 set -m
 
+hostname "$HOSTNAME" &> /dev/null
+if [[ $? == 0 ]]; then
+	PRIVILEGED=true
+else
+	PRIVILEGED=false
+fi
+
 function start_udev()
 {
 	if [ "$UDEV" == "on" ]; then
@@ -127,8 +134,12 @@ esac
 
 if [ ! -z "$RESIN" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 	# run this on resin device only
-	update_hostname
-	mount_dev
+
+	if $PRIVILEGED; then
+		# Only run this in privileged container
+		update_hostname
+		mount_dev
+	fi
 	start_udev
 fi 
 

--- a/resin-base-images/ubuntu/armv7hf/artful/entry.sh
+++ b/resin-base-images/ubuntu/armv7hf/artful/entry.sh
@@ -2,6 +2,13 @@
 
 set -m
 
+hostname "$HOSTNAME" &> /dev/null
+if [[ $? == 0 ]]; then
+	PRIVILEGED=true
+else
+	PRIVILEGED=false
+fi
+
 function start_udev()
 {
 	if [ "$UDEV" == "on" ]; then
@@ -127,8 +134,12 @@ esac
 
 if [ ! -z "$RESIN" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 	# run this on resin device only
-	update_hostname
-	mount_dev
+
+	if $PRIVILEGED; then
+		# Only run this in privileged container
+		update_hostname
+		mount_dev
+	fi
 	start_udev
 fi 
 

--- a/resin-base-images/ubuntu/armv7hf/bionic/entry.sh
+++ b/resin-base-images/ubuntu/armv7hf/bionic/entry.sh
@@ -2,6 +2,13 @@
 
 set -m
 
+hostname "$HOSTNAME" &> /dev/null
+if [[ $? == 0 ]]; then
+	PRIVILEGED=true
+else
+	PRIVILEGED=false
+fi
+
 function start_udev()
 {
 	if [ "$UDEV" == "on" ]; then
@@ -127,8 +134,12 @@ esac
 
 if [ ! -z "$RESIN" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 	# run this on resin device only
-	update_hostname
-	mount_dev
+
+	if $PRIVILEGED; then
+		# Only run this in privileged container
+		update_hostname
+		mount_dev
+	fi
 	start_udev
 fi 
 

--- a/resin-base-images/ubuntu/armv7hf/cosmic/entry.sh
+++ b/resin-base-images/ubuntu/armv7hf/cosmic/entry.sh
@@ -2,6 +2,13 @@
 
 set -m
 
+hostname "$HOSTNAME" &> /dev/null
+if [[ $? == 0 ]]; then
+	PRIVILEGED=true
+else
+	PRIVILEGED=false
+fi
+
 function start_udev()
 {
 	if [ "$UDEV" == "on" ]; then
@@ -127,8 +134,12 @@ esac
 
 if [ ! -z "$RESIN" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 	# run this on resin device only
-	update_hostname
-	mount_dev
+
+	if $PRIVILEGED; then
+		# Only run this in privileged container
+		update_hostname
+		mount_dev
+	fi
 	start_udev
 fi 
 

--- a/resin-base-images/ubuntu/armv7hf/trusty/entry.sh
+++ b/resin-base-images/ubuntu/armv7hf/trusty/entry.sh
@@ -2,6 +2,13 @@
 
 set -m
 
+hostname "$HOSTNAME" &> /dev/null
+if [[ $? == 0 ]]; then
+	PRIVILEGED=true
+else
+	PRIVILEGED=false
+fi
+
 function start_udev()
 {
 	if [ "$UDEV" == "on" ]; then
@@ -127,8 +134,12 @@ esac
 
 if [ ! -z "$RESIN" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 	# run this on resin device only
-	update_hostname
-	mount_dev
+
+	if $PRIVILEGED; then
+		# Only run this in privileged container
+		update_hostname
+		mount_dev
+	fi
 	start_udev
 fi 
 

--- a/resin-base-images/ubuntu/armv7hf/xenial/entry.sh
+++ b/resin-base-images/ubuntu/armv7hf/xenial/entry.sh
@@ -2,6 +2,13 @@
 
 set -m
 
+hostname "$HOSTNAME" &> /dev/null
+if [[ $? == 0 ]]; then
+	PRIVILEGED=true
+else
+	PRIVILEGED=false
+fi
+
 function start_udev()
 {
 	if [ "$UDEV" == "on" ]; then
@@ -127,8 +134,12 @@ esac
 
 if [ ! -z "$RESIN" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 	# run this on resin device only
-	update_hostname
-	mount_dev
+
+	if $PRIVILEGED; then
+		# Only run this in privileged container
+		update_hostname
+		mount_dev
+	fi
 	start_udev
 fi 
 

--- a/resin-base-images/ubuntu/i386-nlp/artful/entry.sh
+++ b/resin-base-images/ubuntu/i386-nlp/artful/entry.sh
@@ -2,6 +2,13 @@
 
 set -m
 
+hostname "$HOSTNAME" &> /dev/null
+if [[ $? == 0 ]]; then
+	PRIVILEGED=true
+else
+	PRIVILEGED=false
+fi
+
 function start_udev()
 {
 	if [ "$UDEV" == "on" ]; then
@@ -127,8 +134,12 @@ esac
 
 if [ ! -z "$RESIN" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 	# run this on resin device only
-	update_hostname
-	mount_dev
+
+	if $PRIVILEGED; then
+		# Only run this in privileged container
+		update_hostname
+		mount_dev
+	fi
 	start_udev
 fi 
 

--- a/resin-base-images/ubuntu/i386-nlp/bionic/entry.sh
+++ b/resin-base-images/ubuntu/i386-nlp/bionic/entry.sh
@@ -2,6 +2,13 @@
 
 set -m
 
+hostname "$HOSTNAME" &> /dev/null
+if [[ $? == 0 ]]; then
+	PRIVILEGED=true
+else
+	PRIVILEGED=false
+fi
+
 function start_udev()
 {
 	if [ "$UDEV" == "on" ]; then
@@ -127,8 +134,12 @@ esac
 
 if [ ! -z "$RESIN" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 	# run this on resin device only
-	update_hostname
-	mount_dev
+
+	if $PRIVILEGED; then
+		# Only run this in privileged container
+		update_hostname
+		mount_dev
+	fi
 	start_udev
 fi 
 

--- a/resin-base-images/ubuntu/i386-nlp/cosmic/entry.sh
+++ b/resin-base-images/ubuntu/i386-nlp/cosmic/entry.sh
@@ -2,6 +2,13 @@
 
 set -m
 
+hostname "$HOSTNAME" &> /dev/null
+if [[ $? == 0 ]]; then
+	PRIVILEGED=true
+else
+	PRIVILEGED=false
+fi
+
 function start_udev()
 {
 	if [ "$UDEV" == "on" ]; then
@@ -127,8 +134,12 @@ esac
 
 if [ ! -z "$RESIN" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 	# run this on resin device only
-	update_hostname
-	mount_dev
+
+	if $PRIVILEGED; then
+		# Only run this in privileged container
+		update_hostname
+		mount_dev
+	fi
 	start_udev
 fi 
 

--- a/resin-base-images/ubuntu/i386-nlp/trusty/entry.sh
+++ b/resin-base-images/ubuntu/i386-nlp/trusty/entry.sh
@@ -2,6 +2,13 @@
 
 set -m
 
+hostname "$HOSTNAME" &> /dev/null
+if [[ $? == 0 ]]; then
+	PRIVILEGED=true
+else
+	PRIVILEGED=false
+fi
+
 function start_udev()
 {
 	if [ "$UDEV" == "on" ]; then
@@ -127,8 +134,12 @@ esac
 
 if [ ! -z "$RESIN" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 	# run this on resin device only
-	update_hostname
-	mount_dev
+
+	if $PRIVILEGED; then
+		# Only run this in privileged container
+		update_hostname
+		mount_dev
+	fi
 	start_udev
 fi 
 

--- a/resin-base-images/ubuntu/i386-nlp/xenial/entry.sh
+++ b/resin-base-images/ubuntu/i386-nlp/xenial/entry.sh
@@ -2,6 +2,13 @@
 
 set -m
 
+hostname "$HOSTNAME" &> /dev/null
+if [[ $? == 0 ]]; then
+	PRIVILEGED=true
+else
+	PRIVILEGED=false
+fi
+
 function start_udev()
 {
 	if [ "$UDEV" == "on" ]; then
@@ -127,8 +134,12 @@ esac
 
 if [ ! -z "$RESIN" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 	# run this on resin device only
-	update_hostname
-	mount_dev
+
+	if $PRIVILEGED; then
+		# Only run this in privileged container
+		update_hostname
+		mount_dev
+	fi
 	start_udev
 fi 
 

--- a/resin-base-images/ubuntu/i386/artful/entry.sh
+++ b/resin-base-images/ubuntu/i386/artful/entry.sh
@@ -2,6 +2,13 @@
 
 set -m
 
+hostname "$HOSTNAME" &> /dev/null
+if [[ $? == 0 ]]; then
+	PRIVILEGED=true
+else
+	PRIVILEGED=false
+fi
+
 function start_udev()
 {
 	if [ "$UDEV" == "on" ]; then
@@ -127,8 +134,12 @@ esac
 
 if [ ! -z "$RESIN" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 	# run this on resin device only
-	update_hostname
-	mount_dev
+
+	if $PRIVILEGED; then
+		# Only run this in privileged container
+		update_hostname
+		mount_dev
+	fi
 	start_udev
 fi 
 

--- a/resin-base-images/ubuntu/i386/bionic/entry.sh
+++ b/resin-base-images/ubuntu/i386/bionic/entry.sh
@@ -2,6 +2,13 @@
 
 set -m
 
+hostname "$HOSTNAME" &> /dev/null
+if [[ $? == 0 ]]; then
+	PRIVILEGED=true
+else
+	PRIVILEGED=false
+fi
+
 function start_udev()
 {
 	if [ "$UDEV" == "on" ]; then
@@ -127,8 +134,12 @@ esac
 
 if [ ! -z "$RESIN" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 	# run this on resin device only
-	update_hostname
-	mount_dev
+
+	if $PRIVILEGED; then
+		# Only run this in privileged container
+		update_hostname
+		mount_dev
+	fi
 	start_udev
 fi 
 

--- a/resin-base-images/ubuntu/i386/cosmic/entry.sh
+++ b/resin-base-images/ubuntu/i386/cosmic/entry.sh
@@ -2,6 +2,13 @@
 
 set -m
 
+hostname "$HOSTNAME" &> /dev/null
+if [[ $? == 0 ]]; then
+	PRIVILEGED=true
+else
+	PRIVILEGED=false
+fi
+
 function start_udev()
 {
 	if [ "$UDEV" == "on" ]; then
@@ -127,8 +134,12 @@ esac
 
 if [ ! -z "$RESIN" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 	# run this on resin device only
-	update_hostname
-	mount_dev
+
+	if $PRIVILEGED; then
+		# Only run this in privileged container
+		update_hostname
+		mount_dev
+	fi
 	start_udev
 fi 
 

--- a/resin-base-images/ubuntu/i386/trusty/entry.sh
+++ b/resin-base-images/ubuntu/i386/trusty/entry.sh
@@ -2,6 +2,13 @@
 
 set -m
 
+hostname "$HOSTNAME" &> /dev/null
+if [[ $? == 0 ]]; then
+	PRIVILEGED=true
+else
+	PRIVILEGED=false
+fi
+
 function start_udev()
 {
 	if [ "$UDEV" == "on" ]; then
@@ -127,8 +134,12 @@ esac
 
 if [ ! -z "$RESIN" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 	# run this on resin device only
-	update_hostname
-	mount_dev
+
+	if $PRIVILEGED; then
+		# Only run this in privileged container
+		update_hostname
+		mount_dev
+	fi
 	start_udev
 fi 
 

--- a/resin-base-images/ubuntu/i386/xenial/entry.sh
+++ b/resin-base-images/ubuntu/i386/xenial/entry.sh
@@ -2,6 +2,13 @@
 
 set -m
 
+hostname "$HOSTNAME" &> /dev/null
+if [[ $? == 0 ]]; then
+	PRIVILEGED=true
+else
+	PRIVILEGED=false
+fi
+
 function start_udev()
 {
 	if [ "$UDEV" == "on" ]; then
@@ -127,8 +134,12 @@ esac
 
 if [ ! -z "$RESIN" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 	# run this on resin device only
-	update_hostname
-	mount_dev
+
+	if $PRIVILEGED; then
+		# Only run this in privileged container
+		update_hostname
+		mount_dev
+	fi
 	start_udev
 fi 
 

--- a/scripts/assets/entry-alpine.sh
+++ b/scripts/assets/entry-alpine.sh
@@ -1,5 +1,13 @@
 #!/bin/bash
 
+
+hostname "$HOSTNAME" &> /dev/null
+if [[ $? == 0 ]]; then
+	PRIVILEGED=true
+else
+	PRIVILEGED=false
+fi
+
 function start_udev()
 {
 	if [ "$UDEV" == "on" ]; then
@@ -97,8 +105,12 @@ esac
 
 if [ ! -z "$RESIN_SUPERVISOR_API_KEY" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 	# run this on resin device only
-	update_hostname
-	mount_dev
+
+	if $PRIVILEGED; then
+		# Only run this in privileged container
+		update_hostname
+		mount_dev
+	fi
 	start_udev
 fi 
 

--- a/scripts/assets/entry-fedora.sh
+++ b/scripts/assets/entry-fedora.sh
@@ -2,6 +2,13 @@
 
 set -m
 
+hostname "$HOSTNAME" &> /dev/null
+if [[ $? == 0 ]]; then
+	PRIVILEGED=true
+else
+	PRIVILEGED=false
+fi
+
 function start_udev()
 {
 	if [ "$UDEV" == "on" ]; then
@@ -129,8 +136,12 @@ esac
 
 if [ ! -z "$RESIN" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 	# run this on resin device only
-	update_hostname
-	mount_dev
+
+	if $PRIVILEGED; then
+		# Only run this in privileged container
+		update_hostname
+		mount_dev
+	fi
 	start_udev
 fi 
 

--- a/scripts/assets/entry-no-systemd-debian.sh
+++ b/scripts/assets/entry-no-systemd-debian.sh
@@ -1,5 +1,12 @@
 #!/bin/bash
 
+hostname "$HOSTNAME" &> /dev/null
+if [[ $? == 0 ]]; then
+	PRIVILEGED=true
+else
+	PRIVILEGED=false
+fi
+
 function start_udev()
 {
 	if [ "$UDEV" == "on" ]; then
@@ -88,8 +95,12 @@ esac
 
 if [ ! -z "$RESIN_SUPERVISOR_API_KEY" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 	# run this on resin device only
-	update_hostname
-	mount_dev
+
+	if $PRIVILEGED; then
+		# Only run this in privileged container
+		update_hostname
+		mount_dev
+	fi
 	start_udev
 fi 
 

--- a/scripts/assets/entry-systemd-debian.sh
+++ b/scripts/assets/entry-systemd-debian.sh
@@ -2,6 +2,13 @@
 
 set -m
 
+hostname "$HOSTNAME" &> /dev/null
+if [[ $? == 0 ]]; then
+	PRIVILEGED=true
+else
+	PRIVILEGED=false
+fi
+
 function start_udev()
 {
 	if [ "$UDEV" == "on" ]; then
@@ -127,8 +134,12 @@ esac
 
 if [ ! -z "$RESIN" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 	# run this on resin device only
-	update_hostname
-	mount_dev
+
+	if $PRIVILEGED; then
+		# Only run this in privileged container
+		update_hostname
+		mount_dev
+	fi
 	start_udev
 fi 
 


### PR DESCRIPTION
The entry scripts used by contracts are not latest version that supports MC.
So some ugly logs get printed when unprivileged container starts.

Here are the latest entry scripts
https://github.com/resin-io-library/base-images/blob/master/alpine/entry.sh
https://github.com/resin-io-library/base-images/blob/master/debian/entry-nosystemd.sh
https://github.com/resin-io-library/base-images/blob/master/debian/entry.sh
https://github.com/resin-io-library/base-images/blob/master/fedora/entry.sh