### PR TITLE
entry.sh: Do not double-escape env vars when building docker.env

### DIFF
--- a/alpine/entry.sh
+++ b/alpine/entry.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
 
 
-hostname "$HOSTNAME" &> /dev/null
-if [[ $? == 0 ]]; then
+if hostname "$HOSTNAME" &> /dev/null; then
 	PRIVILEGED=true
 else
 	PRIVILEGED=false
@@ -24,10 +23,10 @@ function start_udev()
 # For backward compatibility, we only update the hostname for ResinOS 1.x devices.
 function update_hostname()
 {
-	if [ ${RESIN_DEVICE_UUID:0:7} != ${HOSTNAME:0:7} ]; then
+	if [ "${RESIN_DEVICE_UUID:0:7}" != "${HOSTNAME:0:7}" ]; then
 		# For 1.x Devices only.
 		HOSTNAME="$RESIN_DEVICE_TYPE-${RESIN_DEVICE_UUID:0:7}"
-		echo $HOSTNAME > /etc/hostname
+		echo "$HOSTNAME" > /etc/hostname
 		echo "127.0.1.1 $HOSTNAME" >> /etc/hosts
 		hostname "$HOSTNAME"
 	fi
@@ -76,9 +75,8 @@ function init_openrc()
 
 function init_non_openrc()
 {
-	CMD=$(which "$1")
 	# echo error message, when executable file doesn't exist.
-	if [ $? == '0' ]; then
+	if CMD=$(command -v "$1" 2>/dev/null); then
 		shift
 		exec tini -sg -- "$CMD" "$@"
 	else
@@ -112,7 +110,7 @@ if [ ! -z "$RESIN_SUPERVISOR_API_KEY" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 		mount_dev
 	fi
 	start_udev
-fi 
+fi
 
 if [ "$INITSYSTEM" = "on" ]; then
 	init_openrc "$@"

--- a/debian/entry.sh
+++ b/debian/entry.sh
@@ -2,8 +2,7 @@
 
 set -m
 
-hostname "$HOSTNAME" &> /dev/null
-if [[ $? == 0 ]]; then
+if hostname "$HOSTNAME" &> /dev/null; then
 	PRIVILEGED=true
 else
 	PRIVILEGED=false
@@ -13,8 +12,7 @@ function start_udev()
 {
 	if [ "$UDEV" == "on" ]; then
 		if [ "$INITSYSTEM" != "on" ]; then
-			which udevd
-			if [ $? == '0' ]; then
+			if command -v udevd &>/dev/null; then
 				udevd --daemon &> /dev/null
 			else
 				/lib/systemd/systemd-udevd --daemon &> /dev/null
@@ -36,17 +34,17 @@ function remove_buildtime_env_var()
 # Send SIGTERM to child processes of PID 1.
 function signal_handler()
 {
-	kill $pid
+	kill "$pid"
 }
 
 # On ResinOS 2.x devices, the hostname is set by the hostOS.
 # For backward compatibility, we only update the hostname for ResinOS 1.x devices.
 function update_hostname()
 {
-	if [ ${RESIN_DEVICE_UUID:0:7} != ${HOSTNAME:0:7} ]; then
+	if [ "${RESIN_DEVICE_UUID:0:7}" != "${HOSTNAME:0:7}" ]; then
 		# For 1.x Devices only.
 		HOSTNAME="$RESIN_DEVICE_TYPE-${RESIN_DEVICE_UUID:0:7}"
-		echo $HOSTNAME > /etc/hostname
+		echo "$HOSTNAME" > /etc/hostname
 		echo "127.0.1.1 $HOSTNAME" >> /etc/hosts
 		hostname "$HOSTNAME"
 	fi
@@ -79,7 +77,7 @@ function init_systemd()
 	GREEN='\033[0;32m'
 	echo -e "${GREEN}Systemd init system enabled."
 	for var in $(compgen -e); do
-		printf '%q="%q"\n' "$var" "${!var}"
+		printf '%q=%q\n' "$var" "${!var}"
 	done > /etc/docker.env
 
 	printf '#!/bin/bash\n exec ' > /etc/resinApp.sh
@@ -101,9 +99,8 @@ function init_non_systemd()
 	# trap the stop signal then send SIGTERM to user processes
 	trap signal_handler SIGRTMIN+3 SIGTERM
 
-	CMD=$(which "$1")
 	# echo error message, when executable file doesn't exist.
-	if [ $? == '0' ]; then
+	if CMD=$(command -v "$1" 2>/dev/null); then
 		shift
 		tini -sg -- "$CMD" "$@" &
 		pid=$!
@@ -141,7 +138,7 @@ if [ ! -z "$RESIN" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 		mount_dev
 	fi
 	start_udev
-fi 
+fi
 
 if [ "$INITSYSTEM" = "on" ]; then
 	init_systemd "$@"

--- a/fedora/entry.sh
+++ b/fedora/entry.sh
@@ -2,8 +2,7 @@
 
 set -m
 
-hostname "$HOSTNAME" &> /dev/null
-if [[ $? == 0 ]]; then
+if hostname "$HOSTNAME" &> /dev/null; then
 	PRIVILEGED=true
 else
 	PRIVILEGED=false
@@ -13,8 +12,7 @@ function start_udev()
 {
 	if [ "$UDEV" == "on" ]; then
 		if [ "$INITSYSTEM" != "on" ]; then
-			which udevd
-			if [ $? == '0' ]; then
+			if command -v udevd &>/dev/null; then
 				udevd --daemon &> /dev/null
 			else
 				/lib/systemd/systemd-udevd --daemon &> /dev/null
@@ -36,17 +34,17 @@ function remove_buildtime_env_var()
 # Send SIGTERM to child processes of PID 1.
 function signal_handler()
 {
-	kill $pid
+	kill "$pid"
 }
 
 # On ResinOS 2.x devices, the hostname is set by the hostOS.
 # For backward compatibility, we only update the hostname for ResinOS 1.x devices.
 function update_hostname()
 {
-	if [ ${RESIN_DEVICE_UUID:0:7} != ${HOSTNAME:0:7} ]; then
+	if [ "${RESIN_DEVICE_UUID:0:7}" != "${HOSTNAME:0:7}" ]; then
 		# For 1.x Devices only.
 		HOSTNAME="$RESIN_DEVICE_TYPE-${RESIN_DEVICE_UUID:0:7}"
-		echo $HOSTNAME > /etc/hostname
+		echo "$HOSTNAME" > /etc/hostname
 		echo "127.0.1.1 $HOSTNAME" >> /etc/hosts
 		hostname "$HOSTNAME"
 	fi
@@ -79,7 +77,7 @@ function init_systemd()
 	GREEN='\033[0;32m'
 	echo -e "${GREEN}Systemd init system enabled."
 	for var in $(compgen -e); do
-		printf '%q="%q"\n' "$var" "${!var}"
+		printf '%q=%q\n' "$var" "${!var}"
 	done > /etc/docker.env
 
 	printf '#!/bin/bash\n exec ' > /etc/resinApp.sh
@@ -103,9 +101,8 @@ function init_non_systemd()
 	# trap the stop signal then send SIGTERM to user processes
 	trap signal_handler SIGRTMIN+3 SIGTERM
 
-	CMD=$(which "$1")
 	# echo error message, when executable file doesn't exist.
-	if [ $? == '0' ]; then
+	if CMD=$(command -v "$1" 2>/dev/null); then
 		shift
 		tini -sg -- "$CMD" "$@" &
 		pid=$!
@@ -143,7 +140,7 @@ if [ ! -z "$RESIN" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 		mount_dev
 	fi
 	start_udev
-fi 
+fi
 
 if [ "$INITSYSTEM" = "on" ]; then
 	init_systemd "$@"

--- a/resin-base-images/alpine/aarch64/3.5/entry.sh
+++ b/resin-base-images/alpine/aarch64/3.5/entry.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
 
 
-hostname "$HOSTNAME" &> /dev/null
-if [[ $? == 0 ]]; then
+if hostname "$HOSTNAME" &> /dev/null; then
 	PRIVILEGED=true
 else
 	PRIVILEGED=false
@@ -24,10 +23,10 @@ function start_udev()
 # For backward compatibility, we only update the hostname for ResinOS 1.x devices.
 function update_hostname()
 {
-	if [ ${RESIN_DEVICE_UUID:0:7} != ${HOSTNAME:0:7} ]; then
+	if [ "${RESIN_DEVICE_UUID:0:7}" != "${HOSTNAME:0:7}" ]; then
 		# For 1.x Devices only.
 		HOSTNAME="$RESIN_DEVICE_TYPE-${RESIN_DEVICE_UUID:0:7}"
-		echo $HOSTNAME > /etc/hostname
+		echo "$HOSTNAME" > /etc/hostname
 		echo "127.0.1.1 $HOSTNAME" >> /etc/hosts
 		hostname "$HOSTNAME"
 	fi
@@ -76,9 +75,8 @@ function init_openrc()
 
 function init_non_openrc()
 {
-	CMD=$(which "$1")
 	# echo error message, when executable file doesn't exist.
-	if [ $? == '0' ]; then
+	if CMD=$(command -v "$1" 2>/dev/null); then
 		shift
 		exec tini -sg -- "$CMD" "$@"
 	else
@@ -112,7 +110,7 @@ if [ ! -z "$RESIN_SUPERVISOR_API_KEY" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 		mount_dev
 	fi
 	start_udev
-fi 
+fi
 
 if [ "$INITSYSTEM" = "on" ]; then
 	init_openrc "$@"

--- a/resin-base-images/alpine/aarch64/3.6/entry.sh
+++ b/resin-base-images/alpine/aarch64/3.6/entry.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
 
 
-hostname "$HOSTNAME" &> /dev/null
-if [[ $? == 0 ]]; then
+if hostname "$HOSTNAME" &> /dev/null; then
 	PRIVILEGED=true
 else
 	PRIVILEGED=false
@@ -24,10 +23,10 @@ function start_udev()
 # For backward compatibility, we only update the hostname for ResinOS 1.x devices.
 function update_hostname()
 {
-	if [ ${RESIN_DEVICE_UUID:0:7} != ${HOSTNAME:0:7} ]; then
+	if [ "${RESIN_DEVICE_UUID:0:7}" != "${HOSTNAME:0:7}" ]; then
 		# For 1.x Devices only.
 		HOSTNAME="$RESIN_DEVICE_TYPE-${RESIN_DEVICE_UUID:0:7}"
-		echo $HOSTNAME > /etc/hostname
+		echo "$HOSTNAME" > /etc/hostname
 		echo "127.0.1.1 $HOSTNAME" >> /etc/hosts
 		hostname "$HOSTNAME"
 	fi
@@ -76,9 +75,8 @@ function init_openrc()
 
 function init_non_openrc()
 {
-	CMD=$(which "$1")
 	# echo error message, when executable file doesn't exist.
-	if [ $? == '0' ]; then
+	if CMD=$(command -v "$1" 2>/dev/null); then
 		shift
 		exec tini -sg -- "$CMD" "$@"
 	else
@@ -112,7 +110,7 @@ if [ ! -z "$RESIN_SUPERVISOR_API_KEY" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 		mount_dev
 	fi
 	start_udev
-fi 
+fi
 
 if [ "$INITSYSTEM" = "on" ]; then
 	init_openrc "$@"

--- a/resin-base-images/alpine/aarch64/3.7/entry.sh
+++ b/resin-base-images/alpine/aarch64/3.7/entry.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
 
 
-hostname "$HOSTNAME" &> /dev/null
-if [[ $? == 0 ]]; then
+if hostname "$HOSTNAME" &> /dev/null; then
 	PRIVILEGED=true
 else
 	PRIVILEGED=false
@@ -24,10 +23,10 @@ function start_udev()
 # For backward compatibility, we only update the hostname for ResinOS 1.x devices.
 function update_hostname()
 {
-	if [ ${RESIN_DEVICE_UUID:0:7} != ${HOSTNAME:0:7} ]; then
+	if [ "${RESIN_DEVICE_UUID:0:7}" != "${HOSTNAME:0:7}" ]; then
 		# For 1.x Devices only.
 		HOSTNAME="$RESIN_DEVICE_TYPE-${RESIN_DEVICE_UUID:0:7}"
-		echo $HOSTNAME > /etc/hostname
+		echo "$HOSTNAME" > /etc/hostname
 		echo "127.0.1.1 $HOSTNAME" >> /etc/hosts
 		hostname "$HOSTNAME"
 	fi
@@ -76,9 +75,8 @@ function init_openrc()
 
 function init_non_openrc()
 {
-	CMD=$(which "$1")
 	# echo error message, when executable file doesn't exist.
-	if [ $? == '0' ]; then
+	if CMD=$(command -v "$1" 2>/dev/null); then
 		shift
 		exec tini -sg -- "$CMD" "$@"
 	else
@@ -112,7 +110,7 @@ if [ ! -z "$RESIN_SUPERVISOR_API_KEY" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 		mount_dev
 	fi
 	start_udev
-fi 
+fi
 
 if [ "$INITSYSTEM" = "on" ]; then
 	init_openrc "$@"

--- a/resin-base-images/alpine/aarch64/3.8/entry.sh
+++ b/resin-base-images/alpine/aarch64/3.8/entry.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
 
 
-hostname "$HOSTNAME" &> /dev/null
-if [[ $? == 0 ]]; then
+if hostname "$HOSTNAME" &> /dev/null; then
 	PRIVILEGED=true
 else
 	PRIVILEGED=false
@@ -24,10 +23,10 @@ function start_udev()
 # For backward compatibility, we only update the hostname for ResinOS 1.x devices.
 function update_hostname()
 {
-	if [ ${RESIN_DEVICE_UUID:0:7} != ${HOSTNAME:0:7} ]; then
+	if [ "${RESIN_DEVICE_UUID:0:7}" != "${HOSTNAME:0:7}" ]; then
 		# For 1.x Devices only.
 		HOSTNAME="$RESIN_DEVICE_TYPE-${RESIN_DEVICE_UUID:0:7}"
-		echo $HOSTNAME > /etc/hostname
+		echo "$HOSTNAME" > /etc/hostname
 		echo "127.0.1.1 $HOSTNAME" >> /etc/hosts
 		hostname "$HOSTNAME"
 	fi
@@ -76,9 +75,8 @@ function init_openrc()
 
 function init_non_openrc()
 {
-	CMD=$(which "$1")
 	# echo error message, when executable file doesn't exist.
-	if [ $? == '0' ]; then
+	if CMD=$(command -v "$1" 2>/dev/null); then
 		shift
 		exec tini -sg -- "$CMD" "$@"
 	else
@@ -112,7 +110,7 @@ if [ ! -z "$RESIN_SUPERVISOR_API_KEY" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 		mount_dev
 	fi
 	start_udev
-fi 
+fi
 
 if [ "$INITSYSTEM" = "on" ]; then
 	init_openrc "$@"

--- a/resin-base-images/alpine/aarch64/edge/entry.sh
+++ b/resin-base-images/alpine/aarch64/edge/entry.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
 
 
-hostname "$HOSTNAME" &> /dev/null
-if [[ $? == 0 ]]; then
+if hostname "$HOSTNAME" &> /dev/null; then
 	PRIVILEGED=true
 else
 	PRIVILEGED=false
@@ -24,10 +23,10 @@ function start_udev()
 # For backward compatibility, we only update the hostname for ResinOS 1.x devices.
 function update_hostname()
 {
-	if [ ${RESIN_DEVICE_UUID:0:7} != ${HOSTNAME:0:7} ]; then
+	if [ "${RESIN_DEVICE_UUID:0:7}" != "${HOSTNAME:0:7}" ]; then
 		# For 1.x Devices only.
 		HOSTNAME="$RESIN_DEVICE_TYPE-${RESIN_DEVICE_UUID:0:7}"
-		echo $HOSTNAME > /etc/hostname
+		echo "$HOSTNAME" > /etc/hostname
 		echo "127.0.1.1 $HOSTNAME" >> /etc/hosts
 		hostname "$HOSTNAME"
 	fi
@@ -76,9 +75,8 @@ function init_openrc()
 
 function init_non_openrc()
 {
-	CMD=$(which "$1")
 	# echo error message, when executable file doesn't exist.
-	if [ $? == '0' ]; then
+	if CMD=$(command -v "$1" 2>/dev/null); then
 		shift
 		exec tini -sg -- "$CMD" "$@"
 	else
@@ -112,7 +110,7 @@ if [ ! -z "$RESIN_SUPERVISOR_API_KEY" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 		mount_dev
 	fi
 	start_udev
-fi 
+fi
 
 if [ "$INITSYSTEM" = "on" ]; then
 	init_openrc "$@"

--- a/resin-base-images/alpine/amd64/3.5/entry.sh
+++ b/resin-base-images/alpine/amd64/3.5/entry.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
 
 
-hostname "$HOSTNAME" &> /dev/null
-if [[ $? == 0 ]]; then
+if hostname "$HOSTNAME" &> /dev/null; then
 	PRIVILEGED=true
 else
 	PRIVILEGED=false
@@ -24,10 +23,10 @@ function start_udev()
 # For backward compatibility, we only update the hostname for ResinOS 1.x devices.
 function update_hostname()
 {
-	if [ ${RESIN_DEVICE_UUID:0:7} != ${HOSTNAME:0:7} ]; then
+	if [ "${RESIN_DEVICE_UUID:0:7}" != "${HOSTNAME:0:7}" ]; then
 		# For 1.x Devices only.
 		HOSTNAME="$RESIN_DEVICE_TYPE-${RESIN_DEVICE_UUID:0:7}"
-		echo $HOSTNAME > /etc/hostname
+		echo "$HOSTNAME" > /etc/hostname
 		echo "127.0.1.1 $HOSTNAME" >> /etc/hosts
 		hostname "$HOSTNAME"
 	fi
@@ -76,9 +75,8 @@ function init_openrc()
 
 function init_non_openrc()
 {
-	CMD=$(which "$1")
 	# echo error message, when executable file doesn't exist.
-	if [ $? == '0' ]; then
+	if CMD=$(command -v "$1" 2>/dev/null); then
 		shift
 		exec tini -sg -- "$CMD" "$@"
 	else
@@ -112,7 +110,7 @@ if [ ! -z "$RESIN_SUPERVISOR_API_KEY" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 		mount_dev
 	fi
 	start_udev
-fi 
+fi
 
 if [ "$INITSYSTEM" = "on" ]; then
 	init_openrc "$@"

--- a/resin-base-images/alpine/amd64/3.6/entry.sh
+++ b/resin-base-images/alpine/amd64/3.6/entry.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
 
 
-hostname "$HOSTNAME" &> /dev/null
-if [[ $? == 0 ]]; then
+if hostname "$HOSTNAME" &> /dev/null; then
 	PRIVILEGED=true
 else
 	PRIVILEGED=false
@@ -24,10 +23,10 @@ function start_udev()
 # For backward compatibility, we only update the hostname for ResinOS 1.x devices.
 function update_hostname()
 {
-	if [ ${RESIN_DEVICE_UUID:0:7} != ${HOSTNAME:0:7} ]; then
+	if [ "${RESIN_DEVICE_UUID:0:7}" != "${HOSTNAME:0:7}" ]; then
 		# For 1.x Devices only.
 		HOSTNAME="$RESIN_DEVICE_TYPE-${RESIN_DEVICE_UUID:0:7}"
-		echo $HOSTNAME > /etc/hostname
+		echo "$HOSTNAME" > /etc/hostname
 		echo "127.0.1.1 $HOSTNAME" >> /etc/hosts
 		hostname "$HOSTNAME"
 	fi
@@ -76,9 +75,8 @@ function init_openrc()
 
 function init_non_openrc()
 {
-	CMD=$(which "$1")
 	# echo error message, when executable file doesn't exist.
-	if [ $? == '0' ]; then
+	if CMD=$(command -v "$1" 2>/dev/null); then
 		shift
 		exec tini -sg -- "$CMD" "$@"
 	else
@@ -112,7 +110,7 @@ if [ ! -z "$RESIN_SUPERVISOR_API_KEY" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 		mount_dev
 	fi
 	start_udev
-fi 
+fi
 
 if [ "$INITSYSTEM" = "on" ]; then
 	init_openrc "$@"

--- a/resin-base-images/alpine/amd64/3.7/entry.sh
+++ b/resin-base-images/alpine/amd64/3.7/entry.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
 
 
-hostname "$HOSTNAME" &> /dev/null
-if [[ $? == 0 ]]; then
+if hostname "$HOSTNAME" &> /dev/null; then
 	PRIVILEGED=true
 else
 	PRIVILEGED=false
@@ -24,10 +23,10 @@ function start_udev()
 # For backward compatibility, we only update the hostname for ResinOS 1.x devices.
 function update_hostname()
 {
-	if [ ${RESIN_DEVICE_UUID:0:7} != ${HOSTNAME:0:7} ]; then
+	if [ "${RESIN_DEVICE_UUID:0:7}" != "${HOSTNAME:0:7}" ]; then
 		# For 1.x Devices only.
 		HOSTNAME="$RESIN_DEVICE_TYPE-${RESIN_DEVICE_UUID:0:7}"
-		echo $HOSTNAME > /etc/hostname
+		echo "$HOSTNAME" > /etc/hostname
 		echo "127.0.1.1 $HOSTNAME" >> /etc/hosts
 		hostname "$HOSTNAME"
 	fi
@@ -76,9 +75,8 @@ function init_openrc()
 
 function init_non_openrc()
 {
-	CMD=$(which "$1")
 	# echo error message, when executable file doesn't exist.
-	if [ $? == '0' ]; then
+	if CMD=$(command -v "$1" 2>/dev/null); then
 		shift
 		exec tini -sg -- "$CMD" "$@"
 	else
@@ -112,7 +110,7 @@ if [ ! -z "$RESIN_SUPERVISOR_API_KEY" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 		mount_dev
 	fi
 	start_udev
-fi 
+fi
 
 if [ "$INITSYSTEM" = "on" ]; then
 	init_openrc "$@"

--- a/resin-base-images/alpine/amd64/3.8/entry.sh
+++ b/resin-base-images/alpine/amd64/3.8/entry.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
 
 
-hostname "$HOSTNAME" &> /dev/null
-if [[ $? == 0 ]]; then
+if hostname "$HOSTNAME" &> /dev/null; then
 	PRIVILEGED=true
 else
 	PRIVILEGED=false
@@ -24,10 +23,10 @@ function start_udev()
 # For backward compatibility, we only update the hostname for ResinOS 1.x devices.
 function update_hostname()
 {
-	if [ ${RESIN_DEVICE_UUID:0:7} != ${HOSTNAME:0:7} ]; then
+	if [ "${RESIN_DEVICE_UUID:0:7}" != "${HOSTNAME:0:7}" ]; then
 		# For 1.x Devices only.
 		HOSTNAME="$RESIN_DEVICE_TYPE-${RESIN_DEVICE_UUID:0:7}"
-		echo $HOSTNAME > /etc/hostname
+		echo "$HOSTNAME" > /etc/hostname
 		echo "127.0.1.1 $HOSTNAME" >> /etc/hosts
 		hostname "$HOSTNAME"
 	fi
@@ -76,9 +75,8 @@ function init_openrc()
 
 function init_non_openrc()
 {
-	CMD=$(which "$1")
 	# echo error message, when executable file doesn't exist.
-	if [ $? == '0' ]; then
+	if CMD=$(command -v "$1" 2>/dev/null); then
 		shift
 		exec tini -sg -- "$CMD" "$@"
 	else
@@ -112,7 +110,7 @@ if [ ! -z "$RESIN_SUPERVISOR_API_KEY" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 		mount_dev
 	fi
 	start_udev
-fi 
+fi
 
 if [ "$INITSYSTEM" = "on" ]; then
 	init_openrc "$@"

--- a/resin-base-images/alpine/amd64/edge/entry.sh
+++ b/resin-base-images/alpine/amd64/edge/entry.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
 
 
-hostname "$HOSTNAME" &> /dev/null
-if [[ $? == 0 ]]; then
+if hostname "$HOSTNAME" &> /dev/null; then
 	PRIVILEGED=true
 else
 	PRIVILEGED=false
@@ -24,10 +23,10 @@ function start_udev()
 # For backward compatibility, we only update the hostname for ResinOS 1.x devices.
 function update_hostname()
 {
-	if [ ${RESIN_DEVICE_UUID:0:7} != ${HOSTNAME:0:7} ]; then
+	if [ "${RESIN_DEVICE_UUID:0:7}" != "${HOSTNAME:0:7}" ]; then
 		# For 1.x Devices only.
 		HOSTNAME="$RESIN_DEVICE_TYPE-${RESIN_DEVICE_UUID:0:7}"
-		echo $HOSTNAME > /etc/hostname
+		echo "$HOSTNAME" > /etc/hostname
 		echo "127.0.1.1 $HOSTNAME" >> /etc/hosts
 		hostname "$HOSTNAME"
 	fi
@@ -76,9 +75,8 @@ function init_openrc()
 
 function init_non_openrc()
 {
-	CMD=$(which "$1")
 	# echo error message, when executable file doesn't exist.
-	if [ $? == '0' ]; then
+	if CMD=$(command -v "$1" 2>/dev/null); then
 		shift
 		exec tini -sg -- "$CMD" "$@"
 	else
@@ -112,7 +110,7 @@ if [ ! -z "$RESIN_SUPERVISOR_API_KEY" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 		mount_dev
 	fi
 	start_udev
-fi 
+fi
 
 if [ "$INITSYSTEM" = "on" ]; then
 	init_openrc "$@"

--- a/resin-base-images/alpine/armv7hf/3.5/entry.sh
+++ b/resin-base-images/alpine/armv7hf/3.5/entry.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
 
 
-hostname "$HOSTNAME" &> /dev/null
-if [[ $? == 0 ]]; then
+if hostname "$HOSTNAME" &> /dev/null; then
 	PRIVILEGED=true
 else
 	PRIVILEGED=false
@@ -24,10 +23,10 @@ function start_udev()
 # For backward compatibility, we only update the hostname for ResinOS 1.x devices.
 function update_hostname()
 {
-	if [ ${RESIN_DEVICE_UUID:0:7} != ${HOSTNAME:0:7} ]; then
+	if [ "${RESIN_DEVICE_UUID:0:7}" != "${HOSTNAME:0:7}" ]; then
 		# For 1.x Devices only.
 		HOSTNAME="$RESIN_DEVICE_TYPE-${RESIN_DEVICE_UUID:0:7}"
-		echo $HOSTNAME > /etc/hostname
+		echo "$HOSTNAME" > /etc/hostname
 		echo "127.0.1.1 $HOSTNAME" >> /etc/hosts
 		hostname "$HOSTNAME"
 	fi
@@ -76,9 +75,8 @@ function init_openrc()
 
 function init_non_openrc()
 {
-	CMD=$(which "$1")
 	# echo error message, when executable file doesn't exist.
-	if [ $? == '0' ]; then
+	if CMD=$(command -v "$1" 2>/dev/null); then
 		shift
 		exec tini -sg -- "$CMD" "$@"
 	else
@@ -112,7 +110,7 @@ if [ ! -z "$RESIN_SUPERVISOR_API_KEY" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 		mount_dev
 	fi
 	start_udev
-fi 
+fi
 
 if [ "$INITSYSTEM" = "on" ]; then
 	init_openrc "$@"

--- a/resin-base-images/alpine/armv7hf/3.6/entry.sh
+++ b/resin-base-images/alpine/armv7hf/3.6/entry.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
 
 
-hostname "$HOSTNAME" &> /dev/null
-if [[ $? == 0 ]]; then
+if hostname "$HOSTNAME" &> /dev/null; then
 	PRIVILEGED=true
 else
 	PRIVILEGED=false
@@ -24,10 +23,10 @@ function start_udev()
 # For backward compatibility, we only update the hostname for ResinOS 1.x devices.
 function update_hostname()
 {
-	if [ ${RESIN_DEVICE_UUID:0:7} != ${HOSTNAME:0:7} ]; then
+	if [ "${RESIN_DEVICE_UUID:0:7}" != "${HOSTNAME:0:7}" ]; then
 		# For 1.x Devices only.
 		HOSTNAME="$RESIN_DEVICE_TYPE-${RESIN_DEVICE_UUID:0:7}"
-		echo $HOSTNAME > /etc/hostname
+		echo "$HOSTNAME" > /etc/hostname
 		echo "127.0.1.1 $HOSTNAME" >> /etc/hosts
 		hostname "$HOSTNAME"
 	fi
@@ -76,9 +75,8 @@ function init_openrc()
 
 function init_non_openrc()
 {
-	CMD=$(which "$1")
 	# echo error message, when executable file doesn't exist.
-	if [ $? == '0' ]; then
+	if CMD=$(command -v "$1" 2>/dev/null); then
 		shift
 		exec tini -sg -- "$CMD" "$@"
 	else
@@ -112,7 +110,7 @@ if [ ! -z "$RESIN_SUPERVISOR_API_KEY" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 		mount_dev
 	fi
 	start_udev
-fi 
+fi
 
 if [ "$INITSYSTEM" = "on" ]; then
 	init_openrc "$@"

--- a/resin-base-images/alpine/armv7hf/3.7/entry.sh
+++ b/resin-base-images/alpine/armv7hf/3.7/entry.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
 
 
-hostname "$HOSTNAME" &> /dev/null
-if [[ $? == 0 ]]; then
+if hostname "$HOSTNAME" &> /dev/null; then
 	PRIVILEGED=true
 else
 	PRIVILEGED=false
@@ -24,10 +23,10 @@ function start_udev()
 # For backward compatibility, we only update the hostname for ResinOS 1.x devices.
 function update_hostname()
 {
-	if [ ${RESIN_DEVICE_UUID:0:7} != ${HOSTNAME:0:7} ]; then
+	if [ "${RESIN_DEVICE_UUID:0:7}" != "${HOSTNAME:0:7}" ]; then
 		# For 1.x Devices only.
 		HOSTNAME="$RESIN_DEVICE_TYPE-${RESIN_DEVICE_UUID:0:7}"
-		echo $HOSTNAME > /etc/hostname
+		echo "$HOSTNAME" > /etc/hostname
 		echo "127.0.1.1 $HOSTNAME" >> /etc/hosts
 		hostname "$HOSTNAME"
 	fi
@@ -76,9 +75,8 @@ function init_openrc()
 
 function init_non_openrc()
 {
-	CMD=$(which "$1")
 	# echo error message, when executable file doesn't exist.
-	if [ $? == '0' ]; then
+	if CMD=$(command -v "$1" 2>/dev/null); then
 		shift
 		exec tini -sg -- "$CMD" "$@"
 	else
@@ -112,7 +110,7 @@ if [ ! -z "$RESIN_SUPERVISOR_API_KEY" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 		mount_dev
 	fi
 	start_udev
-fi 
+fi
 
 if [ "$INITSYSTEM" = "on" ]; then
 	init_openrc "$@"

--- a/resin-base-images/alpine/armv7hf/3.8/entry.sh
+++ b/resin-base-images/alpine/armv7hf/3.8/entry.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
 
 
-hostname "$HOSTNAME" &> /dev/null
-if [[ $? == 0 ]]; then
+if hostname "$HOSTNAME" &> /dev/null; then
 	PRIVILEGED=true
 else
 	PRIVILEGED=false
@@ -24,10 +23,10 @@ function start_udev()
 # For backward compatibility, we only update the hostname for ResinOS 1.x devices.
 function update_hostname()
 {
-	if [ ${RESIN_DEVICE_UUID:0:7} != ${HOSTNAME:0:7} ]; then
+	if [ "${RESIN_DEVICE_UUID:0:7}" != "${HOSTNAME:0:7}" ]; then
 		# For 1.x Devices only.
 		HOSTNAME="$RESIN_DEVICE_TYPE-${RESIN_DEVICE_UUID:0:7}"
-		echo $HOSTNAME > /etc/hostname
+		echo "$HOSTNAME" > /etc/hostname
 		echo "127.0.1.1 $HOSTNAME" >> /etc/hosts
 		hostname "$HOSTNAME"
 	fi
@@ -76,9 +75,8 @@ function init_openrc()
 
 function init_non_openrc()
 {
-	CMD=$(which "$1")
 	# echo error message, when executable file doesn't exist.
-	if [ $? == '0' ]; then
+	if CMD=$(command -v "$1" 2>/dev/null); then
 		shift
 		exec tini -sg -- "$CMD" "$@"
 	else
@@ -112,7 +110,7 @@ if [ ! -z "$RESIN_SUPERVISOR_API_KEY" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 		mount_dev
 	fi
 	start_udev
-fi 
+fi
 
 if [ "$INITSYSTEM" = "on" ]; then
 	init_openrc "$@"

--- a/resin-base-images/alpine/armv7hf/edge/entry.sh
+++ b/resin-base-images/alpine/armv7hf/edge/entry.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
 
 
-hostname "$HOSTNAME" &> /dev/null
-if [[ $? == 0 ]]; then
+if hostname "$HOSTNAME" &> /dev/null; then
 	PRIVILEGED=true
 else
 	PRIVILEGED=false
@@ -24,10 +23,10 @@ function start_udev()
 # For backward compatibility, we only update the hostname for ResinOS 1.x devices.
 function update_hostname()
 {
-	if [ ${RESIN_DEVICE_UUID:0:7} != ${HOSTNAME:0:7} ]; then
+	if [ "${RESIN_DEVICE_UUID:0:7}" != "${HOSTNAME:0:7}" ]; then
 		# For 1.x Devices only.
 		HOSTNAME="$RESIN_DEVICE_TYPE-${RESIN_DEVICE_UUID:0:7}"
-		echo $HOSTNAME > /etc/hostname
+		echo "$HOSTNAME" > /etc/hostname
 		echo "127.0.1.1 $HOSTNAME" >> /etc/hosts
 		hostname "$HOSTNAME"
 	fi
@@ -76,9 +75,8 @@ function init_openrc()
 
 function init_non_openrc()
 {
-	CMD=$(which "$1")
 	# echo error message, when executable file doesn't exist.
-	if [ $? == '0' ]; then
+	if CMD=$(command -v "$1" 2>/dev/null); then
 		shift
 		exec tini -sg -- "$CMD" "$@"
 	else
@@ -112,7 +110,7 @@ if [ ! -z "$RESIN_SUPERVISOR_API_KEY" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 		mount_dev
 	fi
 	start_udev
-fi 
+fi
 
 if [ "$INITSYSTEM" = "on" ]; then
 	init_openrc "$@"

--- a/resin-base-images/alpine/i386-nlp/3.5/entry.sh
+++ b/resin-base-images/alpine/i386-nlp/3.5/entry.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
 
 
-hostname "$HOSTNAME" &> /dev/null
-if [[ $? == 0 ]]; then
+if hostname "$HOSTNAME" &> /dev/null; then
 	PRIVILEGED=true
 else
 	PRIVILEGED=false
@@ -24,10 +23,10 @@ function start_udev()
 # For backward compatibility, we only update the hostname for ResinOS 1.x devices.
 function update_hostname()
 {
-	if [ ${RESIN_DEVICE_UUID:0:7} != ${HOSTNAME:0:7} ]; then
+	if [ "${RESIN_DEVICE_UUID:0:7}" != "${HOSTNAME:0:7}" ]; then
 		# For 1.x Devices only.
 		HOSTNAME="$RESIN_DEVICE_TYPE-${RESIN_DEVICE_UUID:0:7}"
-		echo $HOSTNAME > /etc/hostname
+		echo "$HOSTNAME" > /etc/hostname
 		echo "127.0.1.1 $HOSTNAME" >> /etc/hosts
 		hostname "$HOSTNAME"
 	fi
@@ -76,9 +75,8 @@ function init_openrc()
 
 function init_non_openrc()
 {
-	CMD=$(which "$1")
 	# echo error message, when executable file doesn't exist.
-	if [ $? == '0' ]; then
+	if CMD=$(command -v "$1" 2>/dev/null); then
 		shift
 		exec tini -sg -- "$CMD" "$@"
 	else
@@ -112,7 +110,7 @@ if [ ! -z "$RESIN_SUPERVISOR_API_KEY" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 		mount_dev
 	fi
 	start_udev
-fi 
+fi
 
 if [ "$INITSYSTEM" = "on" ]; then
 	init_openrc "$@"

--- a/resin-base-images/alpine/i386-nlp/3.6/entry.sh
+++ b/resin-base-images/alpine/i386-nlp/3.6/entry.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
 
 
-hostname "$HOSTNAME" &> /dev/null
-if [[ $? == 0 ]]; then
+if hostname "$HOSTNAME" &> /dev/null; then
 	PRIVILEGED=true
 else
 	PRIVILEGED=false
@@ -24,10 +23,10 @@ function start_udev()
 # For backward compatibility, we only update the hostname for ResinOS 1.x devices.
 function update_hostname()
 {
-	if [ ${RESIN_DEVICE_UUID:0:7} != ${HOSTNAME:0:7} ]; then
+	if [ "${RESIN_DEVICE_UUID:0:7}" != "${HOSTNAME:0:7}" ]; then
 		# For 1.x Devices only.
 		HOSTNAME="$RESIN_DEVICE_TYPE-${RESIN_DEVICE_UUID:0:7}"
-		echo $HOSTNAME > /etc/hostname
+		echo "$HOSTNAME" > /etc/hostname
 		echo "127.0.1.1 $HOSTNAME" >> /etc/hosts
 		hostname "$HOSTNAME"
 	fi
@@ -76,9 +75,8 @@ function init_openrc()
 
 function init_non_openrc()
 {
-	CMD=$(which "$1")
 	# echo error message, when executable file doesn't exist.
-	if [ $? == '0' ]; then
+	if CMD=$(command -v "$1" 2>/dev/null); then
 		shift
 		exec tini -sg -- "$CMD" "$@"
 	else
@@ -112,7 +110,7 @@ if [ ! -z "$RESIN_SUPERVISOR_API_KEY" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 		mount_dev
 	fi
 	start_udev
-fi 
+fi
 
 if [ "$INITSYSTEM" = "on" ]; then
 	init_openrc "$@"

--- a/resin-base-images/alpine/i386-nlp/3.7/entry.sh
+++ b/resin-base-images/alpine/i386-nlp/3.7/entry.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
 
 
-hostname "$HOSTNAME" &> /dev/null
-if [[ $? == 0 ]]; then
+if hostname "$HOSTNAME" &> /dev/null; then
 	PRIVILEGED=true
 else
 	PRIVILEGED=false
@@ -24,10 +23,10 @@ function start_udev()
 # For backward compatibility, we only update the hostname for ResinOS 1.x devices.
 function update_hostname()
 {
-	if [ ${RESIN_DEVICE_UUID:0:7} != ${HOSTNAME:0:7} ]; then
+	if [ "${RESIN_DEVICE_UUID:0:7}" != "${HOSTNAME:0:7}" ]; then
 		# For 1.x Devices only.
 		HOSTNAME="$RESIN_DEVICE_TYPE-${RESIN_DEVICE_UUID:0:7}"
-		echo $HOSTNAME > /etc/hostname
+		echo "$HOSTNAME" > /etc/hostname
 		echo "127.0.1.1 $HOSTNAME" >> /etc/hosts
 		hostname "$HOSTNAME"
 	fi
@@ -76,9 +75,8 @@ function init_openrc()
 
 function init_non_openrc()
 {
-	CMD=$(which "$1")
 	# echo error message, when executable file doesn't exist.
-	if [ $? == '0' ]; then
+	if CMD=$(command -v "$1" 2>/dev/null); then
 		shift
 		exec tini -sg -- "$CMD" "$@"
 	else
@@ -112,7 +110,7 @@ if [ ! -z "$RESIN_SUPERVISOR_API_KEY" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 		mount_dev
 	fi
 	start_udev
-fi 
+fi
 
 if [ "$INITSYSTEM" = "on" ]; then
 	init_openrc "$@"

--- a/resin-base-images/alpine/i386-nlp/3.8/entry.sh
+++ b/resin-base-images/alpine/i386-nlp/3.8/entry.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
 
 
-hostname "$HOSTNAME" &> /dev/null
-if [[ $? == 0 ]]; then
+if hostname "$HOSTNAME" &> /dev/null; then
 	PRIVILEGED=true
 else
 	PRIVILEGED=false
@@ -24,10 +23,10 @@ function start_udev()
 # For backward compatibility, we only update the hostname for ResinOS 1.x devices.
 function update_hostname()
 {
-	if [ ${RESIN_DEVICE_UUID:0:7} != ${HOSTNAME:0:7} ]; then
+	if [ "${RESIN_DEVICE_UUID:0:7}" != "${HOSTNAME:0:7}" ]; then
 		# For 1.x Devices only.
 		HOSTNAME="$RESIN_DEVICE_TYPE-${RESIN_DEVICE_UUID:0:7}"
-		echo $HOSTNAME > /etc/hostname
+		echo "$HOSTNAME" > /etc/hostname
 		echo "127.0.1.1 $HOSTNAME" >> /etc/hosts
 		hostname "$HOSTNAME"
 	fi
@@ -76,9 +75,8 @@ function init_openrc()
 
 function init_non_openrc()
 {
-	CMD=$(which "$1")
 	# echo error message, when executable file doesn't exist.
-	if [ $? == '0' ]; then
+	if CMD=$(command -v "$1" 2>/dev/null); then
 		shift
 		exec tini -sg -- "$CMD" "$@"
 	else
@@ -112,7 +110,7 @@ if [ ! -z "$RESIN_SUPERVISOR_API_KEY" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 		mount_dev
 	fi
 	start_udev
-fi 
+fi
 
 if [ "$INITSYSTEM" = "on" ]; then
 	init_openrc "$@"

--- a/resin-base-images/alpine/i386-nlp/edge/entry.sh
+++ b/resin-base-images/alpine/i386-nlp/edge/entry.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
 
 
-hostname "$HOSTNAME" &> /dev/null
-if [[ $? == 0 ]]; then
+if hostname "$HOSTNAME" &> /dev/null; then
 	PRIVILEGED=true
 else
 	PRIVILEGED=false
@@ -24,10 +23,10 @@ function start_udev()
 # For backward compatibility, we only update the hostname for ResinOS 1.x devices.
 function update_hostname()
 {
-	if [ ${RESIN_DEVICE_UUID:0:7} != ${HOSTNAME:0:7} ]; then
+	if [ "${RESIN_DEVICE_UUID:0:7}" != "${HOSTNAME:0:7}" ]; then
 		# For 1.x Devices only.
 		HOSTNAME="$RESIN_DEVICE_TYPE-${RESIN_DEVICE_UUID:0:7}"
-		echo $HOSTNAME > /etc/hostname
+		echo "$HOSTNAME" > /etc/hostname
 		echo "127.0.1.1 $HOSTNAME" >> /etc/hosts
 		hostname "$HOSTNAME"
 	fi
@@ -76,9 +75,8 @@ function init_openrc()
 
 function init_non_openrc()
 {
-	CMD=$(which "$1")
 	# echo error message, when executable file doesn't exist.
-	if [ $? == '0' ]; then
+	if CMD=$(command -v "$1" 2>/dev/null); then
 		shift
 		exec tini -sg -- "$CMD" "$@"
 	else
@@ -112,7 +110,7 @@ if [ ! -z "$RESIN_SUPERVISOR_API_KEY" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 		mount_dev
 	fi
 	start_udev
-fi 
+fi
 
 if [ "$INITSYSTEM" = "on" ]; then
 	init_openrc "$@"

--- a/resin-base-images/alpine/i386/3.5/entry.sh
+++ b/resin-base-images/alpine/i386/3.5/entry.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
 
 
-hostname "$HOSTNAME" &> /dev/null
-if [[ $? == 0 ]]; then
+if hostname "$HOSTNAME" &> /dev/null; then
 	PRIVILEGED=true
 else
 	PRIVILEGED=false
@@ -24,10 +23,10 @@ function start_udev()
 # For backward compatibility, we only update the hostname for ResinOS 1.x devices.
 function update_hostname()
 {
-	if [ ${RESIN_DEVICE_UUID:0:7} != ${HOSTNAME:0:7} ]; then
+	if [ "${RESIN_DEVICE_UUID:0:7}" != "${HOSTNAME:0:7}" ]; then
 		# For 1.x Devices only.
 		HOSTNAME="$RESIN_DEVICE_TYPE-${RESIN_DEVICE_UUID:0:7}"
-		echo $HOSTNAME > /etc/hostname
+		echo "$HOSTNAME" > /etc/hostname
 		echo "127.0.1.1 $HOSTNAME" >> /etc/hosts
 		hostname "$HOSTNAME"
 	fi
@@ -76,9 +75,8 @@ function init_openrc()
 
 function init_non_openrc()
 {
-	CMD=$(which "$1")
 	# echo error message, when executable file doesn't exist.
-	if [ $? == '0' ]; then
+	if CMD=$(command -v "$1" 2>/dev/null); then
 		shift
 		exec tini -sg -- "$CMD" "$@"
 	else
@@ -112,7 +110,7 @@ if [ ! -z "$RESIN_SUPERVISOR_API_KEY" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 		mount_dev
 	fi
 	start_udev
-fi 
+fi
 
 if [ "$INITSYSTEM" = "on" ]; then
 	init_openrc "$@"

--- a/resin-base-images/alpine/i386/3.6/entry.sh
+++ b/resin-base-images/alpine/i386/3.6/entry.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
 
 
-hostname "$HOSTNAME" &> /dev/null
-if [[ $? == 0 ]]; then
+if hostname "$HOSTNAME" &> /dev/null; then
 	PRIVILEGED=true
 else
 	PRIVILEGED=false
@@ -24,10 +23,10 @@ function start_udev()
 # For backward compatibility, we only update the hostname for ResinOS 1.x devices.
 function update_hostname()
 {
-	if [ ${RESIN_DEVICE_UUID:0:7} != ${HOSTNAME:0:7} ]; then
+	if [ "${RESIN_DEVICE_UUID:0:7}" != "${HOSTNAME:0:7}" ]; then
 		# For 1.x Devices only.
 		HOSTNAME="$RESIN_DEVICE_TYPE-${RESIN_DEVICE_UUID:0:7}"
-		echo $HOSTNAME > /etc/hostname
+		echo "$HOSTNAME" > /etc/hostname
 		echo "127.0.1.1 $HOSTNAME" >> /etc/hosts
 		hostname "$HOSTNAME"
 	fi
@@ -76,9 +75,8 @@ function init_openrc()
 
 function init_non_openrc()
 {
-	CMD=$(which "$1")
 	# echo error message, when executable file doesn't exist.
-	if [ $? == '0' ]; then
+	if CMD=$(command -v "$1" 2>/dev/null); then
 		shift
 		exec tini -sg -- "$CMD" "$@"
 	else
@@ -112,7 +110,7 @@ if [ ! -z "$RESIN_SUPERVISOR_API_KEY" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 		mount_dev
 	fi
 	start_udev
-fi 
+fi
 
 if [ "$INITSYSTEM" = "on" ]; then
 	init_openrc "$@"

--- a/resin-base-images/alpine/i386/3.7/entry.sh
+++ b/resin-base-images/alpine/i386/3.7/entry.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
 
 
-hostname "$HOSTNAME" &> /dev/null
-if [[ $? == 0 ]]; then
+if hostname "$HOSTNAME" &> /dev/null; then
 	PRIVILEGED=true
 else
 	PRIVILEGED=false
@@ -24,10 +23,10 @@ function start_udev()
 # For backward compatibility, we only update the hostname for ResinOS 1.x devices.
 function update_hostname()
 {
-	if [ ${RESIN_DEVICE_UUID:0:7} != ${HOSTNAME:0:7} ]; then
+	if [ "${RESIN_DEVICE_UUID:0:7}" != "${HOSTNAME:0:7}" ]; then
 		# For 1.x Devices only.
 		HOSTNAME="$RESIN_DEVICE_TYPE-${RESIN_DEVICE_UUID:0:7}"
-		echo $HOSTNAME > /etc/hostname
+		echo "$HOSTNAME" > /etc/hostname
 		echo "127.0.1.1 $HOSTNAME" >> /etc/hosts
 		hostname "$HOSTNAME"
 	fi
@@ -76,9 +75,8 @@ function init_openrc()
 
 function init_non_openrc()
 {
-	CMD=$(which "$1")
 	# echo error message, when executable file doesn't exist.
-	if [ $? == '0' ]; then
+	if CMD=$(command -v "$1" 2>/dev/null); then
 		shift
 		exec tini -sg -- "$CMD" "$@"
 	else
@@ -112,7 +110,7 @@ if [ ! -z "$RESIN_SUPERVISOR_API_KEY" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 		mount_dev
 	fi
 	start_udev
-fi 
+fi
 
 if [ "$INITSYSTEM" = "on" ]; then
 	init_openrc "$@"

--- a/resin-base-images/alpine/i386/3.8/entry.sh
+++ b/resin-base-images/alpine/i386/3.8/entry.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
 
 
-hostname "$HOSTNAME" &> /dev/null
-if [[ $? == 0 ]]; then
+if hostname "$HOSTNAME" &> /dev/null; then
 	PRIVILEGED=true
 else
 	PRIVILEGED=false
@@ -24,10 +23,10 @@ function start_udev()
 # For backward compatibility, we only update the hostname for ResinOS 1.x devices.
 function update_hostname()
 {
-	if [ ${RESIN_DEVICE_UUID:0:7} != ${HOSTNAME:0:7} ]; then
+	if [ "${RESIN_DEVICE_UUID:0:7}" != "${HOSTNAME:0:7}" ]; then
 		# For 1.x Devices only.
 		HOSTNAME="$RESIN_DEVICE_TYPE-${RESIN_DEVICE_UUID:0:7}"
-		echo $HOSTNAME > /etc/hostname
+		echo "$HOSTNAME" > /etc/hostname
 		echo "127.0.1.1 $HOSTNAME" >> /etc/hosts
 		hostname "$HOSTNAME"
 	fi
@@ -76,9 +75,8 @@ function init_openrc()
 
 function init_non_openrc()
 {
-	CMD=$(which "$1")
 	# echo error message, when executable file doesn't exist.
-	if [ $? == '0' ]; then
+	if CMD=$(command -v "$1" 2>/dev/null); then
 		shift
 		exec tini -sg -- "$CMD" "$@"
 	else
@@ -112,7 +110,7 @@ if [ ! -z "$RESIN_SUPERVISOR_API_KEY" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 		mount_dev
 	fi
 	start_udev
-fi 
+fi
 
 if [ "$INITSYSTEM" = "on" ]; then
 	init_openrc "$@"

--- a/resin-base-images/alpine/i386/edge/entry.sh
+++ b/resin-base-images/alpine/i386/edge/entry.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
 
 
-hostname "$HOSTNAME" &> /dev/null
-if [[ $? == 0 ]]; then
+if hostname "$HOSTNAME" &> /dev/null; then
 	PRIVILEGED=true
 else
 	PRIVILEGED=false
@@ -24,10 +23,10 @@ function start_udev()
 # For backward compatibility, we only update the hostname for ResinOS 1.x devices.
 function update_hostname()
 {
-	if [ ${RESIN_DEVICE_UUID:0:7} != ${HOSTNAME:0:7} ]; then
+	if [ "${RESIN_DEVICE_UUID:0:7}" != "${HOSTNAME:0:7}" ]; then
 		# For 1.x Devices only.
 		HOSTNAME="$RESIN_DEVICE_TYPE-${RESIN_DEVICE_UUID:0:7}"
-		echo $HOSTNAME > /etc/hostname
+		echo "$HOSTNAME" > /etc/hostname
 		echo "127.0.1.1 $HOSTNAME" >> /etc/hosts
 		hostname "$HOSTNAME"
 	fi
@@ -76,9 +75,8 @@ function init_openrc()
 
 function init_non_openrc()
 {
-	CMD=$(which "$1")
 	# echo error message, when executable file doesn't exist.
-	if [ $? == '0' ]; then
+	if CMD=$(command -v "$1" 2>/dev/null); then
 		shift
 		exec tini -sg -- "$CMD" "$@"
 	else
@@ -112,7 +110,7 @@ if [ ! -z "$RESIN_SUPERVISOR_API_KEY" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 		mount_dev
 	fi
 	start_udev
-fi 
+fi
 
 if [ "$INITSYSTEM" = "on" ]; then
 	init_openrc "$@"

--- a/resin-base-images/alpine/rpi/3.5/entry.sh
+++ b/resin-base-images/alpine/rpi/3.5/entry.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
 
 
-hostname "$HOSTNAME" &> /dev/null
-if [[ $? == 0 ]]; then
+if hostname "$HOSTNAME" &> /dev/null; then
 	PRIVILEGED=true
 else
 	PRIVILEGED=false
@@ -24,10 +23,10 @@ function start_udev()
 # For backward compatibility, we only update the hostname for ResinOS 1.x devices.
 function update_hostname()
 {
-	if [ ${RESIN_DEVICE_UUID:0:7} != ${HOSTNAME:0:7} ]; then
+	if [ "${RESIN_DEVICE_UUID:0:7}" != "${HOSTNAME:0:7}" ]; then
 		# For 1.x Devices only.
 		HOSTNAME="$RESIN_DEVICE_TYPE-${RESIN_DEVICE_UUID:0:7}"
-		echo $HOSTNAME > /etc/hostname
+		echo "$HOSTNAME" > /etc/hostname
 		echo "127.0.1.1 $HOSTNAME" >> /etc/hosts
 		hostname "$HOSTNAME"
 	fi
@@ -76,9 +75,8 @@ function init_openrc()
 
 function init_non_openrc()
 {
-	CMD=$(which "$1")
 	# echo error message, when executable file doesn't exist.
-	if [ $? == '0' ]; then
+	if CMD=$(command -v "$1" 2>/dev/null); then
 		shift
 		exec tini -sg -- "$CMD" "$@"
 	else
@@ -112,7 +110,7 @@ if [ ! -z "$RESIN_SUPERVISOR_API_KEY" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 		mount_dev
 	fi
 	start_udev
-fi 
+fi
 
 if [ "$INITSYSTEM" = "on" ]; then
 	init_openrc "$@"

--- a/resin-base-images/alpine/rpi/3.6/entry.sh
+++ b/resin-base-images/alpine/rpi/3.6/entry.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
 
 
-hostname "$HOSTNAME" &> /dev/null
-if [[ $? == 0 ]]; then
+if hostname "$HOSTNAME" &> /dev/null; then
 	PRIVILEGED=true
 else
 	PRIVILEGED=false
@@ -24,10 +23,10 @@ function start_udev()
 # For backward compatibility, we only update the hostname for ResinOS 1.x devices.
 function update_hostname()
 {
-	if [ ${RESIN_DEVICE_UUID:0:7} != ${HOSTNAME:0:7} ]; then
+	if [ "${RESIN_DEVICE_UUID:0:7}" != "${HOSTNAME:0:7}" ]; then
 		# For 1.x Devices only.
 		HOSTNAME="$RESIN_DEVICE_TYPE-${RESIN_DEVICE_UUID:0:7}"
-		echo $HOSTNAME > /etc/hostname
+		echo "$HOSTNAME" > /etc/hostname
 		echo "127.0.1.1 $HOSTNAME" >> /etc/hosts
 		hostname "$HOSTNAME"
 	fi
@@ -76,9 +75,8 @@ function init_openrc()
 
 function init_non_openrc()
 {
-	CMD=$(which "$1")
 	# echo error message, when executable file doesn't exist.
-	if [ $? == '0' ]; then
+	if CMD=$(command -v "$1" 2>/dev/null); then
 		shift
 		exec tini -sg -- "$CMD" "$@"
 	else
@@ -112,7 +110,7 @@ if [ ! -z "$RESIN_SUPERVISOR_API_KEY" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 		mount_dev
 	fi
 	start_udev
-fi 
+fi
 
 if [ "$INITSYSTEM" = "on" ]; then
 	init_openrc "$@"

--- a/resin-base-images/alpine/rpi/3.7/entry.sh
+++ b/resin-base-images/alpine/rpi/3.7/entry.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
 
 
-hostname "$HOSTNAME" &> /dev/null
-if [[ $? == 0 ]]; then
+if hostname "$HOSTNAME" &> /dev/null; then
 	PRIVILEGED=true
 else
 	PRIVILEGED=false
@@ -24,10 +23,10 @@ function start_udev()
 # For backward compatibility, we only update the hostname for ResinOS 1.x devices.
 function update_hostname()
 {
-	if [ ${RESIN_DEVICE_UUID:0:7} != ${HOSTNAME:0:7} ]; then
+	if [ "${RESIN_DEVICE_UUID:0:7}" != "${HOSTNAME:0:7}" ]; then
 		# For 1.x Devices only.
 		HOSTNAME="$RESIN_DEVICE_TYPE-${RESIN_DEVICE_UUID:0:7}"
-		echo $HOSTNAME > /etc/hostname
+		echo "$HOSTNAME" > /etc/hostname
 		echo "127.0.1.1 $HOSTNAME" >> /etc/hosts
 		hostname "$HOSTNAME"
 	fi
@@ -76,9 +75,8 @@ function init_openrc()
 
 function init_non_openrc()
 {
-	CMD=$(which "$1")
 	# echo error message, when executable file doesn't exist.
-	if [ $? == '0' ]; then
+	if CMD=$(command -v "$1" 2>/dev/null); then
 		shift
 		exec tini -sg -- "$CMD" "$@"
 	else
@@ -112,7 +110,7 @@ if [ ! -z "$RESIN_SUPERVISOR_API_KEY" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 		mount_dev
 	fi
 	start_udev
-fi 
+fi
 
 if [ "$INITSYSTEM" = "on" ]; then
 	init_openrc "$@"

--- a/resin-base-images/alpine/rpi/3.8/entry.sh
+++ b/resin-base-images/alpine/rpi/3.8/entry.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
 
 
-hostname "$HOSTNAME" &> /dev/null
-if [[ $? == 0 ]]; then
+if hostname "$HOSTNAME" &> /dev/null; then
 	PRIVILEGED=true
 else
 	PRIVILEGED=false
@@ -24,10 +23,10 @@ function start_udev()
 # For backward compatibility, we only update the hostname for ResinOS 1.x devices.
 function update_hostname()
 {
-	if [ ${RESIN_DEVICE_UUID:0:7} != ${HOSTNAME:0:7} ]; then
+	if [ "${RESIN_DEVICE_UUID:0:7}" != "${HOSTNAME:0:7}" ]; then
 		# For 1.x Devices only.
 		HOSTNAME="$RESIN_DEVICE_TYPE-${RESIN_DEVICE_UUID:0:7}"
-		echo $HOSTNAME > /etc/hostname
+		echo "$HOSTNAME" > /etc/hostname
 		echo "127.0.1.1 $HOSTNAME" >> /etc/hosts
 		hostname "$HOSTNAME"
 	fi
@@ -76,9 +75,8 @@ function init_openrc()
 
 function init_non_openrc()
 {
-	CMD=$(which "$1")
 	# echo error message, when executable file doesn't exist.
-	if [ $? == '0' ]; then
+	if CMD=$(command -v "$1" 2>/dev/null); then
 		shift
 		exec tini -sg -- "$CMD" "$@"
 	else
@@ -112,7 +110,7 @@ if [ ! -z "$RESIN_SUPERVISOR_API_KEY" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 		mount_dev
 	fi
 	start_udev
-fi 
+fi
 
 if [ "$INITSYSTEM" = "on" ]; then
 	init_openrc "$@"

--- a/resin-base-images/alpine/rpi/edge/entry.sh
+++ b/resin-base-images/alpine/rpi/edge/entry.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
 
 
-hostname "$HOSTNAME" &> /dev/null
-if [[ $? == 0 ]]; then
+if hostname "$HOSTNAME" &> /dev/null; then
 	PRIVILEGED=true
 else
 	PRIVILEGED=false
@@ -24,10 +23,10 @@ function start_udev()
 # For backward compatibility, we only update the hostname for ResinOS 1.x devices.
 function update_hostname()
 {
-	if [ ${RESIN_DEVICE_UUID:0:7} != ${HOSTNAME:0:7} ]; then
+	if [ "${RESIN_DEVICE_UUID:0:7}" != "${HOSTNAME:0:7}" ]; then
 		# For 1.x Devices only.
 		HOSTNAME="$RESIN_DEVICE_TYPE-${RESIN_DEVICE_UUID:0:7}"
-		echo $HOSTNAME > /etc/hostname
+		echo "$HOSTNAME" > /etc/hostname
 		echo "127.0.1.1 $HOSTNAME" >> /etc/hosts
 		hostname "$HOSTNAME"
 	fi
@@ -76,9 +75,8 @@ function init_openrc()
 
 function init_non_openrc()
 {
-	CMD=$(which "$1")
 	# echo error message, when executable file doesn't exist.
-	if [ $? == '0' ]; then
+	if CMD=$(command -v "$1" 2>/dev/null); then
 		shift
 		exec tini -sg -- "$CMD" "$@"
 	else
@@ -112,7 +110,7 @@ if [ ! -z "$RESIN_SUPERVISOR_API_KEY" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 		mount_dev
 	fi
 	start_udev
-fi 
+fi
 
 if [ "$INITSYSTEM" = "on" ]; then
 	init_openrc "$@"

--- a/resin-base-images/debian/aarch64/buster/entry.sh
+++ b/resin-base-images/debian/aarch64/buster/entry.sh
@@ -2,8 +2,7 @@
 
 set -m
 
-hostname "$HOSTNAME" &> /dev/null
-if [[ $? == 0 ]]; then
+if hostname "$HOSTNAME" &> /dev/null; then
 	PRIVILEGED=true
 else
 	PRIVILEGED=false
@@ -13,8 +12,7 @@ function start_udev()
 {
 	if [ "$UDEV" == "on" ]; then
 		if [ "$INITSYSTEM" != "on" ]; then
-			which udevd
-			if [ $? == '0' ]; then
+			if command -v udevd &>/dev/null; then
 				udevd --daemon &> /dev/null
 			else
 				/lib/systemd/systemd-udevd --daemon &> /dev/null
@@ -36,17 +34,17 @@ function remove_buildtime_env_var()
 # Send SIGTERM to child processes of PID 1.
 function signal_handler()
 {
-	kill $pid
+	kill "$pid"
 }
 
 # On ResinOS 2.x devices, the hostname is set by the hostOS.
 # For backward compatibility, we only update the hostname for ResinOS 1.x devices.
 function update_hostname()
 {
-	if [ ${RESIN_DEVICE_UUID:0:7} != ${HOSTNAME:0:7} ]; then
+	if [ "${RESIN_DEVICE_UUID:0:7}" != "${HOSTNAME:0:7}" ]; then
 		# For 1.x Devices only.
 		HOSTNAME="$RESIN_DEVICE_TYPE-${RESIN_DEVICE_UUID:0:7}"
-		echo $HOSTNAME > /etc/hostname
+		echo "$HOSTNAME" > /etc/hostname
 		echo "127.0.1.1 $HOSTNAME" >> /etc/hosts
 		hostname "$HOSTNAME"
 	fi
@@ -79,9 +77,8 @@ function init_systemd()
 	GREEN='\033[0;32m'
 	echo -e "${GREEN}Systemd init system enabled."
 	for var in $(compgen -e); do
-		printf '%q="%q"\n' "$var" "${!var}"
+		printf '%q=%q\n' "$var" "${!var}"
 	done > /etc/docker.env
-	echo 'source /etc/docker.env' >> ~/.bashrc
 
 	printf '#!/bin/bash\n exec ' > /etc/resinApp.sh
 	printf '%q ' "$@" >> /etc/resinApp.sh
@@ -102,9 +99,8 @@ function init_non_systemd()
 	# trap the stop signal then send SIGTERM to user processes
 	trap signal_handler SIGRTMIN+3 SIGTERM
 
-	CMD=$(which "$1")
 	# echo error message, when executable file doesn't exist.
-	if [ $? == '0' ]; then
+	if CMD=$(command -v "$1" 2>/dev/null); then
 		shift
 		tini -sg -- "$CMD" "$@" &
 		pid=$!
@@ -142,7 +138,7 @@ if [ ! -z "$RESIN" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 		mount_dev
 	fi
 	start_udev
-fi 
+fi
 
 if [ "$INITSYSTEM" = "on" ]; then
 	init_systemd "$@"

--- a/resin-base-images/debian/aarch64/jessie/entry.sh
+++ b/resin-base-images/debian/aarch64/jessie/entry.sh
@@ -2,8 +2,7 @@
 
 set -m
 
-hostname "$HOSTNAME" &> /dev/null
-if [[ $? == 0 ]]; then
+if hostname "$HOSTNAME" &> /dev/null; then
 	PRIVILEGED=true
 else
 	PRIVILEGED=false
@@ -13,8 +12,7 @@ function start_udev()
 {
 	if [ "$UDEV" == "on" ]; then
 		if [ "$INITSYSTEM" != "on" ]; then
-			which udevd
-			if [ $? == '0' ]; then
+			if command -v udevd &>/dev/null; then
 				udevd --daemon &> /dev/null
 			else
 				/lib/systemd/systemd-udevd --daemon &> /dev/null
@@ -36,17 +34,17 @@ function remove_buildtime_env_var()
 # Send SIGTERM to child processes of PID 1.
 function signal_handler()
 {
-	kill $pid
+	kill "$pid"
 }
 
 # On ResinOS 2.x devices, the hostname is set by the hostOS.
 # For backward compatibility, we only update the hostname for ResinOS 1.x devices.
 function update_hostname()
 {
-	if [ ${RESIN_DEVICE_UUID:0:7} != ${HOSTNAME:0:7} ]; then
+	if [ "${RESIN_DEVICE_UUID:0:7}" != "${HOSTNAME:0:7}" ]; then
 		# For 1.x Devices only.
 		HOSTNAME="$RESIN_DEVICE_TYPE-${RESIN_DEVICE_UUID:0:7}"
-		echo $HOSTNAME > /etc/hostname
+		echo "$HOSTNAME" > /etc/hostname
 		echo "127.0.1.1 $HOSTNAME" >> /etc/hosts
 		hostname "$HOSTNAME"
 	fi
@@ -79,9 +77,8 @@ function init_systemd()
 	GREEN='\033[0;32m'
 	echo -e "${GREEN}Systemd init system enabled."
 	for var in $(compgen -e); do
-		printf '%q="%q"\n' "$var" "${!var}"
+		printf '%q=%q\n' "$var" "${!var}"
 	done > /etc/docker.env
-	echo 'source /etc/docker.env' >> ~/.bashrc
 
 	printf '#!/bin/bash\n exec ' > /etc/resinApp.sh
 	printf '%q ' "$@" >> /etc/resinApp.sh
@@ -102,9 +99,8 @@ function init_non_systemd()
 	# trap the stop signal then send SIGTERM to user processes
 	trap signal_handler SIGRTMIN+3 SIGTERM
 
-	CMD=$(which "$1")
 	# echo error message, when executable file doesn't exist.
-	if [ $? == '0' ]; then
+	if CMD=$(command -v "$1" 2>/dev/null); then
 		shift
 		tini -sg -- "$CMD" "$@" &
 		pid=$!
@@ -142,7 +138,7 @@ if [ ! -z "$RESIN" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 		mount_dev
 	fi
 	start_udev
-fi 
+fi
 
 if [ "$INITSYSTEM" = "on" ]; then
 	init_systemd "$@"

--- a/resin-base-images/debian/aarch64/sid/entry.sh
+++ b/resin-base-images/debian/aarch64/sid/entry.sh
@@ -2,8 +2,7 @@
 
 set -m
 
-hostname "$HOSTNAME" &> /dev/null
-if [[ $? == 0 ]]; then
+if hostname "$HOSTNAME" &> /dev/null; then
 	PRIVILEGED=true
 else
 	PRIVILEGED=false
@@ -13,8 +12,7 @@ function start_udev()
 {
 	if [ "$UDEV" == "on" ]; then
 		if [ "$INITSYSTEM" != "on" ]; then
-			which udevd
-			if [ $? == '0' ]; then
+			if command -v udevd &>/dev/null; then
 				udevd --daemon &> /dev/null
 			else
 				/lib/systemd/systemd-udevd --daemon &> /dev/null
@@ -36,17 +34,17 @@ function remove_buildtime_env_var()
 # Send SIGTERM to child processes of PID 1.
 function signal_handler()
 {
-	kill $pid
+	kill "$pid"
 }
 
 # On ResinOS 2.x devices, the hostname is set by the hostOS.
 # For backward compatibility, we only update the hostname for ResinOS 1.x devices.
 function update_hostname()
 {
-	if [ ${RESIN_DEVICE_UUID:0:7} != ${HOSTNAME:0:7} ]; then
+	if [ "${RESIN_DEVICE_UUID:0:7}" != "${HOSTNAME:0:7}" ]; then
 		# For 1.x Devices only.
 		HOSTNAME="$RESIN_DEVICE_TYPE-${RESIN_DEVICE_UUID:0:7}"
-		echo $HOSTNAME > /etc/hostname
+		echo "$HOSTNAME" > /etc/hostname
 		echo "127.0.1.1 $HOSTNAME" >> /etc/hosts
 		hostname "$HOSTNAME"
 	fi
@@ -79,9 +77,8 @@ function init_systemd()
 	GREEN='\033[0;32m'
 	echo -e "${GREEN}Systemd init system enabled."
 	for var in $(compgen -e); do
-		printf '%q="%q"\n' "$var" "${!var}"
+		printf '%q=%q\n' "$var" "${!var}"
 	done > /etc/docker.env
-	echo 'source /etc/docker.env' >> ~/.bashrc
 
 	printf '#!/bin/bash\n exec ' > /etc/resinApp.sh
 	printf '%q ' "$@" >> /etc/resinApp.sh
@@ -102,9 +99,8 @@ function init_non_systemd()
 	# trap the stop signal then send SIGTERM to user processes
 	trap signal_handler SIGRTMIN+3 SIGTERM
 
-	CMD=$(which "$1")
 	# echo error message, when executable file doesn't exist.
-	if [ $? == '0' ]; then
+	if CMD=$(command -v "$1" 2>/dev/null); then
 		shift
 		tini -sg -- "$CMD" "$@" &
 		pid=$!
@@ -142,7 +138,7 @@ if [ ! -z "$RESIN" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 		mount_dev
 	fi
 	start_udev
-fi 
+fi
 
 if [ "$INITSYSTEM" = "on" ]; then
 	init_systemd "$@"

--- a/resin-base-images/debian/aarch64/stretch/entry.sh
+++ b/resin-base-images/debian/aarch64/stretch/entry.sh
@@ -2,8 +2,7 @@
 
 set -m
 
-hostname "$HOSTNAME" &> /dev/null
-if [[ $? == 0 ]]; then
+if hostname "$HOSTNAME" &> /dev/null; then
 	PRIVILEGED=true
 else
 	PRIVILEGED=false
@@ -13,8 +12,7 @@ function start_udev()
 {
 	if [ "$UDEV" == "on" ]; then
 		if [ "$INITSYSTEM" != "on" ]; then
-			which udevd
-			if [ $? == '0' ]; then
+			if command -v udevd &>/dev/null; then
 				udevd --daemon &> /dev/null
 			else
 				/lib/systemd/systemd-udevd --daemon &> /dev/null
@@ -36,17 +34,17 @@ function remove_buildtime_env_var()
 # Send SIGTERM to child processes of PID 1.
 function signal_handler()
 {
-	kill $pid
+	kill "$pid"
 }
 
 # On ResinOS 2.x devices, the hostname is set by the hostOS.
 # For backward compatibility, we only update the hostname for ResinOS 1.x devices.
 function update_hostname()
 {
-	if [ ${RESIN_DEVICE_UUID:0:7} != ${HOSTNAME:0:7} ]; then
+	if [ "${RESIN_DEVICE_UUID:0:7}" != "${HOSTNAME:0:7}" ]; then
 		# For 1.x Devices only.
 		HOSTNAME="$RESIN_DEVICE_TYPE-${RESIN_DEVICE_UUID:0:7}"
-		echo $HOSTNAME > /etc/hostname
+		echo "$HOSTNAME" > /etc/hostname
 		echo "127.0.1.1 $HOSTNAME" >> /etc/hosts
 		hostname "$HOSTNAME"
 	fi
@@ -79,9 +77,8 @@ function init_systemd()
 	GREEN='\033[0;32m'
 	echo -e "${GREEN}Systemd init system enabled."
 	for var in $(compgen -e); do
-		printf '%q="%q"\n' "$var" "${!var}"
+		printf '%q=%q\n' "$var" "${!var}"
 	done > /etc/docker.env
-	echo 'source /etc/docker.env' >> ~/.bashrc
 
 	printf '#!/bin/bash\n exec ' > /etc/resinApp.sh
 	printf '%q ' "$@" >> /etc/resinApp.sh
@@ -102,9 +99,8 @@ function init_non_systemd()
 	# trap the stop signal then send SIGTERM to user processes
 	trap signal_handler SIGRTMIN+3 SIGTERM
 
-	CMD=$(which "$1")
 	# echo error message, when executable file doesn't exist.
-	if [ $? == '0' ]; then
+	if CMD=$(command -v "$1" 2>/dev/null); then
 		shift
 		tini -sg -- "$CMD" "$@" &
 		pid=$!
@@ -142,7 +138,7 @@ if [ ! -z "$RESIN" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 		mount_dev
 	fi
 	start_udev
-fi 
+fi
 
 if [ "$INITSYSTEM" = "on" ]; then
 	init_systemd "$@"

--- a/resin-base-images/debian/amd64/buster/entry.sh
+++ b/resin-base-images/debian/amd64/buster/entry.sh
@@ -2,8 +2,7 @@
 
 set -m
 
-hostname "$HOSTNAME" &> /dev/null
-if [[ $? == 0 ]]; then
+if hostname "$HOSTNAME" &> /dev/null; then
 	PRIVILEGED=true
 else
 	PRIVILEGED=false
@@ -13,8 +12,7 @@ function start_udev()
 {
 	if [ "$UDEV" == "on" ]; then
 		if [ "$INITSYSTEM" != "on" ]; then
-			which udevd
-			if [ $? == '0' ]; then
+			if command -v udevd &>/dev/null; then
 				udevd --daemon &> /dev/null
 			else
 				/lib/systemd/systemd-udevd --daemon &> /dev/null
@@ -36,17 +34,17 @@ function remove_buildtime_env_var()
 # Send SIGTERM to child processes of PID 1.
 function signal_handler()
 {
-	kill $pid
+	kill "$pid"
 }
 
 # On ResinOS 2.x devices, the hostname is set by the hostOS.
 # For backward compatibility, we only update the hostname for ResinOS 1.x devices.
 function update_hostname()
 {
-	if [ ${RESIN_DEVICE_UUID:0:7} != ${HOSTNAME:0:7} ]; then
+	if [ "${RESIN_DEVICE_UUID:0:7}" != "${HOSTNAME:0:7}" ]; then
 		# For 1.x Devices only.
 		HOSTNAME="$RESIN_DEVICE_TYPE-${RESIN_DEVICE_UUID:0:7}"
-		echo $HOSTNAME > /etc/hostname
+		echo "$HOSTNAME" > /etc/hostname
 		echo "127.0.1.1 $HOSTNAME" >> /etc/hosts
 		hostname "$HOSTNAME"
 	fi
@@ -79,9 +77,8 @@ function init_systemd()
 	GREEN='\033[0;32m'
 	echo -e "${GREEN}Systemd init system enabled."
 	for var in $(compgen -e); do
-		printf '%q="%q"\n' "$var" "${!var}"
+		printf '%q=%q\n' "$var" "${!var}"
 	done > /etc/docker.env
-	echo 'source /etc/docker.env' >> ~/.bashrc
 
 	printf '#!/bin/bash\n exec ' > /etc/resinApp.sh
 	printf '%q ' "$@" >> /etc/resinApp.sh
@@ -102,9 +99,8 @@ function init_non_systemd()
 	# trap the stop signal then send SIGTERM to user processes
 	trap signal_handler SIGRTMIN+3 SIGTERM
 
-	CMD=$(which "$1")
 	# echo error message, when executable file doesn't exist.
-	if [ $? == '0' ]; then
+	if CMD=$(command -v "$1" 2>/dev/null); then
 		shift
 		tini -sg -- "$CMD" "$@" &
 		pid=$!
@@ -142,7 +138,7 @@ if [ ! -z "$RESIN" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 		mount_dev
 	fi
 	start_udev
-fi 
+fi
 
 if [ "$INITSYSTEM" = "on" ]; then
 	init_systemd "$@"

--- a/resin-base-images/debian/amd64/jessie/entry.sh
+++ b/resin-base-images/debian/amd64/jessie/entry.sh
@@ -2,8 +2,7 @@
 
 set -m
 
-hostname "$HOSTNAME" &> /dev/null
-if [[ $? == 0 ]]; then
+if hostname "$HOSTNAME" &> /dev/null; then
 	PRIVILEGED=true
 else
 	PRIVILEGED=false
@@ -13,8 +12,7 @@ function start_udev()
 {
 	if [ "$UDEV" == "on" ]; then
 		if [ "$INITSYSTEM" != "on" ]; then
-			which udevd
-			if [ $? == '0' ]; then
+			if command -v udevd &>/dev/null; then
 				udevd --daemon &> /dev/null
 			else
 				/lib/systemd/systemd-udevd --daemon &> /dev/null
@@ -36,17 +34,17 @@ function remove_buildtime_env_var()
 # Send SIGTERM to child processes of PID 1.
 function signal_handler()
 {
-	kill $pid
+	kill "$pid"
 }
 
 # On ResinOS 2.x devices, the hostname is set by the hostOS.
 # For backward compatibility, we only update the hostname for ResinOS 1.x devices.
 function update_hostname()
 {
-	if [ ${RESIN_DEVICE_UUID:0:7} != ${HOSTNAME:0:7} ]; then
+	if [ "${RESIN_DEVICE_UUID:0:7}" != "${HOSTNAME:0:7}" ]; then
 		# For 1.x Devices only.
 		HOSTNAME="$RESIN_DEVICE_TYPE-${RESIN_DEVICE_UUID:0:7}"
-		echo $HOSTNAME > /etc/hostname
+		echo "$HOSTNAME" > /etc/hostname
 		echo "127.0.1.1 $HOSTNAME" >> /etc/hosts
 		hostname "$HOSTNAME"
 	fi
@@ -79,9 +77,8 @@ function init_systemd()
 	GREEN='\033[0;32m'
 	echo -e "${GREEN}Systemd init system enabled."
 	for var in $(compgen -e); do
-		printf '%q="%q"\n' "$var" "${!var}"
+		printf '%q=%q\n' "$var" "${!var}"
 	done > /etc/docker.env
-	echo 'source /etc/docker.env' >> ~/.bashrc
 
 	printf '#!/bin/bash\n exec ' > /etc/resinApp.sh
 	printf '%q ' "$@" >> /etc/resinApp.sh
@@ -102,9 +99,8 @@ function init_non_systemd()
 	# trap the stop signal then send SIGTERM to user processes
 	trap signal_handler SIGRTMIN+3 SIGTERM
 
-	CMD=$(which "$1")
 	# echo error message, when executable file doesn't exist.
-	if [ $? == '0' ]; then
+	if CMD=$(command -v "$1" 2>/dev/null); then
 		shift
 		tini -sg -- "$CMD" "$@" &
 		pid=$!
@@ -142,7 +138,7 @@ if [ ! -z "$RESIN" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 		mount_dev
 	fi
 	start_udev
-fi 
+fi
 
 if [ "$INITSYSTEM" = "on" ]; then
 	init_systemd "$@"

--- a/resin-base-images/debian/amd64/sid/entry.sh
+++ b/resin-base-images/debian/amd64/sid/entry.sh
@@ -2,8 +2,7 @@
 
 set -m
 
-hostname "$HOSTNAME" &> /dev/null
-if [[ $? == 0 ]]; then
+if hostname "$HOSTNAME" &> /dev/null; then
 	PRIVILEGED=true
 else
 	PRIVILEGED=false
@@ -13,8 +12,7 @@ function start_udev()
 {
 	if [ "$UDEV" == "on" ]; then
 		if [ "$INITSYSTEM" != "on" ]; then
-			which udevd
-			if [ $? == '0' ]; then
+			if command -v udevd &>/dev/null; then
 				udevd --daemon &> /dev/null
 			else
 				/lib/systemd/systemd-udevd --daemon &> /dev/null
@@ -36,17 +34,17 @@ function remove_buildtime_env_var()
 # Send SIGTERM to child processes of PID 1.
 function signal_handler()
 {
-	kill $pid
+	kill "$pid"
 }
 
 # On ResinOS 2.x devices, the hostname is set by the hostOS.
 # For backward compatibility, we only update the hostname for ResinOS 1.x devices.
 function update_hostname()
 {
-	if [ ${RESIN_DEVICE_UUID:0:7} != ${HOSTNAME:0:7} ]; then
+	if [ "${RESIN_DEVICE_UUID:0:7}" != "${HOSTNAME:0:7}" ]; then
 		# For 1.x Devices only.
 		HOSTNAME="$RESIN_DEVICE_TYPE-${RESIN_DEVICE_UUID:0:7}"
-		echo $HOSTNAME > /etc/hostname
+		echo "$HOSTNAME" > /etc/hostname
 		echo "127.0.1.1 $HOSTNAME" >> /etc/hosts
 		hostname "$HOSTNAME"
 	fi
@@ -79,9 +77,8 @@ function init_systemd()
 	GREEN='\033[0;32m'
 	echo -e "${GREEN}Systemd init system enabled."
 	for var in $(compgen -e); do
-		printf '%q="%q"\n' "$var" "${!var}"
+		printf '%q=%q\n' "$var" "${!var}"
 	done > /etc/docker.env
-	echo 'source /etc/docker.env' >> ~/.bashrc
 
 	printf '#!/bin/bash\n exec ' > /etc/resinApp.sh
 	printf '%q ' "$@" >> /etc/resinApp.sh
@@ -102,9 +99,8 @@ function init_non_systemd()
 	# trap the stop signal then send SIGTERM to user processes
 	trap signal_handler SIGRTMIN+3 SIGTERM
 
-	CMD=$(which "$1")
 	# echo error message, when executable file doesn't exist.
-	if [ $? == '0' ]; then
+	if CMD=$(command -v "$1" 2>/dev/null); then
 		shift
 		tini -sg -- "$CMD" "$@" &
 		pid=$!
@@ -142,7 +138,7 @@ if [ ! -z "$RESIN" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 		mount_dev
 	fi
 	start_udev
-fi 
+fi
 
 if [ "$INITSYSTEM" = "on" ]; then
 	init_systemd "$@"

--- a/resin-base-images/debian/amd64/stretch/entry.sh
+++ b/resin-base-images/debian/amd64/stretch/entry.sh
@@ -2,8 +2,7 @@
 
 set -m
 
-hostname "$HOSTNAME" &> /dev/null
-if [[ $? == 0 ]]; then
+if hostname "$HOSTNAME" &> /dev/null; then
 	PRIVILEGED=true
 else
 	PRIVILEGED=false
@@ -13,8 +12,7 @@ function start_udev()
 {
 	if [ "$UDEV" == "on" ]; then
 		if [ "$INITSYSTEM" != "on" ]; then
-			which udevd
-			if [ $? == '0' ]; then
+			if command -v udevd &>/dev/null; then
 				udevd --daemon &> /dev/null
 			else
 				/lib/systemd/systemd-udevd --daemon &> /dev/null
@@ -36,17 +34,17 @@ function remove_buildtime_env_var()
 # Send SIGTERM to child processes of PID 1.
 function signal_handler()
 {
-	kill $pid
+	kill "$pid"
 }
 
 # On ResinOS 2.x devices, the hostname is set by the hostOS.
 # For backward compatibility, we only update the hostname for ResinOS 1.x devices.
 function update_hostname()
 {
-	if [ ${RESIN_DEVICE_UUID:0:7} != ${HOSTNAME:0:7} ]; then
+	if [ "${RESIN_DEVICE_UUID:0:7}" != "${HOSTNAME:0:7}" ]; then
 		# For 1.x Devices only.
 		HOSTNAME="$RESIN_DEVICE_TYPE-${RESIN_DEVICE_UUID:0:7}"
-		echo $HOSTNAME > /etc/hostname
+		echo "$HOSTNAME" > /etc/hostname
 		echo "127.0.1.1 $HOSTNAME" >> /etc/hosts
 		hostname "$HOSTNAME"
 	fi
@@ -79,9 +77,8 @@ function init_systemd()
 	GREEN='\033[0;32m'
 	echo -e "${GREEN}Systemd init system enabled."
 	for var in $(compgen -e); do
-		printf '%q="%q"\n' "$var" "${!var}"
+		printf '%q=%q\n' "$var" "${!var}"
 	done > /etc/docker.env
-	echo 'source /etc/docker.env' >> ~/.bashrc
 
 	printf '#!/bin/bash\n exec ' > /etc/resinApp.sh
 	printf '%q ' "$@" >> /etc/resinApp.sh
@@ -102,9 +99,8 @@ function init_non_systemd()
 	# trap the stop signal then send SIGTERM to user processes
 	trap signal_handler SIGRTMIN+3 SIGTERM
 
-	CMD=$(which "$1")
 	# echo error message, when executable file doesn't exist.
-	if [ $? == '0' ]; then
+	if CMD=$(command -v "$1" 2>/dev/null); then
 		shift
 		tini -sg -- "$CMD" "$@" &
 		pid=$!
@@ -142,7 +138,7 @@ if [ ! -z "$RESIN" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 		mount_dev
 	fi
 	start_udev
-fi 
+fi
 
 if [ "$INITSYSTEM" = "on" ]; then
 	init_systemd "$@"

--- a/resin-base-images/debian/armv5e/buster/entry.sh
+++ b/resin-base-images/debian/armv5e/buster/entry.sh
@@ -2,8 +2,7 @@
 
 set -m
 
-hostname "$HOSTNAME" &> /dev/null
-if [[ $? == 0 ]]; then
+if hostname "$HOSTNAME" &> /dev/null; then
 	PRIVILEGED=true
 else
 	PRIVILEGED=false
@@ -13,8 +12,7 @@ function start_udev()
 {
 	if [ "$UDEV" == "on" ]; then
 		if [ "$INITSYSTEM" != "on" ]; then
-			which udevd
-			if [ $? == '0' ]; then
+			if command -v udevd &>/dev/null; then
 				udevd --daemon &> /dev/null
 			else
 				/lib/systemd/systemd-udevd --daemon &> /dev/null
@@ -36,17 +34,17 @@ function remove_buildtime_env_var()
 # Send SIGTERM to child processes of PID 1.
 function signal_handler()
 {
-	kill $pid
+	kill "$pid"
 }
 
 # On ResinOS 2.x devices, the hostname is set by the hostOS.
 # For backward compatibility, we only update the hostname for ResinOS 1.x devices.
 function update_hostname()
 {
-	if [ ${RESIN_DEVICE_UUID:0:7} != ${HOSTNAME:0:7} ]; then
+	if [ "${RESIN_DEVICE_UUID:0:7}" != "${HOSTNAME:0:7}" ]; then
 		# For 1.x Devices only.
 		HOSTNAME="$RESIN_DEVICE_TYPE-${RESIN_DEVICE_UUID:0:7}"
-		echo $HOSTNAME > /etc/hostname
+		echo "$HOSTNAME" > /etc/hostname
 		echo "127.0.1.1 $HOSTNAME" >> /etc/hosts
 		hostname "$HOSTNAME"
 	fi
@@ -79,9 +77,8 @@ function init_systemd()
 	GREEN='\033[0;32m'
 	echo -e "${GREEN}Systemd init system enabled."
 	for var in $(compgen -e); do
-		printf '%q="%q"\n' "$var" "${!var}"
+		printf '%q=%q\n' "$var" "${!var}"
 	done > /etc/docker.env
-	echo 'source /etc/docker.env' >> ~/.bashrc
 
 	printf '#!/bin/bash\n exec ' > /etc/resinApp.sh
 	printf '%q ' "$@" >> /etc/resinApp.sh
@@ -102,9 +99,8 @@ function init_non_systemd()
 	# trap the stop signal then send SIGTERM to user processes
 	trap signal_handler SIGRTMIN+3 SIGTERM
 
-	CMD=$(which "$1")
 	# echo error message, when executable file doesn't exist.
-	if [ $? == '0' ]; then
+	if CMD=$(command -v "$1" 2>/dev/null); then
 		shift
 		tini -sg -- "$CMD" "$@" &
 		pid=$!
@@ -142,7 +138,7 @@ if [ ! -z "$RESIN" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 		mount_dev
 	fi
 	start_udev
-fi 
+fi
 
 if [ "$INITSYSTEM" = "on" ]; then
 	init_systemd "$@"

--- a/resin-base-images/debian/armv5e/jessie/entry.sh
+++ b/resin-base-images/debian/armv5e/jessie/entry.sh
@@ -2,8 +2,7 @@
 
 set -m
 
-hostname "$HOSTNAME" &> /dev/null
-if [[ $? == 0 ]]; then
+if hostname "$HOSTNAME" &> /dev/null; then
 	PRIVILEGED=true
 else
 	PRIVILEGED=false
@@ -13,8 +12,7 @@ function start_udev()
 {
 	if [ "$UDEV" == "on" ]; then
 		if [ "$INITSYSTEM" != "on" ]; then
-			which udevd
-			if [ $? == '0' ]; then
+			if command -v udevd &>/dev/null; then
 				udevd --daemon &> /dev/null
 			else
 				/lib/systemd/systemd-udevd --daemon &> /dev/null
@@ -36,17 +34,17 @@ function remove_buildtime_env_var()
 # Send SIGTERM to child processes of PID 1.
 function signal_handler()
 {
-	kill $pid
+	kill "$pid"
 }
 
 # On ResinOS 2.x devices, the hostname is set by the hostOS.
 # For backward compatibility, we only update the hostname for ResinOS 1.x devices.
 function update_hostname()
 {
-	if [ ${RESIN_DEVICE_UUID:0:7} != ${HOSTNAME:0:7} ]; then
+	if [ "${RESIN_DEVICE_UUID:0:7}" != "${HOSTNAME:0:7}" ]; then
 		# For 1.x Devices only.
 		HOSTNAME="$RESIN_DEVICE_TYPE-${RESIN_DEVICE_UUID:0:7}"
-		echo $HOSTNAME > /etc/hostname
+		echo "$HOSTNAME" > /etc/hostname
 		echo "127.0.1.1 $HOSTNAME" >> /etc/hosts
 		hostname "$HOSTNAME"
 	fi
@@ -79,9 +77,8 @@ function init_systemd()
 	GREEN='\033[0;32m'
 	echo -e "${GREEN}Systemd init system enabled."
 	for var in $(compgen -e); do
-		printf '%q="%q"\n' "$var" "${!var}"
+		printf '%q=%q\n' "$var" "${!var}"
 	done > /etc/docker.env
-	echo 'source /etc/docker.env' >> ~/.bashrc
 
 	printf '#!/bin/bash\n exec ' > /etc/resinApp.sh
 	printf '%q ' "$@" >> /etc/resinApp.sh
@@ -102,9 +99,8 @@ function init_non_systemd()
 	# trap the stop signal then send SIGTERM to user processes
 	trap signal_handler SIGRTMIN+3 SIGTERM
 
-	CMD=$(which "$1")
 	# echo error message, when executable file doesn't exist.
-	if [ $? == '0' ]; then
+	if CMD=$(command -v "$1" 2>/dev/null); then
 		shift
 		tini -sg -- "$CMD" "$@" &
 		pid=$!
@@ -142,7 +138,7 @@ if [ ! -z "$RESIN" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 		mount_dev
 	fi
 	start_udev
-fi 
+fi
 
 if [ "$INITSYSTEM" = "on" ]; then
 	init_systemd "$@"

--- a/resin-base-images/debian/armv5e/sid/entry.sh
+++ b/resin-base-images/debian/armv5e/sid/entry.sh
@@ -2,8 +2,7 @@
 
 set -m
 
-hostname "$HOSTNAME" &> /dev/null
-if [[ $? == 0 ]]; then
+if hostname "$HOSTNAME" &> /dev/null; then
 	PRIVILEGED=true
 else
 	PRIVILEGED=false
@@ -13,8 +12,7 @@ function start_udev()
 {
 	if [ "$UDEV" == "on" ]; then
 		if [ "$INITSYSTEM" != "on" ]; then
-			which udevd
-			if [ $? == '0' ]; then
+			if command -v udevd &>/dev/null; then
 				udevd --daemon &> /dev/null
 			else
 				/lib/systemd/systemd-udevd --daemon &> /dev/null
@@ -36,17 +34,17 @@ function remove_buildtime_env_var()
 # Send SIGTERM to child processes of PID 1.
 function signal_handler()
 {
-	kill $pid
+	kill "$pid"
 }
 
 # On ResinOS 2.x devices, the hostname is set by the hostOS.
 # For backward compatibility, we only update the hostname for ResinOS 1.x devices.
 function update_hostname()
 {
-	if [ ${RESIN_DEVICE_UUID:0:7} != ${HOSTNAME:0:7} ]; then
+	if [ "${RESIN_DEVICE_UUID:0:7}" != "${HOSTNAME:0:7}" ]; then
 		# For 1.x Devices only.
 		HOSTNAME="$RESIN_DEVICE_TYPE-${RESIN_DEVICE_UUID:0:7}"
-		echo $HOSTNAME > /etc/hostname
+		echo "$HOSTNAME" > /etc/hostname
 		echo "127.0.1.1 $HOSTNAME" >> /etc/hosts
 		hostname "$HOSTNAME"
 	fi
@@ -79,9 +77,8 @@ function init_systemd()
 	GREEN='\033[0;32m'
 	echo -e "${GREEN}Systemd init system enabled."
 	for var in $(compgen -e); do
-		printf '%q="%q"\n' "$var" "${!var}"
+		printf '%q=%q\n' "$var" "${!var}"
 	done > /etc/docker.env
-	echo 'source /etc/docker.env' >> ~/.bashrc
 
 	printf '#!/bin/bash\n exec ' > /etc/resinApp.sh
 	printf '%q ' "$@" >> /etc/resinApp.sh
@@ -102,9 +99,8 @@ function init_non_systemd()
 	# trap the stop signal then send SIGTERM to user processes
 	trap signal_handler SIGRTMIN+3 SIGTERM
 
-	CMD=$(which "$1")
 	# echo error message, when executable file doesn't exist.
-	if [ $? == '0' ]; then
+	if CMD=$(command -v "$1" 2>/dev/null); then
 		shift
 		tini -sg -- "$CMD" "$@" &
 		pid=$!
@@ -142,7 +138,7 @@ if [ ! -z "$RESIN" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 		mount_dev
 	fi
 	start_udev
-fi 
+fi
 
 if [ "$INITSYSTEM" = "on" ]; then
 	init_systemd "$@"

--- a/resin-base-images/debian/armv5e/stretch/entry.sh
+++ b/resin-base-images/debian/armv5e/stretch/entry.sh
@@ -2,8 +2,7 @@
 
 set -m
 
-hostname "$HOSTNAME" &> /dev/null
-if [[ $? == 0 ]]; then
+if hostname "$HOSTNAME" &> /dev/null; then
 	PRIVILEGED=true
 else
 	PRIVILEGED=false
@@ -13,8 +12,7 @@ function start_udev()
 {
 	if [ "$UDEV" == "on" ]; then
 		if [ "$INITSYSTEM" != "on" ]; then
-			which udevd
-			if [ $? == '0' ]; then
+			if command -v udevd &>/dev/null; then
 				udevd --daemon &> /dev/null
 			else
 				/lib/systemd/systemd-udevd --daemon &> /dev/null
@@ -36,17 +34,17 @@ function remove_buildtime_env_var()
 # Send SIGTERM to child processes of PID 1.
 function signal_handler()
 {
-	kill $pid
+	kill "$pid"
 }
 
 # On ResinOS 2.x devices, the hostname is set by the hostOS.
 # For backward compatibility, we only update the hostname for ResinOS 1.x devices.
 function update_hostname()
 {
-	if [ ${RESIN_DEVICE_UUID:0:7} != ${HOSTNAME:0:7} ]; then
+	if [ "${RESIN_DEVICE_UUID:0:7}" != "${HOSTNAME:0:7}" ]; then
 		# For 1.x Devices only.
 		HOSTNAME="$RESIN_DEVICE_TYPE-${RESIN_DEVICE_UUID:0:7}"
-		echo $HOSTNAME > /etc/hostname
+		echo "$HOSTNAME" > /etc/hostname
 		echo "127.0.1.1 $HOSTNAME" >> /etc/hosts
 		hostname "$HOSTNAME"
 	fi
@@ -79,9 +77,8 @@ function init_systemd()
 	GREEN='\033[0;32m'
 	echo -e "${GREEN}Systemd init system enabled."
 	for var in $(compgen -e); do
-		printf '%q="%q"\n' "$var" "${!var}"
+		printf '%q=%q\n' "$var" "${!var}"
 	done > /etc/docker.env
-	echo 'source /etc/docker.env' >> ~/.bashrc
 
 	printf '#!/bin/bash\n exec ' > /etc/resinApp.sh
 	printf '%q ' "$@" >> /etc/resinApp.sh
@@ -102,9 +99,8 @@ function init_non_systemd()
 	# trap the stop signal then send SIGTERM to user processes
 	trap signal_handler SIGRTMIN+3 SIGTERM
 
-	CMD=$(which "$1")
 	# echo error message, when executable file doesn't exist.
-	if [ $? == '0' ]; then
+	if CMD=$(command -v "$1" 2>/dev/null); then
 		shift
 		tini -sg -- "$CMD" "$@" &
 		pid=$!
@@ -142,7 +138,7 @@ if [ ! -z "$RESIN" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 		mount_dev
 	fi
 	start_udev
-fi 
+fi
 
 if [ "$INITSYSTEM" = "on" ]; then
 	init_systemd "$@"

--- a/resin-base-images/debian/armv7hf/buster/entry.sh
+++ b/resin-base-images/debian/armv7hf/buster/entry.sh
@@ -2,8 +2,7 @@
 
 set -m
 
-hostname "$HOSTNAME" &> /dev/null
-if [[ $? == 0 ]]; then
+if hostname "$HOSTNAME" &> /dev/null; then
 	PRIVILEGED=true
 else
 	PRIVILEGED=false
@@ -13,8 +12,7 @@ function start_udev()
 {
 	if [ "$UDEV" == "on" ]; then
 		if [ "$INITSYSTEM" != "on" ]; then
-			which udevd
-			if [ $? == '0' ]; then
+			if command -v udevd &>/dev/null; then
 				udevd --daemon &> /dev/null
 			else
 				/lib/systemd/systemd-udevd --daemon &> /dev/null
@@ -36,17 +34,17 @@ function remove_buildtime_env_var()
 # Send SIGTERM to child processes of PID 1.
 function signal_handler()
 {
-	kill $pid
+	kill "$pid"
 }
 
 # On ResinOS 2.x devices, the hostname is set by the hostOS.
 # For backward compatibility, we only update the hostname for ResinOS 1.x devices.
 function update_hostname()
 {
-	if [ ${RESIN_DEVICE_UUID:0:7} != ${HOSTNAME:0:7} ]; then
+	if [ "${RESIN_DEVICE_UUID:0:7}" != "${HOSTNAME:0:7}" ]; then
 		# For 1.x Devices only.
 		HOSTNAME="$RESIN_DEVICE_TYPE-${RESIN_DEVICE_UUID:0:7}"
-		echo $HOSTNAME > /etc/hostname
+		echo "$HOSTNAME" > /etc/hostname
 		echo "127.0.1.1 $HOSTNAME" >> /etc/hosts
 		hostname "$HOSTNAME"
 	fi
@@ -79,9 +77,8 @@ function init_systemd()
 	GREEN='\033[0;32m'
 	echo -e "${GREEN}Systemd init system enabled."
 	for var in $(compgen -e); do
-		printf '%q="%q"\n' "$var" "${!var}"
+		printf '%q=%q\n' "$var" "${!var}"
 	done > /etc/docker.env
-	echo 'source /etc/docker.env' >> ~/.bashrc
 
 	printf '#!/bin/bash\n exec ' > /etc/resinApp.sh
 	printf '%q ' "$@" >> /etc/resinApp.sh
@@ -102,9 +99,8 @@ function init_non_systemd()
 	# trap the stop signal then send SIGTERM to user processes
 	trap signal_handler SIGRTMIN+3 SIGTERM
 
-	CMD=$(which "$1")
 	# echo error message, when executable file doesn't exist.
-	if [ $? == '0' ]; then
+	if CMD=$(command -v "$1" 2>/dev/null); then
 		shift
 		tini -sg -- "$CMD" "$@" &
 		pid=$!
@@ -142,7 +138,7 @@ if [ ! -z "$RESIN" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 		mount_dev
 	fi
 	start_udev
-fi 
+fi
 
 if [ "$INITSYSTEM" = "on" ]; then
 	init_systemd "$@"

--- a/resin-base-images/debian/armv7hf/jessie/entry.sh
+++ b/resin-base-images/debian/armv7hf/jessie/entry.sh
@@ -2,8 +2,7 @@
 
 set -m
 
-hostname "$HOSTNAME" &> /dev/null
-if [[ $? == 0 ]]; then
+if hostname "$HOSTNAME" &> /dev/null; then
 	PRIVILEGED=true
 else
 	PRIVILEGED=false
@@ -13,8 +12,7 @@ function start_udev()
 {
 	if [ "$UDEV" == "on" ]; then
 		if [ "$INITSYSTEM" != "on" ]; then
-			which udevd
-			if [ $? == '0' ]; then
+			if command -v udevd &>/dev/null; then
 				udevd --daemon &> /dev/null
 			else
 				/lib/systemd/systemd-udevd --daemon &> /dev/null
@@ -36,17 +34,17 @@ function remove_buildtime_env_var()
 # Send SIGTERM to child processes of PID 1.
 function signal_handler()
 {
-	kill $pid
+	kill "$pid"
 }
 
 # On ResinOS 2.x devices, the hostname is set by the hostOS.
 # For backward compatibility, we only update the hostname for ResinOS 1.x devices.
 function update_hostname()
 {
-	if [ ${RESIN_DEVICE_UUID:0:7} != ${HOSTNAME:0:7} ]; then
+	if [ "${RESIN_DEVICE_UUID:0:7}" != "${HOSTNAME:0:7}" ]; then
 		# For 1.x Devices only.
 		HOSTNAME="$RESIN_DEVICE_TYPE-${RESIN_DEVICE_UUID:0:7}"
-		echo $HOSTNAME > /etc/hostname
+		echo "$HOSTNAME" > /etc/hostname
 		echo "127.0.1.1 $HOSTNAME" >> /etc/hosts
 		hostname "$HOSTNAME"
 	fi
@@ -79,9 +77,8 @@ function init_systemd()
 	GREEN='\033[0;32m'
 	echo -e "${GREEN}Systemd init system enabled."
 	for var in $(compgen -e); do
-		printf '%q="%q"\n' "$var" "${!var}"
+		printf '%q=%q\n' "$var" "${!var}"
 	done > /etc/docker.env
-	echo 'source /etc/docker.env' >> ~/.bashrc
 
 	printf '#!/bin/bash\n exec ' > /etc/resinApp.sh
 	printf '%q ' "$@" >> /etc/resinApp.sh
@@ -102,9 +99,8 @@ function init_non_systemd()
 	# trap the stop signal then send SIGTERM to user processes
 	trap signal_handler SIGRTMIN+3 SIGTERM
 
-	CMD=$(which "$1")
 	# echo error message, when executable file doesn't exist.
-	if [ $? == '0' ]; then
+	if CMD=$(command -v "$1" 2>/dev/null); then
 		shift
 		tini -sg -- "$CMD" "$@" &
 		pid=$!
@@ -142,7 +138,7 @@ if [ ! -z "$RESIN" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 		mount_dev
 	fi
 	start_udev
-fi 
+fi
 
 if [ "$INITSYSTEM" = "on" ]; then
 	init_systemd "$@"

--- a/resin-base-images/debian/armv7hf/sid/entry.sh
+++ b/resin-base-images/debian/armv7hf/sid/entry.sh
@@ -2,8 +2,7 @@
 
 set -m
 
-hostname "$HOSTNAME" &> /dev/null
-if [[ $? == 0 ]]; then
+if hostname "$HOSTNAME" &> /dev/null; then
 	PRIVILEGED=true
 else
 	PRIVILEGED=false
@@ -13,8 +12,7 @@ function start_udev()
 {
 	if [ "$UDEV" == "on" ]; then
 		if [ "$INITSYSTEM" != "on" ]; then
-			which udevd
-			if [ $? == '0' ]; then
+			if command -v udevd &>/dev/null; then
 				udevd --daemon &> /dev/null
 			else
 				/lib/systemd/systemd-udevd --daemon &> /dev/null
@@ -36,17 +34,17 @@ function remove_buildtime_env_var()
 # Send SIGTERM to child processes of PID 1.
 function signal_handler()
 {
-	kill $pid
+	kill "$pid"
 }
 
 # On ResinOS 2.x devices, the hostname is set by the hostOS.
 # For backward compatibility, we only update the hostname for ResinOS 1.x devices.
 function update_hostname()
 {
-	if [ ${RESIN_DEVICE_UUID:0:7} != ${HOSTNAME:0:7} ]; then
+	if [ "${RESIN_DEVICE_UUID:0:7}" != "${HOSTNAME:0:7}" ]; then
 		# For 1.x Devices only.
 		HOSTNAME="$RESIN_DEVICE_TYPE-${RESIN_DEVICE_UUID:0:7}"
-		echo $HOSTNAME > /etc/hostname
+		echo "$HOSTNAME" > /etc/hostname
 		echo "127.0.1.1 $HOSTNAME" >> /etc/hosts
 		hostname "$HOSTNAME"
 	fi
@@ -79,9 +77,8 @@ function init_systemd()
 	GREEN='\033[0;32m'
 	echo -e "${GREEN}Systemd init system enabled."
 	for var in $(compgen -e); do
-		printf '%q="%q"\n' "$var" "${!var}"
+		printf '%q=%q\n' "$var" "${!var}"
 	done > /etc/docker.env
-	echo 'source /etc/docker.env' >> ~/.bashrc
 
 	printf '#!/bin/bash\n exec ' > /etc/resinApp.sh
 	printf '%q ' "$@" >> /etc/resinApp.sh
@@ -102,9 +99,8 @@ function init_non_systemd()
 	# trap the stop signal then send SIGTERM to user processes
 	trap signal_handler SIGRTMIN+3 SIGTERM
 
-	CMD=$(which "$1")
 	# echo error message, when executable file doesn't exist.
-	if [ $? == '0' ]; then
+	if CMD=$(command -v "$1" 2>/dev/null); then
 		shift
 		tini -sg -- "$CMD" "$@" &
 		pid=$!
@@ -142,7 +138,7 @@ if [ ! -z "$RESIN" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 		mount_dev
 	fi
 	start_udev
-fi 
+fi
 
 if [ "$INITSYSTEM" = "on" ]; then
 	init_systemd "$@"

--- a/resin-base-images/debian/armv7hf/stretch/entry.sh
+++ b/resin-base-images/debian/armv7hf/stretch/entry.sh
@@ -2,8 +2,7 @@
 
 set -m
 
-hostname "$HOSTNAME" &> /dev/null
-if [[ $? == 0 ]]; then
+if hostname "$HOSTNAME" &> /dev/null; then
 	PRIVILEGED=true
 else
 	PRIVILEGED=false
@@ -13,8 +12,7 @@ function start_udev()
 {
 	if [ "$UDEV" == "on" ]; then
 		if [ "$INITSYSTEM" != "on" ]; then
-			which udevd
-			if [ $? == '0' ]; then
+			if command -v udevd &>/dev/null; then
 				udevd --daemon &> /dev/null
 			else
 				/lib/systemd/systemd-udevd --daemon &> /dev/null
@@ -36,17 +34,17 @@ function remove_buildtime_env_var()
 # Send SIGTERM to child processes of PID 1.
 function signal_handler()
 {
-	kill $pid
+	kill "$pid"
 }
 
 # On ResinOS 2.x devices, the hostname is set by the hostOS.
 # For backward compatibility, we only update the hostname for ResinOS 1.x devices.
 function update_hostname()
 {
-	if [ ${RESIN_DEVICE_UUID:0:7} != ${HOSTNAME:0:7} ]; then
+	if [ "${RESIN_DEVICE_UUID:0:7}" != "${HOSTNAME:0:7}" ]; then
 		# For 1.x Devices only.
 		HOSTNAME="$RESIN_DEVICE_TYPE-${RESIN_DEVICE_UUID:0:7}"
-		echo $HOSTNAME > /etc/hostname
+		echo "$HOSTNAME" > /etc/hostname
 		echo "127.0.1.1 $HOSTNAME" >> /etc/hosts
 		hostname "$HOSTNAME"
 	fi
@@ -79,9 +77,8 @@ function init_systemd()
 	GREEN='\033[0;32m'
 	echo -e "${GREEN}Systemd init system enabled."
 	for var in $(compgen -e); do
-		printf '%q="%q"\n' "$var" "${!var}"
+		printf '%q=%q\n' "$var" "${!var}"
 	done > /etc/docker.env
-	echo 'source /etc/docker.env' >> ~/.bashrc
 
 	printf '#!/bin/bash\n exec ' > /etc/resinApp.sh
 	printf '%q ' "$@" >> /etc/resinApp.sh
@@ -102,9 +99,8 @@ function init_non_systemd()
 	# trap the stop signal then send SIGTERM to user processes
 	trap signal_handler SIGRTMIN+3 SIGTERM
 
-	CMD=$(which "$1")
 	# echo error message, when executable file doesn't exist.
-	if [ $? == '0' ]; then
+	if CMD=$(command -v "$1" 2>/dev/null); then
 		shift
 		tini -sg -- "$CMD" "$@" &
 		pid=$!
@@ -142,7 +138,7 @@ if [ ! -z "$RESIN" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 		mount_dev
 	fi
 	start_udev
-fi 
+fi
 
 if [ "$INITSYSTEM" = "on" ]; then
 	init_systemd "$@"

--- a/resin-base-images/debian/i386-nlp/buster/entry.sh
+++ b/resin-base-images/debian/i386-nlp/buster/entry.sh
@@ -2,8 +2,7 @@
 
 set -m
 
-hostname "$HOSTNAME" &> /dev/null
-if [[ $? == 0 ]]; then
+if hostname "$HOSTNAME" &> /dev/null; then
 	PRIVILEGED=true
 else
 	PRIVILEGED=false
@@ -13,8 +12,7 @@ function start_udev()
 {
 	if [ "$UDEV" == "on" ]; then
 		if [ "$INITSYSTEM" != "on" ]; then
-			which udevd
-			if [ $? == '0' ]; then
+			if command -v udevd &>/dev/null; then
 				udevd --daemon &> /dev/null
 			else
 				/lib/systemd/systemd-udevd --daemon &> /dev/null
@@ -36,17 +34,17 @@ function remove_buildtime_env_var()
 # Send SIGTERM to child processes of PID 1.
 function signal_handler()
 {
-	kill $pid
+	kill "$pid"
 }
 
 # On ResinOS 2.x devices, the hostname is set by the hostOS.
 # For backward compatibility, we only update the hostname for ResinOS 1.x devices.
 function update_hostname()
 {
-	if [ ${RESIN_DEVICE_UUID:0:7} != ${HOSTNAME:0:7} ]; then
+	if [ "${RESIN_DEVICE_UUID:0:7}" != "${HOSTNAME:0:7}" ]; then
 		# For 1.x Devices only.
 		HOSTNAME="$RESIN_DEVICE_TYPE-${RESIN_DEVICE_UUID:0:7}"
-		echo $HOSTNAME > /etc/hostname
+		echo "$HOSTNAME" > /etc/hostname
 		echo "127.0.1.1 $HOSTNAME" >> /etc/hosts
 		hostname "$HOSTNAME"
 	fi
@@ -79,9 +77,8 @@ function init_systemd()
 	GREEN='\033[0;32m'
 	echo -e "${GREEN}Systemd init system enabled."
 	for var in $(compgen -e); do
-		printf '%q="%q"\n' "$var" "${!var}"
+		printf '%q=%q\n' "$var" "${!var}"
 	done > /etc/docker.env
-	echo 'source /etc/docker.env' >> ~/.bashrc
 
 	printf '#!/bin/bash\n exec ' > /etc/resinApp.sh
 	printf '%q ' "$@" >> /etc/resinApp.sh
@@ -102,9 +99,8 @@ function init_non_systemd()
 	# trap the stop signal then send SIGTERM to user processes
 	trap signal_handler SIGRTMIN+3 SIGTERM
 
-	CMD=$(which "$1")
 	# echo error message, when executable file doesn't exist.
-	if [ $? == '0' ]; then
+	if CMD=$(command -v "$1" 2>/dev/null); then
 		shift
 		tini -sg -- "$CMD" "$@" &
 		pid=$!
@@ -142,7 +138,7 @@ if [ ! -z "$RESIN" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 		mount_dev
 	fi
 	start_udev
-fi 
+fi
 
 if [ "$INITSYSTEM" = "on" ]; then
 	init_systemd "$@"

--- a/resin-base-images/debian/i386-nlp/jessie/entry.sh
+++ b/resin-base-images/debian/i386-nlp/jessie/entry.sh
@@ -2,8 +2,7 @@
 
 set -m
 
-hostname "$HOSTNAME" &> /dev/null
-if [[ $? == 0 ]]; then
+if hostname "$HOSTNAME" &> /dev/null; then
 	PRIVILEGED=true
 else
 	PRIVILEGED=false
@@ -13,8 +12,7 @@ function start_udev()
 {
 	if [ "$UDEV" == "on" ]; then
 		if [ "$INITSYSTEM" != "on" ]; then
-			which udevd
-			if [ $? == '0' ]; then
+			if command -v udevd &>/dev/null; then
 				udevd --daemon &> /dev/null
 			else
 				/lib/systemd/systemd-udevd --daemon &> /dev/null
@@ -36,17 +34,17 @@ function remove_buildtime_env_var()
 # Send SIGTERM to child processes of PID 1.
 function signal_handler()
 {
-	kill $pid
+	kill "$pid"
 }
 
 # On ResinOS 2.x devices, the hostname is set by the hostOS.
 # For backward compatibility, we only update the hostname for ResinOS 1.x devices.
 function update_hostname()
 {
-	if [ ${RESIN_DEVICE_UUID:0:7} != ${HOSTNAME:0:7} ]; then
+	if [ "${RESIN_DEVICE_UUID:0:7}" != "${HOSTNAME:0:7}" ]; then
 		# For 1.x Devices only.
 		HOSTNAME="$RESIN_DEVICE_TYPE-${RESIN_DEVICE_UUID:0:7}"
-		echo $HOSTNAME > /etc/hostname
+		echo "$HOSTNAME" > /etc/hostname
 		echo "127.0.1.1 $HOSTNAME" >> /etc/hosts
 		hostname "$HOSTNAME"
 	fi
@@ -79,9 +77,8 @@ function init_systemd()
 	GREEN='\033[0;32m'
 	echo -e "${GREEN}Systemd init system enabled."
 	for var in $(compgen -e); do
-		printf '%q="%q"\n' "$var" "${!var}"
+		printf '%q=%q\n' "$var" "${!var}"
 	done > /etc/docker.env
-	echo 'source /etc/docker.env' >> ~/.bashrc
 
 	printf '#!/bin/bash\n exec ' > /etc/resinApp.sh
 	printf '%q ' "$@" >> /etc/resinApp.sh
@@ -102,9 +99,8 @@ function init_non_systemd()
 	# trap the stop signal then send SIGTERM to user processes
 	trap signal_handler SIGRTMIN+3 SIGTERM
 
-	CMD=$(which "$1")
 	# echo error message, when executable file doesn't exist.
-	if [ $? == '0' ]; then
+	if CMD=$(command -v "$1" 2>/dev/null); then
 		shift
 		tini -sg -- "$CMD" "$@" &
 		pid=$!
@@ -142,7 +138,7 @@ if [ ! -z "$RESIN" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 		mount_dev
 	fi
 	start_udev
-fi 
+fi
 
 if [ "$INITSYSTEM" = "on" ]; then
 	init_systemd "$@"

--- a/resin-base-images/debian/i386-nlp/sid/entry.sh
+++ b/resin-base-images/debian/i386-nlp/sid/entry.sh
@@ -2,8 +2,7 @@
 
 set -m
 
-hostname "$HOSTNAME" &> /dev/null
-if [[ $? == 0 ]]; then
+if hostname "$HOSTNAME" &> /dev/null; then
 	PRIVILEGED=true
 else
 	PRIVILEGED=false
@@ -13,8 +12,7 @@ function start_udev()
 {
 	if [ "$UDEV" == "on" ]; then
 		if [ "$INITSYSTEM" != "on" ]; then
-			which udevd
-			if [ $? == '0' ]; then
+			if command -v udevd &>/dev/null; then
 				udevd --daemon &> /dev/null
 			else
 				/lib/systemd/systemd-udevd --daemon &> /dev/null
@@ -36,17 +34,17 @@ function remove_buildtime_env_var()
 # Send SIGTERM to child processes of PID 1.
 function signal_handler()
 {
-	kill $pid
+	kill "$pid"
 }
 
 # On ResinOS 2.x devices, the hostname is set by the hostOS.
 # For backward compatibility, we only update the hostname for ResinOS 1.x devices.
 function update_hostname()
 {
-	if [ ${RESIN_DEVICE_UUID:0:7} != ${HOSTNAME:0:7} ]; then
+	if [ "${RESIN_DEVICE_UUID:0:7}" != "${HOSTNAME:0:7}" ]; then
 		# For 1.x Devices only.
 		HOSTNAME="$RESIN_DEVICE_TYPE-${RESIN_DEVICE_UUID:0:7}"
-		echo $HOSTNAME > /etc/hostname
+		echo "$HOSTNAME" > /etc/hostname
 		echo "127.0.1.1 $HOSTNAME" >> /etc/hosts
 		hostname "$HOSTNAME"
 	fi
@@ -79,9 +77,8 @@ function init_systemd()
 	GREEN='\033[0;32m'
 	echo -e "${GREEN}Systemd init system enabled."
 	for var in $(compgen -e); do
-		printf '%q="%q"\n' "$var" "${!var}"
+		printf '%q=%q\n' "$var" "${!var}"
 	done > /etc/docker.env
-	echo 'source /etc/docker.env' >> ~/.bashrc
 
 	printf '#!/bin/bash\n exec ' > /etc/resinApp.sh
 	printf '%q ' "$@" >> /etc/resinApp.sh
@@ -102,9 +99,8 @@ function init_non_systemd()
 	# trap the stop signal then send SIGTERM to user processes
 	trap signal_handler SIGRTMIN+3 SIGTERM
 
-	CMD=$(which "$1")
 	# echo error message, when executable file doesn't exist.
-	if [ $? == '0' ]; then
+	if CMD=$(command -v "$1" 2>/dev/null); then
 		shift
 		tini -sg -- "$CMD" "$@" &
 		pid=$!
@@ -142,7 +138,7 @@ if [ ! -z "$RESIN" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 		mount_dev
 	fi
 	start_udev
-fi 
+fi
 
 if [ "$INITSYSTEM" = "on" ]; then
 	init_systemd "$@"

--- a/resin-base-images/debian/i386-nlp/stretch/entry.sh
+++ b/resin-base-images/debian/i386-nlp/stretch/entry.sh
@@ -2,8 +2,7 @@
 
 set -m
 
-hostname "$HOSTNAME" &> /dev/null
-if [[ $? == 0 ]]; then
+if hostname "$HOSTNAME" &> /dev/null; then
 	PRIVILEGED=true
 else
 	PRIVILEGED=false
@@ -13,8 +12,7 @@ function start_udev()
 {
 	if [ "$UDEV" == "on" ]; then
 		if [ "$INITSYSTEM" != "on" ]; then
-			which udevd
-			if [ $? == '0' ]; then
+			if command -v udevd &>/dev/null; then
 				udevd --daemon &> /dev/null
 			else
 				/lib/systemd/systemd-udevd --daemon &> /dev/null
@@ -36,17 +34,17 @@ function remove_buildtime_env_var()
 # Send SIGTERM to child processes of PID 1.
 function signal_handler()
 {
-	kill $pid
+	kill "$pid"
 }
 
 # On ResinOS 2.x devices, the hostname is set by the hostOS.
 # For backward compatibility, we only update the hostname for ResinOS 1.x devices.
 function update_hostname()
 {
-	if [ ${RESIN_DEVICE_UUID:0:7} != ${HOSTNAME:0:7} ]; then
+	if [ "${RESIN_DEVICE_UUID:0:7}" != "${HOSTNAME:0:7}" ]; then
 		# For 1.x Devices only.
 		HOSTNAME="$RESIN_DEVICE_TYPE-${RESIN_DEVICE_UUID:0:7}"
-		echo $HOSTNAME > /etc/hostname
+		echo "$HOSTNAME" > /etc/hostname
 		echo "127.0.1.1 $HOSTNAME" >> /etc/hosts
 		hostname "$HOSTNAME"
 	fi
@@ -79,9 +77,8 @@ function init_systemd()
 	GREEN='\033[0;32m'
 	echo -e "${GREEN}Systemd init system enabled."
 	for var in $(compgen -e); do
-		printf '%q="%q"\n' "$var" "${!var}"
+		printf '%q=%q\n' "$var" "${!var}"
 	done > /etc/docker.env
-	echo 'source /etc/docker.env' >> ~/.bashrc
 
 	printf '#!/bin/bash\n exec ' > /etc/resinApp.sh
 	printf '%q ' "$@" >> /etc/resinApp.sh
@@ -102,9 +99,8 @@ function init_non_systemd()
 	# trap the stop signal then send SIGTERM to user processes
 	trap signal_handler SIGRTMIN+3 SIGTERM
 
-	CMD=$(which "$1")
 	# echo error message, when executable file doesn't exist.
-	if [ $? == '0' ]; then
+	if CMD=$(command -v "$1" 2>/dev/null); then
 		shift
 		tini -sg -- "$CMD" "$@" &
 		pid=$!
@@ -142,7 +138,7 @@ if [ ! -z "$RESIN" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 		mount_dev
 	fi
 	start_udev
-fi 
+fi
 
 if [ "$INITSYSTEM" = "on" ]; then
 	init_systemd "$@"

--- a/resin-base-images/debian/i386/buster/entry.sh
+++ b/resin-base-images/debian/i386/buster/entry.sh
@@ -2,8 +2,7 @@
 
 set -m
 
-hostname "$HOSTNAME" &> /dev/null
-if [[ $? == 0 ]]; then
+if hostname "$HOSTNAME" &> /dev/null; then
 	PRIVILEGED=true
 else
 	PRIVILEGED=false
@@ -13,8 +12,7 @@ function start_udev()
 {
 	if [ "$UDEV" == "on" ]; then
 		if [ "$INITSYSTEM" != "on" ]; then
-			which udevd
-			if [ $? == '0' ]; then
+			if command -v udevd &>/dev/null; then
 				udevd --daemon &> /dev/null
 			else
 				/lib/systemd/systemd-udevd --daemon &> /dev/null
@@ -36,17 +34,17 @@ function remove_buildtime_env_var()
 # Send SIGTERM to child processes of PID 1.
 function signal_handler()
 {
-	kill $pid
+	kill "$pid"
 }
 
 # On ResinOS 2.x devices, the hostname is set by the hostOS.
 # For backward compatibility, we only update the hostname for ResinOS 1.x devices.
 function update_hostname()
 {
-	if [ ${RESIN_DEVICE_UUID:0:7} != ${HOSTNAME:0:7} ]; then
+	if [ "${RESIN_DEVICE_UUID:0:7}" != "${HOSTNAME:0:7}" ]; then
 		# For 1.x Devices only.
 		HOSTNAME="$RESIN_DEVICE_TYPE-${RESIN_DEVICE_UUID:0:7}"
-		echo $HOSTNAME > /etc/hostname
+		echo "$HOSTNAME" > /etc/hostname
 		echo "127.0.1.1 $HOSTNAME" >> /etc/hosts
 		hostname "$HOSTNAME"
 	fi
@@ -79,9 +77,8 @@ function init_systemd()
 	GREEN='\033[0;32m'
 	echo -e "${GREEN}Systemd init system enabled."
 	for var in $(compgen -e); do
-		printf '%q="%q"\n' "$var" "${!var}"
+		printf '%q=%q\n' "$var" "${!var}"
 	done > /etc/docker.env
-	echo 'source /etc/docker.env' >> ~/.bashrc
 
 	printf '#!/bin/bash\n exec ' > /etc/resinApp.sh
 	printf '%q ' "$@" >> /etc/resinApp.sh
@@ -102,9 +99,8 @@ function init_non_systemd()
 	# trap the stop signal then send SIGTERM to user processes
 	trap signal_handler SIGRTMIN+3 SIGTERM
 
-	CMD=$(which "$1")
 	# echo error message, when executable file doesn't exist.
-	if [ $? == '0' ]; then
+	if CMD=$(command -v "$1" 2>/dev/null); then
 		shift
 		tini -sg -- "$CMD" "$@" &
 		pid=$!
@@ -142,7 +138,7 @@ if [ ! -z "$RESIN" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 		mount_dev
 	fi
 	start_udev
-fi 
+fi
 
 if [ "$INITSYSTEM" = "on" ]; then
 	init_systemd "$@"

--- a/resin-base-images/debian/i386/jessie/entry.sh
+++ b/resin-base-images/debian/i386/jessie/entry.sh
@@ -2,8 +2,7 @@
 
 set -m
 
-hostname "$HOSTNAME" &> /dev/null
-if [[ $? == 0 ]]; then
+if hostname "$HOSTNAME" &> /dev/null; then
 	PRIVILEGED=true
 else
 	PRIVILEGED=false
@@ -13,8 +12,7 @@ function start_udev()
 {
 	if [ "$UDEV" == "on" ]; then
 		if [ "$INITSYSTEM" != "on" ]; then
-			which udevd
-			if [ $? == '0' ]; then
+			if command -v udevd &>/dev/null; then
 				udevd --daemon &> /dev/null
 			else
 				/lib/systemd/systemd-udevd --daemon &> /dev/null
@@ -36,17 +34,17 @@ function remove_buildtime_env_var()
 # Send SIGTERM to child processes of PID 1.
 function signal_handler()
 {
-	kill $pid
+	kill "$pid"
 }
 
 # On ResinOS 2.x devices, the hostname is set by the hostOS.
 # For backward compatibility, we only update the hostname for ResinOS 1.x devices.
 function update_hostname()
 {
-	if [ ${RESIN_DEVICE_UUID:0:7} != ${HOSTNAME:0:7} ]; then
+	if [ "${RESIN_DEVICE_UUID:0:7}" != "${HOSTNAME:0:7}" ]; then
 		# For 1.x Devices only.
 		HOSTNAME="$RESIN_DEVICE_TYPE-${RESIN_DEVICE_UUID:0:7}"
-		echo $HOSTNAME > /etc/hostname
+		echo "$HOSTNAME" > /etc/hostname
 		echo "127.0.1.1 $HOSTNAME" >> /etc/hosts
 		hostname "$HOSTNAME"
 	fi
@@ -79,9 +77,8 @@ function init_systemd()
 	GREEN='\033[0;32m'
 	echo -e "${GREEN}Systemd init system enabled."
 	for var in $(compgen -e); do
-		printf '%q="%q"\n' "$var" "${!var}"
+		printf '%q=%q\n' "$var" "${!var}"
 	done > /etc/docker.env
-	echo 'source /etc/docker.env' >> ~/.bashrc
 
 	printf '#!/bin/bash\n exec ' > /etc/resinApp.sh
 	printf '%q ' "$@" >> /etc/resinApp.sh
@@ -102,9 +99,8 @@ function init_non_systemd()
 	# trap the stop signal then send SIGTERM to user processes
 	trap signal_handler SIGRTMIN+3 SIGTERM
 
-	CMD=$(which "$1")
 	# echo error message, when executable file doesn't exist.
-	if [ $? == '0' ]; then
+	if CMD=$(command -v "$1" 2>/dev/null); then
 		shift
 		tini -sg -- "$CMD" "$@" &
 		pid=$!
@@ -142,7 +138,7 @@ if [ ! -z "$RESIN" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 		mount_dev
 	fi
 	start_udev
-fi 
+fi
 
 if [ "$INITSYSTEM" = "on" ]; then
 	init_systemd "$@"

--- a/resin-base-images/debian/i386/sid/entry.sh
+++ b/resin-base-images/debian/i386/sid/entry.sh
@@ -2,8 +2,7 @@
 
 set -m
 
-hostname "$HOSTNAME" &> /dev/null
-if [[ $? == 0 ]]; then
+if hostname "$HOSTNAME" &> /dev/null; then
 	PRIVILEGED=true
 else
 	PRIVILEGED=false
@@ -13,8 +12,7 @@ function start_udev()
 {
 	if [ "$UDEV" == "on" ]; then
 		if [ "$INITSYSTEM" != "on" ]; then
-			which udevd
-			if [ $? == '0' ]; then
+			if command -v udevd &>/dev/null; then
 				udevd --daemon &> /dev/null
 			else
 				/lib/systemd/systemd-udevd --daemon &> /dev/null
@@ -36,17 +34,17 @@ function remove_buildtime_env_var()
 # Send SIGTERM to child processes of PID 1.
 function signal_handler()
 {
-	kill $pid
+	kill "$pid"
 }
 
 # On ResinOS 2.x devices, the hostname is set by the hostOS.
 # For backward compatibility, we only update the hostname for ResinOS 1.x devices.
 function update_hostname()
 {
-	if [ ${RESIN_DEVICE_UUID:0:7} != ${HOSTNAME:0:7} ]; then
+	if [ "${RESIN_DEVICE_UUID:0:7}" != "${HOSTNAME:0:7}" ]; then
 		# For 1.x Devices only.
 		HOSTNAME="$RESIN_DEVICE_TYPE-${RESIN_DEVICE_UUID:0:7}"
-		echo $HOSTNAME > /etc/hostname
+		echo "$HOSTNAME" > /etc/hostname
 		echo "127.0.1.1 $HOSTNAME" >> /etc/hosts
 		hostname "$HOSTNAME"
 	fi
@@ -79,9 +77,8 @@ function init_systemd()
 	GREEN='\033[0;32m'
 	echo -e "${GREEN}Systemd init system enabled."
 	for var in $(compgen -e); do
-		printf '%q="%q"\n' "$var" "${!var}"
+		printf '%q=%q\n' "$var" "${!var}"
 	done > /etc/docker.env
-	echo 'source /etc/docker.env' >> ~/.bashrc
 
 	printf '#!/bin/bash\n exec ' > /etc/resinApp.sh
 	printf '%q ' "$@" >> /etc/resinApp.sh
@@ -102,9 +99,8 @@ function init_non_systemd()
 	# trap the stop signal then send SIGTERM to user processes
 	trap signal_handler SIGRTMIN+3 SIGTERM
 
-	CMD=$(which "$1")
 	# echo error message, when executable file doesn't exist.
-	if [ $? == '0' ]; then
+	if CMD=$(command -v "$1" 2>/dev/null); then
 		shift
 		tini -sg -- "$CMD" "$@" &
 		pid=$!
@@ -142,7 +138,7 @@ if [ ! -z "$RESIN" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 		mount_dev
 	fi
 	start_udev
-fi 
+fi
 
 if [ "$INITSYSTEM" = "on" ]; then
 	init_systemd "$@"

--- a/resin-base-images/debian/i386/stretch/entry.sh
+++ b/resin-base-images/debian/i386/stretch/entry.sh
@@ -2,8 +2,7 @@
 
 set -m
 
-hostname "$HOSTNAME" &> /dev/null
-if [[ $? == 0 ]]; then
+if hostname "$HOSTNAME" &> /dev/null; then
 	PRIVILEGED=true
 else
 	PRIVILEGED=false
@@ -13,8 +12,7 @@ function start_udev()
 {
 	if [ "$UDEV" == "on" ]; then
 		if [ "$INITSYSTEM" != "on" ]; then
-			which udevd
-			if [ $? == '0' ]; then
+			if command -v udevd &>/dev/null; then
 				udevd --daemon &> /dev/null
 			else
 				/lib/systemd/systemd-udevd --daemon &> /dev/null
@@ -36,17 +34,17 @@ function remove_buildtime_env_var()
 # Send SIGTERM to child processes of PID 1.
 function signal_handler()
 {
-	kill $pid
+	kill "$pid"
 }
 
 # On ResinOS 2.x devices, the hostname is set by the hostOS.
 # For backward compatibility, we only update the hostname for ResinOS 1.x devices.
 function update_hostname()
 {
-	if [ ${RESIN_DEVICE_UUID:0:7} != ${HOSTNAME:0:7} ]; then
+	if [ "${RESIN_DEVICE_UUID:0:7}" != "${HOSTNAME:0:7}" ]; then
 		# For 1.x Devices only.
 		HOSTNAME="$RESIN_DEVICE_TYPE-${RESIN_DEVICE_UUID:0:7}"
-		echo $HOSTNAME > /etc/hostname
+		echo "$HOSTNAME" > /etc/hostname
 		echo "127.0.1.1 $HOSTNAME" >> /etc/hosts
 		hostname "$HOSTNAME"
 	fi
@@ -79,9 +77,8 @@ function init_systemd()
 	GREEN='\033[0;32m'
 	echo -e "${GREEN}Systemd init system enabled."
 	for var in $(compgen -e); do
-		printf '%q="%q"\n' "$var" "${!var}"
+		printf '%q=%q\n' "$var" "${!var}"
 	done > /etc/docker.env
-	echo 'source /etc/docker.env' >> ~/.bashrc
 
 	printf '#!/bin/bash\n exec ' > /etc/resinApp.sh
 	printf '%q ' "$@" >> /etc/resinApp.sh
@@ -102,9 +99,8 @@ function init_non_systemd()
 	# trap the stop signal then send SIGTERM to user processes
 	trap signal_handler SIGRTMIN+3 SIGTERM
 
-	CMD=$(which "$1")
 	# echo error message, when executable file doesn't exist.
-	if [ $? == '0' ]; then
+	if CMD=$(command -v "$1" 2>/dev/null); then
 		shift
 		tini -sg -- "$CMD" "$@" &
 		pid=$!
@@ -142,7 +138,7 @@ if [ ! -z "$RESIN" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 		mount_dev
 	fi
 	start_udev
-fi 
+fi
 
 if [ "$INITSYSTEM" = "on" ]; then
 	init_systemd "$@"

--- a/resin-base-images/fedora/aarch64/24/entry.sh
+++ b/resin-base-images/fedora/aarch64/24/entry.sh
@@ -2,8 +2,7 @@
 
 set -m
 
-hostname "$HOSTNAME" &> /dev/null
-if [[ $? == 0 ]]; then
+if hostname "$HOSTNAME" &> /dev/null; then
 	PRIVILEGED=true
 else
 	PRIVILEGED=false
@@ -13,8 +12,7 @@ function start_udev()
 {
 	if [ "$UDEV" == "on" ]; then
 		if [ "$INITSYSTEM" != "on" ]; then
-			which udevd
-			if [ $? == '0' ]; then
+			if command -v udevd &>/dev/null; then
 				udevd --daemon &> /dev/null
 			else
 				/lib/systemd/systemd-udevd --daemon &> /dev/null
@@ -36,17 +34,17 @@ function remove_buildtime_env_var()
 # Send SIGTERM to child processes of PID 1.
 function signal_handler()
 {
-	kill $pid
+	kill "$pid"
 }
 
 # On ResinOS 2.x devices, the hostname is set by the hostOS.
 # For backward compatibility, we only update the hostname for ResinOS 1.x devices.
 function update_hostname()
 {
-	if [ ${RESIN_DEVICE_UUID:0:7} != ${HOSTNAME:0:7} ]; then
+	if [ "${RESIN_DEVICE_UUID:0:7}" != "${HOSTNAME:0:7}" ]; then
 		# For 1.x Devices only.
 		HOSTNAME="$RESIN_DEVICE_TYPE-${RESIN_DEVICE_UUID:0:7}"
-		echo $HOSTNAME > /etc/hostname
+		echo "$HOSTNAME" > /etc/hostname
 		echo "127.0.1.1 $HOSTNAME" >> /etc/hosts
 		hostname "$HOSTNAME"
 	fi
@@ -79,9 +77,8 @@ function init_systemd()
 	GREEN='\033[0;32m'
 	echo -e "${GREEN}Systemd init system enabled."
 	for var in $(compgen -e); do
-		printf '%q="%q"\n' "$var" "${!var}"
+		printf '%q=%q\n' "$var" "${!var}"
 	done > /etc/docker.env
-	echo 'source /etc/docker.env' >> ~/.bashrc
 
 	printf '#!/bin/bash\n exec ' > /etc/resinApp.sh
 	printf '%q ' "$@" >> /etc/resinApp.sh
@@ -104,9 +101,8 @@ function init_non_systemd()
 	# trap the stop signal then send SIGTERM to user processes
 	trap signal_handler SIGRTMIN+3 SIGTERM
 
-	CMD=$(which "$1")
 	# echo error message, when executable file doesn't exist.
-	if [ $? == '0' ]; then
+	if CMD=$(command -v "$1" 2>/dev/null); then
 		shift
 		tini -sg -- "$CMD" "$@" &
 		pid=$!
@@ -144,7 +140,7 @@ if [ ! -z "$RESIN" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 		mount_dev
 	fi
 	start_udev
-fi 
+fi
 
 if [ "$INITSYSTEM" = "on" ]; then
 	init_systemd "$@"

--- a/resin-base-images/fedora/aarch64/25/entry.sh
+++ b/resin-base-images/fedora/aarch64/25/entry.sh
@@ -2,8 +2,7 @@
 
 set -m
 
-hostname "$HOSTNAME" &> /dev/null
-if [[ $? == 0 ]]; then
+if hostname "$HOSTNAME" &> /dev/null; then
 	PRIVILEGED=true
 else
 	PRIVILEGED=false
@@ -13,8 +12,7 @@ function start_udev()
 {
 	if [ "$UDEV" == "on" ]; then
 		if [ "$INITSYSTEM" != "on" ]; then
-			which udevd
-			if [ $? == '0' ]; then
+			if command -v udevd &>/dev/null; then
 				udevd --daemon &> /dev/null
 			else
 				/lib/systemd/systemd-udevd --daemon &> /dev/null
@@ -36,17 +34,17 @@ function remove_buildtime_env_var()
 # Send SIGTERM to child processes of PID 1.
 function signal_handler()
 {
-	kill $pid
+	kill "$pid"
 }
 
 # On ResinOS 2.x devices, the hostname is set by the hostOS.
 # For backward compatibility, we only update the hostname for ResinOS 1.x devices.
 function update_hostname()
 {
-	if [ ${RESIN_DEVICE_UUID:0:7} != ${HOSTNAME:0:7} ]; then
+	if [ "${RESIN_DEVICE_UUID:0:7}" != "${HOSTNAME:0:7}" ]; then
 		# For 1.x Devices only.
 		HOSTNAME="$RESIN_DEVICE_TYPE-${RESIN_DEVICE_UUID:0:7}"
-		echo $HOSTNAME > /etc/hostname
+		echo "$HOSTNAME" > /etc/hostname
 		echo "127.0.1.1 $HOSTNAME" >> /etc/hosts
 		hostname "$HOSTNAME"
 	fi
@@ -79,9 +77,8 @@ function init_systemd()
 	GREEN='\033[0;32m'
 	echo -e "${GREEN}Systemd init system enabled."
 	for var in $(compgen -e); do
-		printf '%q="%q"\n' "$var" "${!var}"
+		printf '%q=%q\n' "$var" "${!var}"
 	done > /etc/docker.env
-	echo 'source /etc/docker.env' >> ~/.bashrc
 
 	printf '#!/bin/bash\n exec ' > /etc/resinApp.sh
 	printf '%q ' "$@" >> /etc/resinApp.sh
@@ -104,9 +101,8 @@ function init_non_systemd()
 	# trap the stop signal then send SIGTERM to user processes
 	trap signal_handler SIGRTMIN+3 SIGTERM
 
-	CMD=$(which "$1")
 	# echo error message, when executable file doesn't exist.
-	if [ $? == '0' ]; then
+	if CMD=$(command -v "$1" 2>/dev/null); then
 		shift
 		tini -sg -- "$CMD" "$@" &
 		pid=$!
@@ -144,7 +140,7 @@ if [ ! -z "$RESIN" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 		mount_dev
 	fi
 	start_udev
-fi 
+fi
 
 if [ "$INITSYSTEM" = "on" ]; then
 	init_systemd "$@"

--- a/resin-base-images/fedora/aarch64/26/entry.sh
+++ b/resin-base-images/fedora/aarch64/26/entry.sh
@@ -2,8 +2,7 @@
 
 set -m
 
-hostname "$HOSTNAME" &> /dev/null
-if [[ $? == 0 ]]; then
+if hostname "$HOSTNAME" &> /dev/null; then
 	PRIVILEGED=true
 else
 	PRIVILEGED=false
@@ -13,8 +12,7 @@ function start_udev()
 {
 	if [ "$UDEV" == "on" ]; then
 		if [ "$INITSYSTEM" != "on" ]; then
-			which udevd
-			if [ $? == '0' ]; then
+			if command -v udevd &>/dev/null; then
 				udevd --daemon &> /dev/null
 			else
 				/lib/systemd/systemd-udevd --daemon &> /dev/null
@@ -36,17 +34,17 @@ function remove_buildtime_env_var()
 # Send SIGTERM to child processes of PID 1.
 function signal_handler()
 {
-	kill $pid
+	kill "$pid"
 }
 
 # On ResinOS 2.x devices, the hostname is set by the hostOS.
 # For backward compatibility, we only update the hostname for ResinOS 1.x devices.
 function update_hostname()
 {
-	if [ ${RESIN_DEVICE_UUID:0:7} != ${HOSTNAME:0:7} ]; then
+	if [ "${RESIN_DEVICE_UUID:0:7}" != "${HOSTNAME:0:7}" ]; then
 		# For 1.x Devices only.
 		HOSTNAME="$RESIN_DEVICE_TYPE-${RESIN_DEVICE_UUID:0:7}"
-		echo $HOSTNAME > /etc/hostname
+		echo "$HOSTNAME" > /etc/hostname
 		echo "127.0.1.1 $HOSTNAME" >> /etc/hosts
 		hostname "$HOSTNAME"
 	fi
@@ -79,9 +77,8 @@ function init_systemd()
 	GREEN='\033[0;32m'
 	echo -e "${GREEN}Systemd init system enabled."
 	for var in $(compgen -e); do
-		printf '%q="%q"\n' "$var" "${!var}"
+		printf '%q=%q\n' "$var" "${!var}"
 	done > /etc/docker.env
-	echo 'source /etc/docker.env' >> ~/.bashrc
 
 	printf '#!/bin/bash\n exec ' > /etc/resinApp.sh
 	printf '%q ' "$@" >> /etc/resinApp.sh
@@ -104,9 +101,8 @@ function init_non_systemd()
 	# trap the stop signal then send SIGTERM to user processes
 	trap signal_handler SIGRTMIN+3 SIGTERM
 
-	CMD=$(which "$1")
 	# echo error message, when executable file doesn't exist.
-	if [ $? == '0' ]; then
+	if CMD=$(command -v "$1" 2>/dev/null); then
 		shift
 		tini -sg -- "$CMD" "$@" &
 		pid=$!
@@ -144,7 +140,7 @@ if [ ! -z "$RESIN" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 		mount_dev
 	fi
 	start_udev
-fi 
+fi
 
 if [ "$INITSYSTEM" = "on" ]; then
 	init_systemd "$@"

--- a/resin-base-images/fedora/amd64/24/entry.sh
+++ b/resin-base-images/fedora/amd64/24/entry.sh
@@ -2,8 +2,7 @@
 
 set -m
 
-hostname "$HOSTNAME" &> /dev/null
-if [[ $? == 0 ]]; then
+if hostname "$HOSTNAME" &> /dev/null; then
 	PRIVILEGED=true
 else
 	PRIVILEGED=false
@@ -13,8 +12,7 @@ function start_udev()
 {
 	if [ "$UDEV" == "on" ]; then
 		if [ "$INITSYSTEM" != "on" ]; then
-			which udevd
-			if [ $? == '0' ]; then
+			if command -v udevd &>/dev/null; then
 				udevd --daemon &> /dev/null
 			else
 				/lib/systemd/systemd-udevd --daemon &> /dev/null
@@ -36,17 +34,17 @@ function remove_buildtime_env_var()
 # Send SIGTERM to child processes of PID 1.
 function signal_handler()
 {
-	kill $pid
+	kill "$pid"
 }
 
 # On ResinOS 2.x devices, the hostname is set by the hostOS.
 # For backward compatibility, we only update the hostname for ResinOS 1.x devices.
 function update_hostname()
 {
-	if [ ${RESIN_DEVICE_UUID:0:7} != ${HOSTNAME:0:7} ]; then
+	if [ "${RESIN_DEVICE_UUID:0:7}" != "${HOSTNAME:0:7}" ]; then
 		# For 1.x Devices only.
 		HOSTNAME="$RESIN_DEVICE_TYPE-${RESIN_DEVICE_UUID:0:7}"
-		echo $HOSTNAME > /etc/hostname
+		echo "$HOSTNAME" > /etc/hostname
 		echo "127.0.1.1 $HOSTNAME" >> /etc/hosts
 		hostname "$HOSTNAME"
 	fi
@@ -79,9 +77,8 @@ function init_systemd()
 	GREEN='\033[0;32m'
 	echo -e "${GREEN}Systemd init system enabled."
 	for var in $(compgen -e); do
-		printf '%q="%q"\n' "$var" "${!var}"
+		printf '%q=%q\n' "$var" "${!var}"
 	done > /etc/docker.env
-	echo 'source /etc/docker.env' >> ~/.bashrc
 
 	printf '#!/bin/bash\n exec ' > /etc/resinApp.sh
 	printf '%q ' "$@" >> /etc/resinApp.sh
@@ -104,9 +101,8 @@ function init_non_systemd()
 	# trap the stop signal then send SIGTERM to user processes
 	trap signal_handler SIGRTMIN+3 SIGTERM
 
-	CMD=$(which "$1")
 	# echo error message, when executable file doesn't exist.
-	if [ $? == '0' ]; then
+	if CMD=$(command -v "$1" 2>/dev/null); then
 		shift
 		tini -sg -- "$CMD" "$@" &
 		pid=$!
@@ -144,7 +140,7 @@ if [ ! -z "$RESIN" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 		mount_dev
 	fi
 	start_udev
-fi 
+fi
 
 if [ "$INITSYSTEM" = "on" ]; then
 	init_systemd "$@"

--- a/resin-base-images/fedora/amd64/25/entry.sh
+++ b/resin-base-images/fedora/amd64/25/entry.sh
@@ -2,8 +2,7 @@
 
 set -m
 
-hostname "$HOSTNAME" &> /dev/null
-if [[ $? == 0 ]]; then
+if hostname "$HOSTNAME" &> /dev/null; then
 	PRIVILEGED=true
 else
 	PRIVILEGED=false
@@ -13,8 +12,7 @@ function start_udev()
 {
 	if [ "$UDEV" == "on" ]; then
 		if [ "$INITSYSTEM" != "on" ]; then
-			which udevd
-			if [ $? == '0' ]; then
+			if command -v udevd &>/dev/null; then
 				udevd --daemon &> /dev/null
 			else
 				/lib/systemd/systemd-udevd --daemon &> /dev/null
@@ -36,17 +34,17 @@ function remove_buildtime_env_var()
 # Send SIGTERM to child processes of PID 1.
 function signal_handler()
 {
-	kill $pid
+	kill "$pid"
 }
 
 # On ResinOS 2.x devices, the hostname is set by the hostOS.
 # For backward compatibility, we only update the hostname for ResinOS 1.x devices.
 function update_hostname()
 {
-	if [ ${RESIN_DEVICE_UUID:0:7} != ${HOSTNAME:0:7} ]; then
+	if [ "${RESIN_DEVICE_UUID:0:7}" != "${HOSTNAME:0:7}" ]; then
 		# For 1.x Devices only.
 		HOSTNAME="$RESIN_DEVICE_TYPE-${RESIN_DEVICE_UUID:0:7}"
-		echo $HOSTNAME > /etc/hostname
+		echo "$HOSTNAME" > /etc/hostname
 		echo "127.0.1.1 $HOSTNAME" >> /etc/hosts
 		hostname "$HOSTNAME"
 	fi
@@ -79,9 +77,8 @@ function init_systemd()
 	GREEN='\033[0;32m'
 	echo -e "${GREEN}Systemd init system enabled."
 	for var in $(compgen -e); do
-		printf '%q="%q"\n' "$var" "${!var}"
+		printf '%q=%q\n' "$var" "${!var}"
 	done > /etc/docker.env
-	echo 'source /etc/docker.env' >> ~/.bashrc
 
 	printf '#!/bin/bash\n exec ' > /etc/resinApp.sh
 	printf '%q ' "$@" >> /etc/resinApp.sh
@@ -104,9 +101,8 @@ function init_non_systemd()
 	# trap the stop signal then send SIGTERM to user processes
 	trap signal_handler SIGRTMIN+3 SIGTERM
 
-	CMD=$(which "$1")
 	# echo error message, when executable file doesn't exist.
-	if [ $? == '0' ]; then
+	if CMD=$(command -v "$1" 2>/dev/null); then
 		shift
 		tini -sg -- "$CMD" "$@" &
 		pid=$!
@@ -144,7 +140,7 @@ if [ ! -z "$RESIN" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 		mount_dev
 	fi
 	start_udev
-fi 
+fi
 
 if [ "$INITSYSTEM" = "on" ]; then
 	init_systemd "$@"

--- a/resin-base-images/fedora/amd64/26/entry.sh
+++ b/resin-base-images/fedora/amd64/26/entry.sh
@@ -2,8 +2,7 @@
 
 set -m
 
-hostname "$HOSTNAME" &> /dev/null
-if [[ $? == 0 ]]; then
+if hostname "$HOSTNAME" &> /dev/null; then
 	PRIVILEGED=true
 else
 	PRIVILEGED=false
@@ -13,8 +12,7 @@ function start_udev()
 {
 	if [ "$UDEV" == "on" ]; then
 		if [ "$INITSYSTEM" != "on" ]; then
-			which udevd
-			if [ $? == '0' ]; then
+			if command -v udevd &>/dev/null; then
 				udevd --daemon &> /dev/null
 			else
 				/lib/systemd/systemd-udevd --daemon &> /dev/null
@@ -36,17 +34,17 @@ function remove_buildtime_env_var()
 # Send SIGTERM to child processes of PID 1.
 function signal_handler()
 {
-	kill $pid
+	kill "$pid"
 }
 
 # On ResinOS 2.x devices, the hostname is set by the hostOS.
 # For backward compatibility, we only update the hostname for ResinOS 1.x devices.
 function update_hostname()
 {
-	if [ ${RESIN_DEVICE_UUID:0:7} != ${HOSTNAME:0:7} ]; then
+	if [ "${RESIN_DEVICE_UUID:0:7}" != "${HOSTNAME:0:7}" ]; then
 		# For 1.x Devices only.
 		HOSTNAME="$RESIN_DEVICE_TYPE-${RESIN_DEVICE_UUID:0:7}"
-		echo $HOSTNAME > /etc/hostname
+		echo "$HOSTNAME" > /etc/hostname
 		echo "127.0.1.1 $HOSTNAME" >> /etc/hosts
 		hostname "$HOSTNAME"
 	fi
@@ -79,9 +77,8 @@ function init_systemd()
 	GREEN='\033[0;32m'
 	echo -e "${GREEN}Systemd init system enabled."
 	for var in $(compgen -e); do
-		printf '%q="%q"\n' "$var" "${!var}"
+		printf '%q=%q\n' "$var" "${!var}"
 	done > /etc/docker.env
-	echo 'source /etc/docker.env' >> ~/.bashrc
 
 	printf '#!/bin/bash\n exec ' > /etc/resinApp.sh
 	printf '%q ' "$@" >> /etc/resinApp.sh
@@ -104,9 +101,8 @@ function init_non_systemd()
 	# trap the stop signal then send SIGTERM to user processes
 	trap signal_handler SIGRTMIN+3 SIGTERM
 
-	CMD=$(which "$1")
 	# echo error message, when executable file doesn't exist.
-	if [ $? == '0' ]; then
+	if CMD=$(command -v "$1" 2>/dev/null); then
 		shift
 		tini -sg -- "$CMD" "$@" &
 		pid=$!
@@ -144,7 +140,7 @@ if [ ! -z "$RESIN" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 		mount_dev
 	fi
 	start_udev
-fi 
+fi
 
 if [ "$INITSYSTEM" = "on" ]; then
 	init_systemd "$@"

--- a/resin-base-images/fedora/armv7hf/24/entry.sh
+++ b/resin-base-images/fedora/armv7hf/24/entry.sh
@@ -2,8 +2,7 @@
 
 set -m
 
-hostname "$HOSTNAME" &> /dev/null
-if [[ $? == 0 ]]; then
+if hostname "$HOSTNAME" &> /dev/null; then
 	PRIVILEGED=true
 else
 	PRIVILEGED=false
@@ -13,8 +12,7 @@ function start_udev()
 {
 	if [ "$UDEV" == "on" ]; then
 		if [ "$INITSYSTEM" != "on" ]; then
-			which udevd
-			if [ $? == '0' ]; then
+			if command -v udevd &>/dev/null; then
 				udevd --daemon &> /dev/null
 			else
 				/lib/systemd/systemd-udevd --daemon &> /dev/null
@@ -36,17 +34,17 @@ function remove_buildtime_env_var()
 # Send SIGTERM to child processes of PID 1.
 function signal_handler()
 {
-	kill $pid
+	kill "$pid"
 }
 
 # On ResinOS 2.x devices, the hostname is set by the hostOS.
 # For backward compatibility, we only update the hostname for ResinOS 1.x devices.
 function update_hostname()
 {
-	if [ ${RESIN_DEVICE_UUID:0:7} != ${HOSTNAME:0:7} ]; then
+	if [ "${RESIN_DEVICE_UUID:0:7}" != "${HOSTNAME:0:7}" ]; then
 		# For 1.x Devices only.
 		HOSTNAME="$RESIN_DEVICE_TYPE-${RESIN_DEVICE_UUID:0:7}"
-		echo $HOSTNAME > /etc/hostname
+		echo "$HOSTNAME" > /etc/hostname
 		echo "127.0.1.1 $HOSTNAME" >> /etc/hosts
 		hostname "$HOSTNAME"
 	fi
@@ -79,9 +77,8 @@ function init_systemd()
 	GREEN='\033[0;32m'
 	echo -e "${GREEN}Systemd init system enabled."
 	for var in $(compgen -e); do
-		printf '%q="%q"\n' "$var" "${!var}"
+		printf '%q=%q\n' "$var" "${!var}"
 	done > /etc/docker.env
-	echo 'source /etc/docker.env' >> ~/.bashrc
 
 	printf '#!/bin/bash\n exec ' > /etc/resinApp.sh
 	printf '%q ' "$@" >> /etc/resinApp.sh
@@ -104,9 +101,8 @@ function init_non_systemd()
 	# trap the stop signal then send SIGTERM to user processes
 	trap signal_handler SIGRTMIN+3 SIGTERM
 
-	CMD=$(which "$1")
 	# echo error message, when executable file doesn't exist.
-	if [ $? == '0' ]; then
+	if CMD=$(command -v "$1" 2>/dev/null); then
 		shift
 		tini -sg -- "$CMD" "$@" &
 		pid=$!
@@ -144,7 +140,7 @@ if [ ! -z "$RESIN" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 		mount_dev
 	fi
 	start_udev
-fi 
+fi
 
 if [ "$INITSYSTEM" = "on" ]; then
 	init_systemd "$@"

--- a/resin-base-images/fedora/armv7hf/25/entry.sh
+++ b/resin-base-images/fedora/armv7hf/25/entry.sh
@@ -2,8 +2,7 @@
 
 set -m
 
-hostname "$HOSTNAME" &> /dev/null
-if [[ $? == 0 ]]; then
+if hostname "$HOSTNAME" &> /dev/null; then
 	PRIVILEGED=true
 else
 	PRIVILEGED=false
@@ -13,8 +12,7 @@ function start_udev()
 {
 	if [ "$UDEV" == "on" ]; then
 		if [ "$INITSYSTEM" != "on" ]; then
-			which udevd
-			if [ $? == '0' ]; then
+			if command -v udevd &>/dev/null; then
 				udevd --daemon &> /dev/null
 			else
 				/lib/systemd/systemd-udevd --daemon &> /dev/null
@@ -36,17 +34,17 @@ function remove_buildtime_env_var()
 # Send SIGTERM to child processes of PID 1.
 function signal_handler()
 {
-	kill $pid
+	kill "$pid"
 }
 
 # On ResinOS 2.x devices, the hostname is set by the hostOS.
 # For backward compatibility, we only update the hostname for ResinOS 1.x devices.
 function update_hostname()
 {
-	if [ ${RESIN_DEVICE_UUID:0:7} != ${HOSTNAME:0:7} ]; then
+	if [ "${RESIN_DEVICE_UUID:0:7}" != "${HOSTNAME:0:7}" ]; then
 		# For 1.x Devices only.
 		HOSTNAME="$RESIN_DEVICE_TYPE-${RESIN_DEVICE_UUID:0:7}"
-		echo $HOSTNAME > /etc/hostname
+		echo "$HOSTNAME" > /etc/hostname
 		echo "127.0.1.1 $HOSTNAME" >> /etc/hosts
 		hostname "$HOSTNAME"
 	fi
@@ -79,9 +77,8 @@ function init_systemd()
 	GREEN='\033[0;32m'
 	echo -e "${GREEN}Systemd init system enabled."
 	for var in $(compgen -e); do
-		printf '%q="%q"\n' "$var" "${!var}"
+		printf '%q=%q\n' "$var" "${!var}"
 	done > /etc/docker.env
-	echo 'source /etc/docker.env' >> ~/.bashrc
 
 	printf '#!/bin/bash\n exec ' > /etc/resinApp.sh
 	printf '%q ' "$@" >> /etc/resinApp.sh
@@ -104,9 +101,8 @@ function init_non_systemd()
 	# trap the stop signal then send SIGTERM to user processes
 	trap signal_handler SIGRTMIN+3 SIGTERM
 
-	CMD=$(which "$1")
 	# echo error message, when executable file doesn't exist.
-	if [ $? == '0' ]; then
+	if CMD=$(command -v "$1" 2>/dev/null); then
 		shift
 		tini -sg -- "$CMD" "$@" &
 		pid=$!
@@ -144,7 +140,7 @@ if [ ! -z "$RESIN" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 		mount_dev
 	fi
 	start_udev
-fi 
+fi
 
 if [ "$INITSYSTEM" = "on" ]; then
 	init_systemd "$@"

--- a/resin-base-images/fedora/armv7hf/26/entry.sh
+++ b/resin-base-images/fedora/armv7hf/26/entry.sh
@@ -2,8 +2,7 @@
 
 set -m
 
-hostname "$HOSTNAME" &> /dev/null
-if [[ $? == 0 ]]; then
+if hostname "$HOSTNAME" &> /dev/null; then
 	PRIVILEGED=true
 else
 	PRIVILEGED=false
@@ -13,8 +12,7 @@ function start_udev()
 {
 	if [ "$UDEV" == "on" ]; then
 		if [ "$INITSYSTEM" != "on" ]; then
-			which udevd
-			if [ $? == '0' ]; then
+			if command -v udevd &>/dev/null; then
 				udevd --daemon &> /dev/null
 			else
 				/lib/systemd/systemd-udevd --daemon &> /dev/null
@@ -36,17 +34,17 @@ function remove_buildtime_env_var()
 # Send SIGTERM to child processes of PID 1.
 function signal_handler()
 {
-	kill $pid
+	kill "$pid"
 }
 
 # On ResinOS 2.x devices, the hostname is set by the hostOS.
 # For backward compatibility, we only update the hostname for ResinOS 1.x devices.
 function update_hostname()
 {
-	if [ ${RESIN_DEVICE_UUID:0:7} != ${HOSTNAME:0:7} ]; then
+	if [ "${RESIN_DEVICE_UUID:0:7}" != "${HOSTNAME:0:7}" ]; then
 		# For 1.x Devices only.
 		HOSTNAME="$RESIN_DEVICE_TYPE-${RESIN_DEVICE_UUID:0:7}"
-		echo $HOSTNAME > /etc/hostname
+		echo "$HOSTNAME" > /etc/hostname
 		echo "127.0.1.1 $HOSTNAME" >> /etc/hosts
 		hostname "$HOSTNAME"
 	fi
@@ -79,9 +77,8 @@ function init_systemd()
 	GREEN='\033[0;32m'
 	echo -e "${GREEN}Systemd init system enabled."
 	for var in $(compgen -e); do
-		printf '%q="%q"\n' "$var" "${!var}"
+		printf '%q=%q\n' "$var" "${!var}"
 	done > /etc/docker.env
-	echo 'source /etc/docker.env' >> ~/.bashrc
 
 	printf '#!/bin/bash\n exec ' > /etc/resinApp.sh
 	printf '%q ' "$@" >> /etc/resinApp.sh
@@ -104,9 +101,8 @@ function init_non_systemd()
 	# trap the stop signal then send SIGTERM to user processes
 	trap signal_handler SIGRTMIN+3 SIGTERM
 
-	CMD=$(which "$1")
 	# echo error message, when executable file doesn't exist.
-	if [ $? == '0' ]; then
+	if CMD=$(command -v "$1" 2>/dev/null); then
 		shift
 		tini -sg -- "$CMD" "$@" &
 		pid=$!
@@ -144,7 +140,7 @@ if [ ! -z "$RESIN" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 		mount_dev
 	fi
 	start_udev
-fi 
+fi
 
 if [ "$INITSYSTEM" = "on" ]; then
 	init_systemd "$@"

--- a/resin-base-images/ubuntu/aarch64/artful/entry.sh
+++ b/resin-base-images/ubuntu/aarch64/artful/entry.sh
@@ -2,8 +2,7 @@
 
 set -m
 
-hostname "$HOSTNAME" &> /dev/null
-if [[ $? == 0 ]]; then
+if hostname "$HOSTNAME" &> /dev/null; then
 	PRIVILEGED=true
 else
 	PRIVILEGED=false
@@ -13,8 +12,7 @@ function start_udev()
 {
 	if [ "$UDEV" == "on" ]; then
 		if [ "$INITSYSTEM" != "on" ]; then
-			which udevd
-			if [ $? == '0' ]; then
+			if command -v udevd &>/dev/null; then
 				udevd --daemon &> /dev/null
 			else
 				/lib/systemd/systemd-udevd --daemon &> /dev/null
@@ -36,17 +34,17 @@ function remove_buildtime_env_var()
 # Send SIGTERM to child processes of PID 1.
 function signal_handler()
 {
-	kill $pid
+	kill "$pid"
 }
 
 # On ResinOS 2.x devices, the hostname is set by the hostOS.
 # For backward compatibility, we only update the hostname for ResinOS 1.x devices.
 function update_hostname()
 {
-	if [ ${RESIN_DEVICE_UUID:0:7} != ${HOSTNAME:0:7} ]; then
+	if [ "${RESIN_DEVICE_UUID:0:7}" != "${HOSTNAME:0:7}" ]; then
 		# For 1.x Devices only.
 		HOSTNAME="$RESIN_DEVICE_TYPE-${RESIN_DEVICE_UUID:0:7}"
-		echo $HOSTNAME > /etc/hostname
+		echo "$HOSTNAME" > /etc/hostname
 		echo "127.0.1.1 $HOSTNAME" >> /etc/hosts
 		hostname "$HOSTNAME"
 	fi
@@ -79,9 +77,8 @@ function init_systemd()
 	GREEN='\033[0;32m'
 	echo -e "${GREEN}Systemd init system enabled."
 	for var in $(compgen -e); do
-		printf '%q="%q"\n' "$var" "${!var}"
+		printf '%q=%q\n' "$var" "${!var}"
 	done > /etc/docker.env
-	echo 'source /etc/docker.env' >> ~/.bashrc
 
 	printf '#!/bin/bash\n exec ' > /etc/resinApp.sh
 	printf '%q ' "$@" >> /etc/resinApp.sh
@@ -102,9 +99,8 @@ function init_non_systemd()
 	# trap the stop signal then send SIGTERM to user processes
 	trap signal_handler SIGRTMIN+3 SIGTERM
 
-	CMD=$(which "$1")
 	# echo error message, when executable file doesn't exist.
-	if [ $? == '0' ]; then
+	if CMD=$(command -v "$1" 2>/dev/null); then
 		shift
 		tini -sg -- "$CMD" "$@" &
 		pid=$!
@@ -142,7 +138,7 @@ if [ ! -z "$RESIN" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 		mount_dev
 	fi
 	start_udev
-fi 
+fi
 
 if [ "$INITSYSTEM" = "on" ]; then
 	init_systemd "$@"

--- a/resin-base-images/ubuntu/aarch64/bionic/entry.sh
+++ b/resin-base-images/ubuntu/aarch64/bionic/entry.sh
@@ -2,8 +2,7 @@
 
 set -m
 
-hostname "$HOSTNAME" &> /dev/null
-if [[ $? == 0 ]]; then
+if hostname "$HOSTNAME" &> /dev/null; then
 	PRIVILEGED=true
 else
 	PRIVILEGED=false
@@ -13,8 +12,7 @@ function start_udev()
 {
 	if [ "$UDEV" == "on" ]; then
 		if [ "$INITSYSTEM" != "on" ]; then
-			which udevd
-			if [ $? == '0' ]; then
+			if command -v udevd &>/dev/null; then
 				udevd --daemon &> /dev/null
 			else
 				/lib/systemd/systemd-udevd --daemon &> /dev/null
@@ -36,17 +34,17 @@ function remove_buildtime_env_var()
 # Send SIGTERM to child processes of PID 1.
 function signal_handler()
 {
-	kill $pid
+	kill "$pid"
 }
 
 # On ResinOS 2.x devices, the hostname is set by the hostOS.
 # For backward compatibility, we only update the hostname for ResinOS 1.x devices.
 function update_hostname()
 {
-	if [ ${RESIN_DEVICE_UUID:0:7} != ${HOSTNAME:0:7} ]; then
+	if [ "${RESIN_DEVICE_UUID:0:7}" != "${HOSTNAME:0:7}" ]; then
 		# For 1.x Devices only.
 		HOSTNAME="$RESIN_DEVICE_TYPE-${RESIN_DEVICE_UUID:0:7}"
-		echo $HOSTNAME > /etc/hostname
+		echo "$HOSTNAME" > /etc/hostname
 		echo "127.0.1.1 $HOSTNAME" >> /etc/hosts
 		hostname "$HOSTNAME"
 	fi
@@ -79,9 +77,8 @@ function init_systemd()
 	GREEN='\033[0;32m'
 	echo -e "${GREEN}Systemd init system enabled."
 	for var in $(compgen -e); do
-		printf '%q="%q"\n' "$var" "${!var}"
+		printf '%q=%q\n' "$var" "${!var}"
 	done > /etc/docker.env
-	echo 'source /etc/docker.env' >> ~/.bashrc
 
 	printf '#!/bin/bash\n exec ' > /etc/resinApp.sh
 	printf '%q ' "$@" >> /etc/resinApp.sh
@@ -102,9 +99,8 @@ function init_non_systemd()
 	# trap the stop signal then send SIGTERM to user processes
 	trap signal_handler SIGRTMIN+3 SIGTERM
 
-	CMD=$(which "$1")
 	# echo error message, when executable file doesn't exist.
-	if [ $? == '0' ]; then
+	if CMD=$(command -v "$1" 2>/dev/null); then
 		shift
 		tini -sg -- "$CMD" "$@" &
 		pid=$!
@@ -142,7 +138,7 @@ if [ ! -z "$RESIN" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 		mount_dev
 	fi
 	start_udev
-fi 
+fi
 
 if [ "$INITSYSTEM" = "on" ]; then
 	init_systemd "$@"

--- a/resin-base-images/ubuntu/aarch64/cosmic/entry.sh
+++ b/resin-base-images/ubuntu/aarch64/cosmic/entry.sh
@@ -2,8 +2,7 @@
 
 set -m
 
-hostname "$HOSTNAME" &> /dev/null
-if [[ $? == 0 ]]; then
+if hostname "$HOSTNAME" &> /dev/null; then
 	PRIVILEGED=true
 else
 	PRIVILEGED=false
@@ -13,8 +12,7 @@ function start_udev()
 {
 	if [ "$UDEV" == "on" ]; then
 		if [ "$INITSYSTEM" != "on" ]; then
-			which udevd
-			if [ $? == '0' ]; then
+			if command -v udevd &>/dev/null; then
 				udevd --daemon &> /dev/null
 			else
 				/lib/systemd/systemd-udevd --daemon &> /dev/null
@@ -36,17 +34,17 @@ function remove_buildtime_env_var()
 # Send SIGTERM to child processes of PID 1.
 function signal_handler()
 {
-	kill $pid
+	kill "$pid"
 }
 
 # On ResinOS 2.x devices, the hostname is set by the hostOS.
 # For backward compatibility, we only update the hostname for ResinOS 1.x devices.
 function update_hostname()
 {
-	if [ ${RESIN_DEVICE_UUID:0:7} != ${HOSTNAME:0:7} ]; then
+	if [ "${RESIN_DEVICE_UUID:0:7}" != "${HOSTNAME:0:7}" ]; then
 		# For 1.x Devices only.
 		HOSTNAME="$RESIN_DEVICE_TYPE-${RESIN_DEVICE_UUID:0:7}"
-		echo $HOSTNAME > /etc/hostname
+		echo "$HOSTNAME" > /etc/hostname
 		echo "127.0.1.1 $HOSTNAME" >> /etc/hosts
 		hostname "$HOSTNAME"
 	fi
@@ -79,9 +77,8 @@ function init_systemd()
 	GREEN='\033[0;32m'
 	echo -e "${GREEN}Systemd init system enabled."
 	for var in $(compgen -e); do
-		printf '%q="%q"\n' "$var" "${!var}"
+		printf '%q=%q\n' "$var" "${!var}"
 	done > /etc/docker.env
-	echo 'source /etc/docker.env' >> ~/.bashrc
 
 	printf '#!/bin/bash\n exec ' > /etc/resinApp.sh
 	printf '%q ' "$@" >> /etc/resinApp.sh
@@ -102,9 +99,8 @@ function init_non_systemd()
 	# trap the stop signal then send SIGTERM to user processes
 	trap signal_handler SIGRTMIN+3 SIGTERM
 
-	CMD=$(which "$1")
 	# echo error message, when executable file doesn't exist.
-	if [ $? == '0' ]; then
+	if CMD=$(command -v "$1" 2>/dev/null); then
 		shift
 		tini -sg -- "$CMD" "$@" &
 		pid=$!
@@ -142,7 +138,7 @@ if [ ! -z "$RESIN" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 		mount_dev
 	fi
 	start_udev
-fi 
+fi
 
 if [ "$INITSYSTEM" = "on" ]; then
 	init_systemd "$@"

--- a/resin-base-images/ubuntu/aarch64/trusty/entry.sh
+++ b/resin-base-images/ubuntu/aarch64/trusty/entry.sh
@@ -2,8 +2,7 @@
 
 set -m
 
-hostname "$HOSTNAME" &> /dev/null
-if [[ $? == 0 ]]; then
+if hostname "$HOSTNAME" &> /dev/null; then
 	PRIVILEGED=true
 else
 	PRIVILEGED=false
@@ -13,8 +12,7 @@ function start_udev()
 {
 	if [ "$UDEV" == "on" ]; then
 		if [ "$INITSYSTEM" != "on" ]; then
-			which udevd
-			if [ $? == '0' ]; then
+			if command -v udevd &>/dev/null; then
 				udevd --daemon &> /dev/null
 			else
 				/lib/systemd/systemd-udevd --daemon &> /dev/null
@@ -36,17 +34,17 @@ function remove_buildtime_env_var()
 # Send SIGTERM to child processes of PID 1.
 function signal_handler()
 {
-	kill $pid
+	kill "$pid"
 }
 
 # On ResinOS 2.x devices, the hostname is set by the hostOS.
 # For backward compatibility, we only update the hostname for ResinOS 1.x devices.
 function update_hostname()
 {
-	if [ ${RESIN_DEVICE_UUID:0:7} != ${HOSTNAME:0:7} ]; then
+	if [ "${RESIN_DEVICE_UUID:0:7}" != "${HOSTNAME:0:7}" ]; then
 		# For 1.x Devices only.
 		HOSTNAME="$RESIN_DEVICE_TYPE-${RESIN_DEVICE_UUID:0:7}"
-		echo $HOSTNAME > /etc/hostname
+		echo "$HOSTNAME" > /etc/hostname
 		echo "127.0.1.1 $HOSTNAME" >> /etc/hosts
 		hostname "$HOSTNAME"
 	fi
@@ -79,9 +77,8 @@ function init_systemd()
 	GREEN='\033[0;32m'
 	echo -e "${GREEN}Systemd init system enabled."
 	for var in $(compgen -e); do
-		printf '%q="%q"\n' "$var" "${!var}"
+		printf '%q=%q\n' "$var" "${!var}"
 	done > /etc/docker.env
-	echo 'source /etc/docker.env' >> ~/.bashrc
 
 	printf '#!/bin/bash\n exec ' > /etc/resinApp.sh
 	printf '%q ' "$@" >> /etc/resinApp.sh
@@ -102,9 +99,8 @@ function init_non_systemd()
 	# trap the stop signal then send SIGTERM to user processes
 	trap signal_handler SIGRTMIN+3 SIGTERM
 
-	CMD=$(which "$1")
 	# echo error message, when executable file doesn't exist.
-	if [ $? == '0' ]; then
+	if CMD=$(command -v "$1" 2>/dev/null); then
 		shift
 		tini -sg -- "$CMD" "$@" &
 		pid=$!
@@ -142,7 +138,7 @@ if [ ! -z "$RESIN" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 		mount_dev
 	fi
 	start_udev
-fi 
+fi
 
 if [ "$INITSYSTEM" = "on" ]; then
 	init_systemd "$@"

--- a/resin-base-images/ubuntu/aarch64/xenial/entry.sh
+++ b/resin-base-images/ubuntu/aarch64/xenial/entry.sh
@@ -2,8 +2,7 @@
 
 set -m
 
-hostname "$HOSTNAME" &> /dev/null
-if [[ $? == 0 ]]; then
+if hostname "$HOSTNAME" &> /dev/null; then
 	PRIVILEGED=true
 else
 	PRIVILEGED=false
@@ -13,8 +12,7 @@ function start_udev()
 {
 	if [ "$UDEV" == "on" ]; then
 		if [ "$INITSYSTEM" != "on" ]; then
-			which udevd
-			if [ $? == '0' ]; then
+			if command -v udevd &>/dev/null; then
 				udevd --daemon &> /dev/null
 			else
 				/lib/systemd/systemd-udevd --daemon &> /dev/null
@@ -36,17 +34,17 @@ function remove_buildtime_env_var()
 # Send SIGTERM to child processes of PID 1.
 function signal_handler()
 {
-	kill $pid
+	kill "$pid"
 }
 
 # On ResinOS 2.x devices, the hostname is set by the hostOS.
 # For backward compatibility, we only update the hostname for ResinOS 1.x devices.
 function update_hostname()
 {
-	if [ ${RESIN_DEVICE_UUID:0:7} != ${HOSTNAME:0:7} ]; then
+	if [ "${RESIN_DEVICE_UUID:0:7}" != "${HOSTNAME:0:7}" ]; then
 		# For 1.x Devices only.
 		HOSTNAME="$RESIN_DEVICE_TYPE-${RESIN_DEVICE_UUID:0:7}"
-		echo $HOSTNAME > /etc/hostname
+		echo "$HOSTNAME" > /etc/hostname
 		echo "127.0.1.1 $HOSTNAME" >> /etc/hosts
 		hostname "$HOSTNAME"
 	fi
@@ -79,9 +77,8 @@ function init_systemd()
 	GREEN='\033[0;32m'
 	echo -e "${GREEN}Systemd init system enabled."
 	for var in $(compgen -e); do
-		printf '%q="%q"\n' "$var" "${!var}"
+		printf '%q=%q\n' "$var" "${!var}"
 	done > /etc/docker.env
-	echo 'source /etc/docker.env' >> ~/.bashrc
 
 	printf '#!/bin/bash\n exec ' > /etc/resinApp.sh
 	printf '%q ' "$@" >> /etc/resinApp.sh
@@ -102,9 +99,8 @@ function init_non_systemd()
 	# trap the stop signal then send SIGTERM to user processes
 	trap signal_handler SIGRTMIN+3 SIGTERM
 
-	CMD=$(which "$1")
 	# echo error message, when executable file doesn't exist.
-	if [ $? == '0' ]; then
+	if CMD=$(command -v "$1" 2>/dev/null); then
 		shift
 		tini -sg -- "$CMD" "$@" &
 		pid=$!
@@ -142,7 +138,7 @@ if [ ! -z "$RESIN" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 		mount_dev
 	fi
 	start_udev
-fi 
+fi
 
 if [ "$INITSYSTEM" = "on" ]; then
 	init_systemd "$@"

--- a/resin-base-images/ubuntu/amd64/artful/entry.sh
+++ b/resin-base-images/ubuntu/amd64/artful/entry.sh
@@ -2,8 +2,7 @@
 
 set -m
 
-hostname "$HOSTNAME" &> /dev/null
-if [[ $? == 0 ]]; then
+if hostname "$HOSTNAME" &> /dev/null; then
 	PRIVILEGED=true
 else
 	PRIVILEGED=false
@@ -13,8 +12,7 @@ function start_udev()
 {
 	if [ "$UDEV" == "on" ]; then
 		if [ "$INITSYSTEM" != "on" ]; then
-			which udevd
-			if [ $? == '0' ]; then
+			if command -v udevd &>/dev/null; then
 				udevd --daemon &> /dev/null
 			else
 				/lib/systemd/systemd-udevd --daemon &> /dev/null
@@ -36,17 +34,17 @@ function remove_buildtime_env_var()
 # Send SIGTERM to child processes of PID 1.
 function signal_handler()
 {
-	kill $pid
+	kill "$pid"
 }
 
 # On ResinOS 2.x devices, the hostname is set by the hostOS.
 # For backward compatibility, we only update the hostname for ResinOS 1.x devices.
 function update_hostname()
 {
-	if [ ${RESIN_DEVICE_UUID:0:7} != ${HOSTNAME:0:7} ]; then
+	if [ "${RESIN_DEVICE_UUID:0:7}" != "${HOSTNAME:0:7}" ]; then
 		# For 1.x Devices only.
 		HOSTNAME="$RESIN_DEVICE_TYPE-${RESIN_DEVICE_UUID:0:7}"
-		echo $HOSTNAME > /etc/hostname
+		echo "$HOSTNAME" > /etc/hostname
 		echo "127.0.1.1 $HOSTNAME" >> /etc/hosts
 		hostname "$HOSTNAME"
 	fi
@@ -79,9 +77,8 @@ function init_systemd()
 	GREEN='\033[0;32m'
 	echo -e "${GREEN}Systemd init system enabled."
 	for var in $(compgen -e); do
-		printf '%q="%q"\n' "$var" "${!var}"
+		printf '%q=%q\n' "$var" "${!var}"
 	done > /etc/docker.env
-	echo 'source /etc/docker.env' >> ~/.bashrc
 
 	printf '#!/bin/bash\n exec ' > /etc/resinApp.sh
 	printf '%q ' "$@" >> /etc/resinApp.sh
@@ -102,9 +99,8 @@ function init_non_systemd()
 	# trap the stop signal then send SIGTERM to user processes
 	trap signal_handler SIGRTMIN+3 SIGTERM
 
-	CMD=$(which "$1")
 	# echo error message, when executable file doesn't exist.
-	if [ $? == '0' ]; then
+	if CMD=$(command -v "$1" 2>/dev/null); then
 		shift
 		tini -sg -- "$CMD" "$@" &
 		pid=$!
@@ -142,7 +138,7 @@ if [ ! -z "$RESIN" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 		mount_dev
 	fi
 	start_udev
-fi 
+fi
 
 if [ "$INITSYSTEM" = "on" ]; then
 	init_systemd "$@"

--- a/resin-base-images/ubuntu/amd64/bionic/entry.sh
+++ b/resin-base-images/ubuntu/amd64/bionic/entry.sh
@@ -2,8 +2,7 @@
 
 set -m
 
-hostname "$HOSTNAME" &> /dev/null
-if [[ $? == 0 ]]; then
+if hostname "$HOSTNAME" &> /dev/null; then
 	PRIVILEGED=true
 else
 	PRIVILEGED=false
@@ -13,8 +12,7 @@ function start_udev()
 {
 	if [ "$UDEV" == "on" ]; then
 		if [ "$INITSYSTEM" != "on" ]; then
-			which udevd
-			if [ $? == '0' ]; then
+			if command -v udevd &>/dev/null; then
 				udevd --daemon &> /dev/null
 			else
 				/lib/systemd/systemd-udevd --daemon &> /dev/null
@@ -36,17 +34,17 @@ function remove_buildtime_env_var()
 # Send SIGTERM to child processes of PID 1.
 function signal_handler()
 {
-	kill $pid
+	kill "$pid"
 }
 
 # On ResinOS 2.x devices, the hostname is set by the hostOS.
 # For backward compatibility, we only update the hostname for ResinOS 1.x devices.
 function update_hostname()
 {
-	if [ ${RESIN_DEVICE_UUID:0:7} != ${HOSTNAME:0:7} ]; then
+	if [ "${RESIN_DEVICE_UUID:0:7}" != "${HOSTNAME:0:7}" ]; then
 		# For 1.x Devices only.
 		HOSTNAME="$RESIN_DEVICE_TYPE-${RESIN_DEVICE_UUID:0:7}"
-		echo $HOSTNAME > /etc/hostname
+		echo "$HOSTNAME" > /etc/hostname
 		echo "127.0.1.1 $HOSTNAME" >> /etc/hosts
 		hostname "$HOSTNAME"
 	fi
@@ -79,9 +77,8 @@ function init_systemd()
 	GREEN='\033[0;32m'
 	echo -e "${GREEN}Systemd init system enabled."
 	for var in $(compgen -e); do
-		printf '%q="%q"\n' "$var" "${!var}"
+		printf '%q=%q\n' "$var" "${!var}"
 	done > /etc/docker.env
-	echo 'source /etc/docker.env' >> ~/.bashrc
 
 	printf '#!/bin/bash\n exec ' > /etc/resinApp.sh
 	printf '%q ' "$@" >> /etc/resinApp.sh
@@ -102,9 +99,8 @@ function init_non_systemd()
 	# trap the stop signal then send SIGTERM to user processes
 	trap signal_handler SIGRTMIN+3 SIGTERM
 
-	CMD=$(which "$1")
 	# echo error message, when executable file doesn't exist.
-	if [ $? == '0' ]; then
+	if CMD=$(command -v "$1" 2>/dev/null); then
 		shift
 		tini -sg -- "$CMD" "$@" &
 		pid=$!
@@ -142,7 +138,7 @@ if [ ! -z "$RESIN" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 		mount_dev
 	fi
 	start_udev
-fi 
+fi
 
 if [ "$INITSYSTEM" = "on" ]; then
 	init_systemd "$@"

--- a/resin-base-images/ubuntu/amd64/cosmic/entry.sh
+++ b/resin-base-images/ubuntu/amd64/cosmic/entry.sh
@@ -2,8 +2,7 @@
 
 set -m
 
-hostname "$HOSTNAME" &> /dev/null
-if [[ $? == 0 ]]; then
+if hostname "$HOSTNAME" &> /dev/null; then
 	PRIVILEGED=true
 else
 	PRIVILEGED=false
@@ -13,8 +12,7 @@ function start_udev()
 {
 	if [ "$UDEV" == "on" ]; then
 		if [ "$INITSYSTEM" != "on" ]; then
-			which udevd
-			if [ $? == '0' ]; then
+			if command -v udevd &>/dev/null; then
 				udevd --daemon &> /dev/null
 			else
 				/lib/systemd/systemd-udevd --daemon &> /dev/null
@@ -36,17 +34,17 @@ function remove_buildtime_env_var()
 # Send SIGTERM to child processes of PID 1.
 function signal_handler()
 {
-	kill $pid
+	kill "$pid"
 }
 
 # On ResinOS 2.x devices, the hostname is set by the hostOS.
 # For backward compatibility, we only update the hostname for ResinOS 1.x devices.
 function update_hostname()
 {
-	if [ ${RESIN_DEVICE_UUID:0:7} != ${HOSTNAME:0:7} ]; then
+	if [ "${RESIN_DEVICE_UUID:0:7}" != "${HOSTNAME:0:7}" ]; then
 		# For 1.x Devices only.
 		HOSTNAME="$RESIN_DEVICE_TYPE-${RESIN_DEVICE_UUID:0:7}"
-		echo $HOSTNAME > /etc/hostname
+		echo "$HOSTNAME" > /etc/hostname
 		echo "127.0.1.1 $HOSTNAME" >> /etc/hosts
 		hostname "$HOSTNAME"
 	fi
@@ -79,9 +77,8 @@ function init_systemd()
 	GREEN='\033[0;32m'
 	echo -e "${GREEN}Systemd init system enabled."
 	for var in $(compgen -e); do
-		printf '%q="%q"\n' "$var" "${!var}"
+		printf '%q=%q\n' "$var" "${!var}"
 	done > /etc/docker.env
-	echo 'source /etc/docker.env' >> ~/.bashrc
 
 	printf '#!/bin/bash\n exec ' > /etc/resinApp.sh
 	printf '%q ' "$@" >> /etc/resinApp.sh
@@ -102,9 +99,8 @@ function init_non_systemd()
 	# trap the stop signal then send SIGTERM to user processes
 	trap signal_handler SIGRTMIN+3 SIGTERM
 
-	CMD=$(which "$1")
 	# echo error message, when executable file doesn't exist.
-	if [ $? == '0' ]; then
+	if CMD=$(command -v "$1" 2>/dev/null); then
 		shift
 		tini -sg -- "$CMD" "$@" &
 		pid=$!
@@ -142,7 +138,7 @@ if [ ! -z "$RESIN" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 		mount_dev
 	fi
 	start_udev
-fi 
+fi
 
 if [ "$INITSYSTEM" = "on" ]; then
 	init_systemd "$@"

--- a/resin-base-images/ubuntu/amd64/trusty/entry.sh
+++ b/resin-base-images/ubuntu/amd64/trusty/entry.sh
@@ -2,8 +2,7 @@
 
 set -m
 
-hostname "$HOSTNAME" &> /dev/null
-if [[ $? == 0 ]]; then
+if hostname "$HOSTNAME" &> /dev/null; then
 	PRIVILEGED=true
 else
 	PRIVILEGED=false
@@ -13,8 +12,7 @@ function start_udev()
 {
 	if [ "$UDEV" == "on" ]; then
 		if [ "$INITSYSTEM" != "on" ]; then
-			which udevd
-			if [ $? == '0' ]; then
+			if command -v udevd &>/dev/null; then
 				udevd --daemon &> /dev/null
 			else
 				/lib/systemd/systemd-udevd --daemon &> /dev/null
@@ -36,17 +34,17 @@ function remove_buildtime_env_var()
 # Send SIGTERM to child processes of PID 1.
 function signal_handler()
 {
-	kill $pid
+	kill "$pid"
 }
 
 # On ResinOS 2.x devices, the hostname is set by the hostOS.
 # For backward compatibility, we only update the hostname for ResinOS 1.x devices.
 function update_hostname()
 {
-	if [ ${RESIN_DEVICE_UUID:0:7} != ${HOSTNAME:0:7} ]; then
+	if [ "${RESIN_DEVICE_UUID:0:7}" != "${HOSTNAME:0:7}" ]; then
 		# For 1.x Devices only.
 		HOSTNAME="$RESIN_DEVICE_TYPE-${RESIN_DEVICE_UUID:0:7}"
-		echo $HOSTNAME > /etc/hostname
+		echo "$HOSTNAME" > /etc/hostname
 		echo "127.0.1.1 $HOSTNAME" >> /etc/hosts
 		hostname "$HOSTNAME"
 	fi
@@ -79,9 +77,8 @@ function init_systemd()
 	GREEN='\033[0;32m'
 	echo -e "${GREEN}Systemd init system enabled."
 	for var in $(compgen -e); do
-		printf '%q="%q"\n' "$var" "${!var}"
+		printf '%q=%q\n' "$var" "${!var}"
 	done > /etc/docker.env
-	echo 'source /etc/docker.env' >> ~/.bashrc
 
 	printf '#!/bin/bash\n exec ' > /etc/resinApp.sh
 	printf '%q ' "$@" >> /etc/resinApp.sh
@@ -102,9 +99,8 @@ function init_non_systemd()
 	# trap the stop signal then send SIGTERM to user processes
 	trap signal_handler SIGRTMIN+3 SIGTERM
 
-	CMD=$(which "$1")
 	# echo error message, when executable file doesn't exist.
-	if [ $? == '0' ]; then
+	if CMD=$(command -v "$1" 2>/dev/null); then
 		shift
 		tini -sg -- "$CMD" "$@" &
 		pid=$!
@@ -142,7 +138,7 @@ if [ ! -z "$RESIN" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 		mount_dev
 	fi
 	start_udev
-fi 
+fi
 
 if [ "$INITSYSTEM" = "on" ]; then
 	init_systemd "$@"

--- a/resin-base-images/ubuntu/amd64/xenial/entry.sh
+++ b/resin-base-images/ubuntu/amd64/xenial/entry.sh
@@ -2,8 +2,7 @@
 
 set -m
 
-hostname "$HOSTNAME" &> /dev/null
-if [[ $? == 0 ]]; then
+if hostname "$HOSTNAME" &> /dev/null; then
 	PRIVILEGED=true
 else
 	PRIVILEGED=false
@@ -13,8 +12,7 @@ function start_udev()
 {
 	if [ "$UDEV" == "on" ]; then
 		if [ "$INITSYSTEM" != "on" ]; then
-			which udevd
-			if [ $? == '0' ]; then
+			if command -v udevd &>/dev/null; then
 				udevd --daemon &> /dev/null
 			else
 				/lib/systemd/systemd-udevd --daemon &> /dev/null
@@ -36,17 +34,17 @@ function remove_buildtime_env_var()
 # Send SIGTERM to child processes of PID 1.
 function signal_handler()
 {
-	kill $pid
+	kill "$pid"
 }
 
 # On ResinOS 2.x devices, the hostname is set by the hostOS.
 # For backward compatibility, we only update the hostname for ResinOS 1.x devices.
 function update_hostname()
 {
-	if [ ${RESIN_DEVICE_UUID:0:7} != ${HOSTNAME:0:7} ]; then
+	if [ "${RESIN_DEVICE_UUID:0:7}" != "${HOSTNAME:0:7}" ]; then
 		# For 1.x Devices only.
 		HOSTNAME="$RESIN_DEVICE_TYPE-${RESIN_DEVICE_UUID:0:7}"
-		echo $HOSTNAME > /etc/hostname
+		echo "$HOSTNAME" > /etc/hostname
 		echo "127.0.1.1 $HOSTNAME" >> /etc/hosts
 		hostname "$HOSTNAME"
 	fi
@@ -79,9 +77,8 @@ function init_systemd()
 	GREEN='\033[0;32m'
 	echo -e "${GREEN}Systemd init system enabled."
 	for var in $(compgen -e); do
-		printf '%q="%q"\n' "$var" "${!var}"
+		printf '%q=%q\n' "$var" "${!var}"
 	done > /etc/docker.env
-	echo 'source /etc/docker.env' >> ~/.bashrc
 
 	printf '#!/bin/bash\n exec ' > /etc/resinApp.sh
 	printf '%q ' "$@" >> /etc/resinApp.sh
@@ -102,9 +99,8 @@ function init_non_systemd()
 	# trap the stop signal then send SIGTERM to user processes
 	trap signal_handler SIGRTMIN+3 SIGTERM
 
-	CMD=$(which "$1")
 	# echo error message, when executable file doesn't exist.
-	if [ $? == '0' ]; then
+	if CMD=$(command -v "$1" 2>/dev/null); then
 		shift
 		tini -sg -- "$CMD" "$@" &
 		pid=$!
@@ -142,7 +138,7 @@ if [ ! -z "$RESIN" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 		mount_dev
 	fi
 	start_udev
-fi 
+fi
 
 if [ "$INITSYSTEM" = "on" ]; then
 	init_systemd "$@"

--- a/resin-base-images/ubuntu/armv7hf/artful/entry.sh
+++ b/resin-base-images/ubuntu/armv7hf/artful/entry.sh
@@ -2,8 +2,7 @@
 
 set -m
 
-hostname "$HOSTNAME" &> /dev/null
-if [[ $? == 0 ]]; then
+if hostname "$HOSTNAME" &> /dev/null; then
 	PRIVILEGED=true
 else
 	PRIVILEGED=false
@@ -13,8 +12,7 @@ function start_udev()
 {
 	if [ "$UDEV" == "on" ]; then
 		if [ "$INITSYSTEM" != "on" ]; then
-			which udevd
-			if [ $? == '0' ]; then
+			if command -v udevd &>/dev/null; then
 				udevd --daemon &> /dev/null
 			else
 				/lib/systemd/systemd-udevd --daemon &> /dev/null
@@ -36,17 +34,17 @@ function remove_buildtime_env_var()
 # Send SIGTERM to child processes of PID 1.
 function signal_handler()
 {
-	kill $pid
+	kill "$pid"
 }
 
 # On ResinOS 2.x devices, the hostname is set by the hostOS.
 # For backward compatibility, we only update the hostname for ResinOS 1.x devices.
 function update_hostname()
 {
-	if [ ${RESIN_DEVICE_UUID:0:7} != ${HOSTNAME:0:7} ]; then
+	if [ "${RESIN_DEVICE_UUID:0:7}" != "${HOSTNAME:0:7}" ]; then
 		# For 1.x Devices only.
 		HOSTNAME="$RESIN_DEVICE_TYPE-${RESIN_DEVICE_UUID:0:7}"
-		echo $HOSTNAME > /etc/hostname
+		echo "$HOSTNAME" > /etc/hostname
 		echo "127.0.1.1 $HOSTNAME" >> /etc/hosts
 		hostname "$HOSTNAME"
 	fi
@@ -79,9 +77,8 @@ function init_systemd()
 	GREEN='\033[0;32m'
 	echo -e "${GREEN}Systemd init system enabled."
 	for var in $(compgen -e); do
-		printf '%q="%q"\n' "$var" "${!var}"
+		printf '%q=%q\n' "$var" "${!var}"
 	done > /etc/docker.env
-	echo 'source /etc/docker.env' >> ~/.bashrc
 
 	printf '#!/bin/bash\n exec ' > /etc/resinApp.sh
 	printf '%q ' "$@" >> /etc/resinApp.sh
@@ -102,9 +99,8 @@ function init_non_systemd()
 	# trap the stop signal then send SIGTERM to user processes
 	trap signal_handler SIGRTMIN+3 SIGTERM
 
-	CMD=$(which "$1")
 	# echo error message, when executable file doesn't exist.
-	if [ $? == '0' ]; then
+	if CMD=$(command -v "$1" 2>/dev/null); then
 		shift
 		tini -sg -- "$CMD" "$@" &
 		pid=$!
@@ -142,7 +138,7 @@ if [ ! -z "$RESIN" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 		mount_dev
 	fi
 	start_udev
-fi 
+fi
 
 if [ "$INITSYSTEM" = "on" ]; then
 	init_systemd "$@"

--- a/resin-base-images/ubuntu/armv7hf/bionic/entry.sh
+++ b/resin-base-images/ubuntu/armv7hf/bionic/entry.sh
@@ -2,8 +2,7 @@
 
 set -m
 
-hostname "$HOSTNAME" &> /dev/null
-if [[ $? == 0 ]]; then
+if hostname "$HOSTNAME" &> /dev/null; then
 	PRIVILEGED=true
 else
 	PRIVILEGED=false
@@ -13,8 +12,7 @@ function start_udev()
 {
 	if [ "$UDEV" == "on" ]; then
 		if [ "$INITSYSTEM" != "on" ]; then
-			which udevd
-			if [ $? == '0' ]; then
+			if command -v udevd &>/dev/null; then
 				udevd --daemon &> /dev/null
 			else
 				/lib/systemd/systemd-udevd --daemon &> /dev/null
@@ -36,17 +34,17 @@ function remove_buildtime_env_var()
 # Send SIGTERM to child processes of PID 1.
 function signal_handler()
 {
-	kill $pid
+	kill "$pid"
 }
 
 # On ResinOS 2.x devices, the hostname is set by the hostOS.
 # For backward compatibility, we only update the hostname for ResinOS 1.x devices.
 function update_hostname()
 {
-	if [ ${RESIN_DEVICE_UUID:0:7} != ${HOSTNAME:0:7} ]; then
+	if [ "${RESIN_DEVICE_UUID:0:7}" != "${HOSTNAME:0:7}" ]; then
 		# For 1.x Devices only.
 		HOSTNAME="$RESIN_DEVICE_TYPE-${RESIN_DEVICE_UUID:0:7}"
-		echo $HOSTNAME > /etc/hostname
+		echo "$HOSTNAME" > /etc/hostname
 		echo "127.0.1.1 $HOSTNAME" >> /etc/hosts
 		hostname "$HOSTNAME"
 	fi
@@ -79,9 +77,8 @@ function init_systemd()
 	GREEN='\033[0;32m'
 	echo -e "${GREEN}Systemd init system enabled."
 	for var in $(compgen -e); do
-		printf '%q="%q"\n' "$var" "${!var}"
+		printf '%q=%q\n' "$var" "${!var}"
 	done > /etc/docker.env
-	echo 'source /etc/docker.env' >> ~/.bashrc
 
 	printf '#!/bin/bash\n exec ' > /etc/resinApp.sh
 	printf '%q ' "$@" >> /etc/resinApp.sh
@@ -102,9 +99,8 @@ function init_non_systemd()
 	# trap the stop signal then send SIGTERM to user processes
 	trap signal_handler SIGRTMIN+3 SIGTERM
 
-	CMD=$(which "$1")
 	# echo error message, when executable file doesn't exist.
-	if [ $? == '0' ]; then
+	if CMD=$(command -v "$1" 2>/dev/null); then
 		shift
 		tini -sg -- "$CMD" "$@" &
 		pid=$!
@@ -142,7 +138,7 @@ if [ ! -z "$RESIN" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 		mount_dev
 	fi
 	start_udev
-fi 
+fi
 
 if [ "$INITSYSTEM" = "on" ]; then
 	init_systemd "$@"

--- a/resin-base-images/ubuntu/armv7hf/cosmic/entry.sh
+++ b/resin-base-images/ubuntu/armv7hf/cosmic/entry.sh
@@ -2,8 +2,7 @@
 
 set -m
 
-hostname "$HOSTNAME" &> /dev/null
-if [[ $? == 0 ]]; then
+if hostname "$HOSTNAME" &> /dev/null; then
 	PRIVILEGED=true
 else
 	PRIVILEGED=false
@@ -13,8 +12,7 @@ function start_udev()
 {
 	if [ "$UDEV" == "on" ]; then
 		if [ "$INITSYSTEM" != "on" ]; then
-			which udevd
-			if [ $? == '0' ]; then
+			if command -v udevd &>/dev/null; then
 				udevd --daemon &> /dev/null
 			else
 				/lib/systemd/systemd-udevd --daemon &> /dev/null
@@ -36,17 +34,17 @@ function remove_buildtime_env_var()
 # Send SIGTERM to child processes of PID 1.
 function signal_handler()
 {
-	kill $pid
+	kill "$pid"
 }
 
 # On ResinOS 2.x devices, the hostname is set by the hostOS.
 # For backward compatibility, we only update the hostname for ResinOS 1.x devices.
 function update_hostname()
 {
-	if [ ${RESIN_DEVICE_UUID:0:7} != ${HOSTNAME:0:7} ]; then
+	if [ "${RESIN_DEVICE_UUID:0:7}" != "${HOSTNAME:0:7}" ]; then
 		# For 1.x Devices only.
 		HOSTNAME="$RESIN_DEVICE_TYPE-${RESIN_DEVICE_UUID:0:7}"
-		echo $HOSTNAME > /etc/hostname
+		echo "$HOSTNAME" > /etc/hostname
 		echo "127.0.1.1 $HOSTNAME" >> /etc/hosts
 		hostname "$HOSTNAME"
 	fi
@@ -79,9 +77,8 @@ function init_systemd()
 	GREEN='\033[0;32m'
 	echo -e "${GREEN}Systemd init system enabled."
 	for var in $(compgen -e); do
-		printf '%q="%q"\n' "$var" "${!var}"
+		printf '%q=%q\n' "$var" "${!var}"
 	done > /etc/docker.env
-	echo 'source /etc/docker.env' >> ~/.bashrc
 
 	printf '#!/bin/bash\n exec ' > /etc/resinApp.sh
 	printf '%q ' "$@" >> /etc/resinApp.sh
@@ -102,9 +99,8 @@ function init_non_systemd()
 	# trap the stop signal then send SIGTERM to user processes
 	trap signal_handler SIGRTMIN+3 SIGTERM
 
-	CMD=$(which "$1")
 	# echo error message, when executable file doesn't exist.
-	if [ $? == '0' ]; then
+	if CMD=$(command -v "$1" 2>/dev/null); then
 		shift
 		tini -sg -- "$CMD" "$@" &
 		pid=$!
@@ -142,7 +138,7 @@ if [ ! -z "$RESIN" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 		mount_dev
 	fi
 	start_udev
-fi 
+fi
 
 if [ "$INITSYSTEM" = "on" ]; then
 	init_systemd "$@"

--- a/resin-base-images/ubuntu/armv7hf/trusty/entry.sh
+++ b/resin-base-images/ubuntu/armv7hf/trusty/entry.sh
@@ -2,8 +2,7 @@
 
 set -m
 
-hostname "$HOSTNAME" &> /dev/null
-if [[ $? == 0 ]]; then
+if hostname "$HOSTNAME" &> /dev/null; then
 	PRIVILEGED=true
 else
 	PRIVILEGED=false
@@ -13,8 +12,7 @@ function start_udev()
 {
 	if [ "$UDEV" == "on" ]; then
 		if [ "$INITSYSTEM" != "on" ]; then
-			which udevd
-			if [ $? == '0' ]; then
+			if command -v udevd &>/dev/null; then
 				udevd --daemon &> /dev/null
 			else
 				/lib/systemd/systemd-udevd --daemon &> /dev/null
@@ -36,17 +34,17 @@ function remove_buildtime_env_var()
 # Send SIGTERM to child processes of PID 1.
 function signal_handler()
 {
-	kill $pid
+	kill "$pid"
 }
 
 # On ResinOS 2.x devices, the hostname is set by the hostOS.
 # For backward compatibility, we only update the hostname for ResinOS 1.x devices.
 function update_hostname()
 {
-	if [ ${RESIN_DEVICE_UUID:0:7} != ${HOSTNAME:0:7} ]; then
+	if [ "${RESIN_DEVICE_UUID:0:7}" != "${HOSTNAME:0:7}" ]; then
 		# For 1.x Devices only.
 		HOSTNAME="$RESIN_DEVICE_TYPE-${RESIN_DEVICE_UUID:0:7}"
-		echo $HOSTNAME > /etc/hostname
+		echo "$HOSTNAME" > /etc/hostname
 		echo "127.0.1.1 $HOSTNAME" >> /etc/hosts
 		hostname "$HOSTNAME"
 	fi
@@ -79,9 +77,8 @@ function init_systemd()
 	GREEN='\033[0;32m'
 	echo -e "${GREEN}Systemd init system enabled."
 	for var in $(compgen -e); do
-		printf '%q="%q"\n' "$var" "${!var}"
+		printf '%q=%q\n' "$var" "${!var}"
 	done > /etc/docker.env
-	echo 'source /etc/docker.env' >> ~/.bashrc
 
 	printf '#!/bin/bash\n exec ' > /etc/resinApp.sh
 	printf '%q ' "$@" >> /etc/resinApp.sh
@@ -102,9 +99,8 @@ function init_non_systemd()
 	# trap the stop signal then send SIGTERM to user processes
 	trap signal_handler SIGRTMIN+3 SIGTERM
 
-	CMD=$(which "$1")
 	# echo error message, when executable file doesn't exist.
-	if [ $? == '0' ]; then
+	if CMD=$(command -v "$1" 2>/dev/null); then
 		shift
 		tini -sg -- "$CMD" "$@" &
 		pid=$!
@@ -142,7 +138,7 @@ if [ ! -z "$RESIN" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 		mount_dev
 	fi
 	start_udev
-fi 
+fi
 
 if [ "$INITSYSTEM" = "on" ]; then
 	init_systemd "$@"

--- a/resin-base-images/ubuntu/armv7hf/xenial/entry.sh
+++ b/resin-base-images/ubuntu/armv7hf/xenial/entry.sh
@@ -2,8 +2,7 @@
 
 set -m
 
-hostname "$HOSTNAME" &> /dev/null
-if [[ $? == 0 ]]; then
+if hostname "$HOSTNAME" &> /dev/null; then
 	PRIVILEGED=true
 else
 	PRIVILEGED=false
@@ -13,8 +12,7 @@ function start_udev()
 {
 	if [ "$UDEV" == "on" ]; then
 		if [ "$INITSYSTEM" != "on" ]; then
-			which udevd
-			if [ $? == '0' ]; then
+			if command -v udevd &>/dev/null; then
 				udevd --daemon &> /dev/null
 			else
 				/lib/systemd/systemd-udevd --daemon &> /dev/null
@@ -36,17 +34,17 @@ function remove_buildtime_env_var()
 # Send SIGTERM to child processes of PID 1.
 function signal_handler()
 {
-	kill $pid
+	kill "$pid"
 }
 
 # On ResinOS 2.x devices, the hostname is set by the hostOS.
 # For backward compatibility, we only update the hostname for ResinOS 1.x devices.
 function update_hostname()
 {
-	if [ ${RESIN_DEVICE_UUID:0:7} != ${HOSTNAME:0:7} ]; then
+	if [ "${RESIN_DEVICE_UUID:0:7}" != "${HOSTNAME:0:7}" ]; then
 		# For 1.x Devices only.
 		HOSTNAME="$RESIN_DEVICE_TYPE-${RESIN_DEVICE_UUID:0:7}"
-		echo $HOSTNAME > /etc/hostname
+		echo "$HOSTNAME" > /etc/hostname
 		echo "127.0.1.1 $HOSTNAME" >> /etc/hosts
 		hostname "$HOSTNAME"
 	fi
@@ -79,9 +77,8 @@ function init_systemd()
 	GREEN='\033[0;32m'
 	echo -e "${GREEN}Systemd init system enabled."
 	for var in $(compgen -e); do
-		printf '%q="%q"\n' "$var" "${!var}"
+		printf '%q=%q\n' "$var" "${!var}"
 	done > /etc/docker.env
-	echo 'source /etc/docker.env' >> ~/.bashrc
 
 	printf '#!/bin/bash\n exec ' > /etc/resinApp.sh
 	printf '%q ' "$@" >> /etc/resinApp.sh
@@ -102,9 +99,8 @@ function init_non_systemd()
 	# trap the stop signal then send SIGTERM to user processes
 	trap signal_handler SIGRTMIN+3 SIGTERM
 
-	CMD=$(which "$1")
 	# echo error message, when executable file doesn't exist.
-	if [ $? == '0' ]; then
+	if CMD=$(command -v "$1" 2>/dev/null); then
 		shift
 		tini -sg -- "$CMD" "$@" &
 		pid=$!
@@ -142,7 +138,7 @@ if [ ! -z "$RESIN" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 		mount_dev
 	fi
 	start_udev
-fi 
+fi
 
 if [ "$INITSYSTEM" = "on" ]; then
 	init_systemd "$@"

--- a/resin-base-images/ubuntu/i386-nlp/artful/entry.sh
+++ b/resin-base-images/ubuntu/i386-nlp/artful/entry.sh
@@ -2,8 +2,7 @@
 
 set -m
 
-hostname "$HOSTNAME" &> /dev/null
-if [[ $? == 0 ]]; then
+if hostname "$HOSTNAME" &> /dev/null; then
 	PRIVILEGED=true
 else
 	PRIVILEGED=false
@@ -13,8 +12,7 @@ function start_udev()
 {
 	if [ "$UDEV" == "on" ]; then
 		if [ "$INITSYSTEM" != "on" ]; then
-			which udevd
-			if [ $? == '0' ]; then
+			if command -v udevd &>/dev/null; then
 				udevd --daemon &> /dev/null
 			else
 				/lib/systemd/systemd-udevd --daemon &> /dev/null
@@ -36,17 +34,17 @@ function remove_buildtime_env_var()
 # Send SIGTERM to child processes of PID 1.
 function signal_handler()
 {
-	kill $pid
+	kill "$pid"
 }
 
 # On ResinOS 2.x devices, the hostname is set by the hostOS.
 # For backward compatibility, we only update the hostname for ResinOS 1.x devices.
 function update_hostname()
 {
-	if [ ${RESIN_DEVICE_UUID:0:7} != ${HOSTNAME:0:7} ]; then
+	if [ "${RESIN_DEVICE_UUID:0:7}" != "${HOSTNAME:0:7}" ]; then
 		# For 1.x Devices only.
 		HOSTNAME="$RESIN_DEVICE_TYPE-${RESIN_DEVICE_UUID:0:7}"
-		echo $HOSTNAME > /etc/hostname
+		echo "$HOSTNAME" > /etc/hostname
 		echo "127.0.1.1 $HOSTNAME" >> /etc/hosts
 		hostname "$HOSTNAME"
 	fi
@@ -79,9 +77,8 @@ function init_systemd()
 	GREEN='\033[0;32m'
 	echo -e "${GREEN}Systemd init system enabled."
 	for var in $(compgen -e); do
-		printf '%q="%q"\n' "$var" "${!var}"
+		printf '%q=%q\n' "$var" "${!var}"
 	done > /etc/docker.env
-	echo 'source /etc/docker.env' >> ~/.bashrc
 
 	printf '#!/bin/bash\n exec ' > /etc/resinApp.sh
 	printf '%q ' "$@" >> /etc/resinApp.sh
@@ -102,9 +99,8 @@ function init_non_systemd()
 	# trap the stop signal then send SIGTERM to user processes
 	trap signal_handler SIGRTMIN+3 SIGTERM
 
-	CMD=$(which "$1")
 	# echo error message, when executable file doesn't exist.
-	if [ $? == '0' ]; then
+	if CMD=$(command -v "$1" 2>/dev/null); then
 		shift
 		tini -sg -- "$CMD" "$@" &
 		pid=$!
@@ -142,7 +138,7 @@ if [ ! -z "$RESIN" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 		mount_dev
 	fi
 	start_udev
-fi 
+fi
 
 if [ "$INITSYSTEM" = "on" ]; then
 	init_systemd "$@"

--- a/resin-base-images/ubuntu/i386-nlp/bionic/entry.sh
+++ b/resin-base-images/ubuntu/i386-nlp/bionic/entry.sh
@@ -2,8 +2,7 @@
 
 set -m
 
-hostname "$HOSTNAME" &> /dev/null
-if [[ $? == 0 ]]; then
+if hostname "$HOSTNAME" &> /dev/null; then
 	PRIVILEGED=true
 else
 	PRIVILEGED=false
@@ -13,8 +12,7 @@ function start_udev()
 {
 	if [ "$UDEV" == "on" ]; then
 		if [ "$INITSYSTEM" != "on" ]; then
-			which udevd
-			if [ $? == '0' ]; then
+			if command -v udevd &>/dev/null; then
 				udevd --daemon &> /dev/null
 			else
 				/lib/systemd/systemd-udevd --daemon &> /dev/null
@@ -36,17 +34,17 @@ function remove_buildtime_env_var()
 # Send SIGTERM to child processes of PID 1.
 function signal_handler()
 {
-	kill $pid
+	kill "$pid"
 }
 
 # On ResinOS 2.x devices, the hostname is set by the hostOS.
 # For backward compatibility, we only update the hostname for ResinOS 1.x devices.
 function update_hostname()
 {
-	if [ ${RESIN_DEVICE_UUID:0:7} != ${HOSTNAME:0:7} ]; then
+	if [ "${RESIN_DEVICE_UUID:0:7}" != "${HOSTNAME:0:7}" ]; then
 		# For 1.x Devices only.
 		HOSTNAME="$RESIN_DEVICE_TYPE-${RESIN_DEVICE_UUID:0:7}"
-		echo $HOSTNAME > /etc/hostname
+		echo "$HOSTNAME" > /etc/hostname
 		echo "127.0.1.1 $HOSTNAME" >> /etc/hosts
 		hostname "$HOSTNAME"
 	fi
@@ -79,9 +77,8 @@ function init_systemd()
 	GREEN='\033[0;32m'
 	echo -e "${GREEN}Systemd init system enabled."
 	for var in $(compgen -e); do
-		printf '%q="%q"\n' "$var" "${!var}"
+		printf '%q=%q\n' "$var" "${!var}"
 	done > /etc/docker.env
-	echo 'source /etc/docker.env' >> ~/.bashrc
 
 	printf '#!/bin/bash\n exec ' > /etc/resinApp.sh
 	printf '%q ' "$@" >> /etc/resinApp.sh
@@ -102,9 +99,8 @@ function init_non_systemd()
 	# trap the stop signal then send SIGTERM to user processes
 	trap signal_handler SIGRTMIN+3 SIGTERM
 
-	CMD=$(which "$1")
 	# echo error message, when executable file doesn't exist.
-	if [ $? == '0' ]; then
+	if CMD=$(command -v "$1" 2>/dev/null); then
 		shift
 		tini -sg -- "$CMD" "$@" &
 		pid=$!
@@ -142,7 +138,7 @@ if [ ! -z "$RESIN" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 		mount_dev
 	fi
 	start_udev
-fi 
+fi
 
 if [ "$INITSYSTEM" = "on" ]; then
 	init_systemd "$@"

--- a/resin-base-images/ubuntu/i386-nlp/cosmic/entry.sh
+++ b/resin-base-images/ubuntu/i386-nlp/cosmic/entry.sh
@@ -2,8 +2,7 @@
 
 set -m
 
-hostname "$HOSTNAME" &> /dev/null
-if [[ $? == 0 ]]; then
+if hostname "$HOSTNAME" &> /dev/null; then
 	PRIVILEGED=true
 else
 	PRIVILEGED=false
@@ -13,8 +12,7 @@ function start_udev()
 {
 	if [ "$UDEV" == "on" ]; then
 		if [ "$INITSYSTEM" != "on" ]; then
-			which udevd
-			if [ $? == '0' ]; then
+			if command -v udevd &>/dev/null; then
 				udevd --daemon &> /dev/null
 			else
 				/lib/systemd/systemd-udevd --daemon &> /dev/null
@@ -36,17 +34,17 @@ function remove_buildtime_env_var()
 # Send SIGTERM to child processes of PID 1.
 function signal_handler()
 {
-	kill $pid
+	kill "$pid"
 }
 
 # On ResinOS 2.x devices, the hostname is set by the hostOS.
 # For backward compatibility, we only update the hostname for ResinOS 1.x devices.
 function update_hostname()
 {
-	if [ ${RESIN_DEVICE_UUID:0:7} != ${HOSTNAME:0:7} ]; then
+	if [ "${RESIN_DEVICE_UUID:0:7}" != "${HOSTNAME:0:7}" ]; then
 		# For 1.x Devices only.
 		HOSTNAME="$RESIN_DEVICE_TYPE-${RESIN_DEVICE_UUID:0:7}"
-		echo $HOSTNAME > /etc/hostname
+		echo "$HOSTNAME" > /etc/hostname
 		echo "127.0.1.1 $HOSTNAME" >> /etc/hosts
 		hostname "$HOSTNAME"
 	fi
@@ -79,9 +77,8 @@ function init_systemd()
 	GREEN='\033[0;32m'
 	echo -e "${GREEN}Systemd init system enabled."
 	for var in $(compgen -e); do
-		printf '%q="%q"\n' "$var" "${!var}"
+		printf '%q=%q\n' "$var" "${!var}"
 	done > /etc/docker.env
-	echo 'source /etc/docker.env' >> ~/.bashrc
 
 	printf '#!/bin/bash\n exec ' > /etc/resinApp.sh
 	printf '%q ' "$@" >> /etc/resinApp.sh
@@ -102,9 +99,8 @@ function init_non_systemd()
 	# trap the stop signal then send SIGTERM to user processes
 	trap signal_handler SIGRTMIN+3 SIGTERM
 
-	CMD=$(which "$1")
 	# echo error message, when executable file doesn't exist.
-	if [ $? == '0' ]; then
+	if CMD=$(command -v "$1" 2>/dev/null); then
 		shift
 		tini -sg -- "$CMD" "$@" &
 		pid=$!
@@ -142,7 +138,7 @@ if [ ! -z "$RESIN" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 		mount_dev
 	fi
 	start_udev
-fi 
+fi
 
 if [ "$INITSYSTEM" = "on" ]; then
 	init_systemd "$@"

--- a/resin-base-images/ubuntu/i386-nlp/trusty/entry.sh
+++ b/resin-base-images/ubuntu/i386-nlp/trusty/entry.sh
@@ -2,8 +2,7 @@
 
 set -m
 
-hostname "$HOSTNAME" &> /dev/null
-if [[ $? == 0 ]]; then
+if hostname "$HOSTNAME" &> /dev/null; then
 	PRIVILEGED=true
 else
 	PRIVILEGED=false
@@ -13,8 +12,7 @@ function start_udev()
 {
 	if [ "$UDEV" == "on" ]; then
 		if [ "$INITSYSTEM" != "on" ]; then
-			which udevd
-			if [ $? == '0' ]; then
+			if command -v udevd &>/dev/null; then
 				udevd --daemon &> /dev/null
 			else
 				/lib/systemd/systemd-udevd --daemon &> /dev/null
@@ -36,17 +34,17 @@ function remove_buildtime_env_var()
 # Send SIGTERM to child processes of PID 1.
 function signal_handler()
 {
-	kill $pid
+	kill "$pid"
 }
 
 # On ResinOS 2.x devices, the hostname is set by the hostOS.
 # For backward compatibility, we only update the hostname for ResinOS 1.x devices.
 function update_hostname()
 {
-	if [ ${RESIN_DEVICE_UUID:0:7} != ${HOSTNAME:0:7} ]; then
+	if [ "${RESIN_DEVICE_UUID:0:7}" != "${HOSTNAME:0:7}" ]; then
 		# For 1.x Devices only.
 		HOSTNAME="$RESIN_DEVICE_TYPE-${RESIN_DEVICE_UUID:0:7}"
-		echo $HOSTNAME > /etc/hostname
+		echo "$HOSTNAME" > /etc/hostname
 		echo "127.0.1.1 $HOSTNAME" >> /etc/hosts
 		hostname "$HOSTNAME"
 	fi
@@ -79,9 +77,8 @@ function init_systemd()
 	GREEN='\033[0;32m'
 	echo -e "${GREEN}Systemd init system enabled."
 	for var in $(compgen -e); do
-		printf '%q="%q"\n' "$var" "${!var}"
+		printf '%q=%q\n' "$var" "${!var}"
 	done > /etc/docker.env
-	echo 'source /etc/docker.env' >> ~/.bashrc
 
 	printf '#!/bin/bash\n exec ' > /etc/resinApp.sh
 	printf '%q ' "$@" >> /etc/resinApp.sh
@@ -102,9 +99,8 @@ function init_non_systemd()
 	# trap the stop signal then send SIGTERM to user processes
 	trap signal_handler SIGRTMIN+3 SIGTERM
 
-	CMD=$(which "$1")
 	# echo error message, when executable file doesn't exist.
-	if [ $? == '0' ]; then
+	if CMD=$(command -v "$1" 2>/dev/null); then
 		shift
 		tini -sg -- "$CMD" "$@" &
 		pid=$!
@@ -142,7 +138,7 @@ if [ ! -z "$RESIN" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 		mount_dev
 	fi
 	start_udev
-fi 
+fi
 
 if [ "$INITSYSTEM" = "on" ]; then
 	init_systemd "$@"

--- a/resin-base-images/ubuntu/i386-nlp/xenial/entry.sh
+++ b/resin-base-images/ubuntu/i386-nlp/xenial/entry.sh
@@ -2,8 +2,7 @@
 
 set -m
 
-hostname "$HOSTNAME" &> /dev/null
-if [[ $? == 0 ]]; then
+if hostname "$HOSTNAME" &> /dev/null; then
 	PRIVILEGED=true
 else
 	PRIVILEGED=false
@@ -13,8 +12,7 @@ function start_udev()
 {
 	if [ "$UDEV" == "on" ]; then
 		if [ "$INITSYSTEM" != "on" ]; then
-			which udevd
-			if [ $? == '0' ]; then
+			if command -v udevd &>/dev/null; then
 				udevd --daemon &> /dev/null
 			else
 				/lib/systemd/systemd-udevd --daemon &> /dev/null
@@ -36,17 +34,17 @@ function remove_buildtime_env_var()
 # Send SIGTERM to child processes of PID 1.
 function signal_handler()
 {
-	kill $pid
+	kill "$pid"
 }
 
 # On ResinOS 2.x devices, the hostname is set by the hostOS.
 # For backward compatibility, we only update the hostname for ResinOS 1.x devices.
 function update_hostname()
 {
-	if [ ${RESIN_DEVICE_UUID:0:7} != ${HOSTNAME:0:7} ]; then
+	if [ "${RESIN_DEVICE_UUID:0:7}" != "${HOSTNAME:0:7}" ]; then
 		# For 1.x Devices only.
 		HOSTNAME="$RESIN_DEVICE_TYPE-${RESIN_DEVICE_UUID:0:7}"
-		echo $HOSTNAME > /etc/hostname
+		echo "$HOSTNAME" > /etc/hostname
 		echo "127.0.1.1 $HOSTNAME" >> /etc/hosts
 		hostname "$HOSTNAME"
 	fi
@@ -79,9 +77,8 @@ function init_systemd()
 	GREEN='\033[0;32m'
 	echo -e "${GREEN}Systemd init system enabled."
 	for var in $(compgen -e); do
-		printf '%q="%q"\n' "$var" "${!var}"
+		printf '%q=%q\n' "$var" "${!var}"
 	done > /etc/docker.env
-	echo 'source /etc/docker.env' >> ~/.bashrc
 
 	printf '#!/bin/bash\n exec ' > /etc/resinApp.sh
 	printf '%q ' "$@" >> /etc/resinApp.sh
@@ -102,9 +99,8 @@ function init_non_systemd()
 	# trap the stop signal then send SIGTERM to user processes
 	trap signal_handler SIGRTMIN+3 SIGTERM
 
-	CMD=$(which "$1")
 	# echo error message, when executable file doesn't exist.
-	if [ $? == '0' ]; then
+	if CMD=$(command -v "$1" 2>/dev/null); then
 		shift
 		tini -sg -- "$CMD" "$@" &
 		pid=$!
@@ -142,7 +138,7 @@ if [ ! -z "$RESIN" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 		mount_dev
 	fi
 	start_udev
-fi 
+fi
 
 if [ "$INITSYSTEM" = "on" ]; then
 	init_systemd "$@"

--- a/resin-base-images/ubuntu/i386/artful/entry.sh
+++ b/resin-base-images/ubuntu/i386/artful/entry.sh
@@ -2,8 +2,7 @@
 
 set -m
 
-hostname "$HOSTNAME" &> /dev/null
-if [[ $? == 0 ]]; then
+if hostname "$HOSTNAME" &> /dev/null; then
 	PRIVILEGED=true
 else
 	PRIVILEGED=false
@@ -13,8 +12,7 @@ function start_udev()
 {
 	if [ "$UDEV" == "on" ]; then
 		if [ "$INITSYSTEM" != "on" ]; then
-			which udevd
-			if [ $? == '0' ]; then
+			if command -v udevd &>/dev/null; then
 				udevd --daemon &> /dev/null
 			else
 				/lib/systemd/systemd-udevd --daemon &> /dev/null
@@ -36,17 +34,17 @@ function remove_buildtime_env_var()
 # Send SIGTERM to child processes of PID 1.
 function signal_handler()
 {
-	kill $pid
+	kill "$pid"
 }
 
 # On ResinOS 2.x devices, the hostname is set by the hostOS.
 # For backward compatibility, we only update the hostname for ResinOS 1.x devices.
 function update_hostname()
 {
-	if [ ${RESIN_DEVICE_UUID:0:7} != ${HOSTNAME:0:7} ]; then
+	if [ "${RESIN_DEVICE_UUID:0:7}" != "${HOSTNAME:0:7}" ]; then
 		# For 1.x Devices only.
 		HOSTNAME="$RESIN_DEVICE_TYPE-${RESIN_DEVICE_UUID:0:7}"
-		echo $HOSTNAME > /etc/hostname
+		echo "$HOSTNAME" > /etc/hostname
 		echo "127.0.1.1 $HOSTNAME" >> /etc/hosts
 		hostname "$HOSTNAME"
 	fi
@@ -79,9 +77,8 @@ function init_systemd()
 	GREEN='\033[0;32m'
 	echo -e "${GREEN}Systemd init system enabled."
 	for var in $(compgen -e); do
-		printf '%q="%q"\n' "$var" "${!var}"
+		printf '%q=%q\n' "$var" "${!var}"
 	done > /etc/docker.env
-	echo 'source /etc/docker.env' >> ~/.bashrc
 
 	printf '#!/bin/bash\n exec ' > /etc/resinApp.sh
 	printf '%q ' "$@" >> /etc/resinApp.sh
@@ -102,9 +99,8 @@ function init_non_systemd()
 	# trap the stop signal then send SIGTERM to user processes
 	trap signal_handler SIGRTMIN+3 SIGTERM
 
-	CMD=$(which "$1")
 	# echo error message, when executable file doesn't exist.
-	if [ $? == '0' ]; then
+	if CMD=$(command -v "$1" 2>/dev/null); then
 		shift
 		tini -sg -- "$CMD" "$@" &
 		pid=$!
@@ -142,7 +138,7 @@ if [ ! -z "$RESIN" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 		mount_dev
 	fi
 	start_udev
-fi 
+fi
 
 if [ "$INITSYSTEM" = "on" ]; then
 	init_systemd "$@"

--- a/resin-base-images/ubuntu/i386/bionic/entry.sh
+++ b/resin-base-images/ubuntu/i386/bionic/entry.sh
@@ -2,8 +2,7 @@
 
 set -m
 
-hostname "$HOSTNAME" &> /dev/null
-if [[ $? == 0 ]]; then
+if hostname "$HOSTNAME" &> /dev/null; then
 	PRIVILEGED=true
 else
 	PRIVILEGED=false
@@ -13,8 +12,7 @@ function start_udev()
 {
 	if [ "$UDEV" == "on" ]; then
 		if [ "$INITSYSTEM" != "on" ]; then
-			which udevd
-			if [ $? == '0' ]; then
+			if command -v udevd &>/dev/null; then
 				udevd --daemon &> /dev/null
 			else
 				/lib/systemd/systemd-udevd --daemon &> /dev/null
@@ -36,17 +34,17 @@ function remove_buildtime_env_var()
 # Send SIGTERM to child processes of PID 1.
 function signal_handler()
 {
-	kill $pid
+	kill "$pid"
 }
 
 # On ResinOS 2.x devices, the hostname is set by the hostOS.
 # For backward compatibility, we only update the hostname for ResinOS 1.x devices.
 function update_hostname()
 {
-	if [ ${RESIN_DEVICE_UUID:0:7} != ${HOSTNAME:0:7} ]; then
+	if [ "${RESIN_DEVICE_UUID:0:7}" != "${HOSTNAME:0:7}" ]; then
 		# For 1.x Devices only.
 		HOSTNAME="$RESIN_DEVICE_TYPE-${RESIN_DEVICE_UUID:0:7}"
-		echo $HOSTNAME > /etc/hostname
+		echo "$HOSTNAME" > /etc/hostname
 		echo "127.0.1.1 $HOSTNAME" >> /etc/hosts
 		hostname "$HOSTNAME"
 	fi
@@ -79,9 +77,8 @@ function init_systemd()
 	GREEN='\033[0;32m'
 	echo -e "${GREEN}Systemd init system enabled."
 	for var in $(compgen -e); do
-		printf '%q="%q"\n' "$var" "${!var}"
+		printf '%q=%q\n' "$var" "${!var}"
 	done > /etc/docker.env
-	echo 'source /etc/docker.env' >> ~/.bashrc
 
 	printf '#!/bin/bash\n exec ' > /etc/resinApp.sh
 	printf '%q ' "$@" >> /etc/resinApp.sh
@@ -102,9 +99,8 @@ function init_non_systemd()
 	# trap the stop signal then send SIGTERM to user processes
 	trap signal_handler SIGRTMIN+3 SIGTERM
 
-	CMD=$(which "$1")
 	# echo error message, when executable file doesn't exist.
-	if [ $? == '0' ]; then
+	if CMD=$(command -v "$1" 2>/dev/null); then
 		shift
 		tini -sg -- "$CMD" "$@" &
 		pid=$!
@@ -142,7 +138,7 @@ if [ ! -z "$RESIN" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 		mount_dev
 	fi
 	start_udev
-fi 
+fi
 
 if [ "$INITSYSTEM" = "on" ]; then
 	init_systemd "$@"

--- a/resin-base-images/ubuntu/i386/cosmic/entry.sh
+++ b/resin-base-images/ubuntu/i386/cosmic/entry.sh
@@ -2,8 +2,7 @@
 
 set -m
 
-hostname "$HOSTNAME" &> /dev/null
-if [[ $? == 0 ]]; then
+if hostname "$HOSTNAME" &> /dev/null; then
 	PRIVILEGED=true
 else
 	PRIVILEGED=false
@@ -13,8 +12,7 @@ function start_udev()
 {
 	if [ "$UDEV" == "on" ]; then
 		if [ "$INITSYSTEM" != "on" ]; then
-			which udevd
-			if [ $? == '0' ]; then
+			if command -v udevd &>/dev/null; then
 				udevd --daemon &> /dev/null
 			else
 				/lib/systemd/systemd-udevd --daemon &> /dev/null
@@ -36,17 +34,17 @@ function remove_buildtime_env_var()
 # Send SIGTERM to child processes of PID 1.
 function signal_handler()
 {
-	kill $pid
+	kill "$pid"
 }
 
 # On ResinOS 2.x devices, the hostname is set by the hostOS.
 # For backward compatibility, we only update the hostname for ResinOS 1.x devices.
 function update_hostname()
 {
-	if [ ${RESIN_DEVICE_UUID:0:7} != ${HOSTNAME:0:7} ]; then
+	if [ "${RESIN_DEVICE_UUID:0:7}" != "${HOSTNAME:0:7}" ]; then
 		# For 1.x Devices only.
 		HOSTNAME="$RESIN_DEVICE_TYPE-${RESIN_DEVICE_UUID:0:7}"
-		echo $HOSTNAME > /etc/hostname
+		echo "$HOSTNAME" > /etc/hostname
 		echo "127.0.1.1 $HOSTNAME" >> /etc/hosts
 		hostname "$HOSTNAME"
 	fi
@@ -79,9 +77,8 @@ function init_systemd()
 	GREEN='\033[0;32m'
 	echo -e "${GREEN}Systemd init system enabled."
 	for var in $(compgen -e); do
-		printf '%q="%q"\n' "$var" "${!var}"
+		printf '%q=%q\n' "$var" "${!var}"
 	done > /etc/docker.env
-	echo 'source /etc/docker.env' >> ~/.bashrc
 
 	printf '#!/bin/bash\n exec ' > /etc/resinApp.sh
 	printf '%q ' "$@" >> /etc/resinApp.sh
@@ -102,9 +99,8 @@ function init_non_systemd()
 	# trap the stop signal then send SIGTERM to user processes
 	trap signal_handler SIGRTMIN+3 SIGTERM
 
-	CMD=$(which "$1")
 	# echo error message, when executable file doesn't exist.
-	if [ $? == '0' ]; then
+	if CMD=$(command -v "$1" 2>/dev/null); then
 		shift
 		tini -sg -- "$CMD" "$@" &
 		pid=$!
@@ -142,7 +138,7 @@ if [ ! -z "$RESIN" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 		mount_dev
 	fi
 	start_udev
-fi 
+fi
 
 if [ "$INITSYSTEM" = "on" ]; then
 	init_systemd "$@"

--- a/resin-base-images/ubuntu/i386/trusty/entry.sh
+++ b/resin-base-images/ubuntu/i386/trusty/entry.sh
@@ -2,8 +2,7 @@
 
 set -m
 
-hostname "$HOSTNAME" &> /dev/null
-if [[ $? == 0 ]]; then
+if hostname "$HOSTNAME" &> /dev/null; then
 	PRIVILEGED=true
 else
 	PRIVILEGED=false
@@ -13,8 +12,7 @@ function start_udev()
 {
 	if [ "$UDEV" == "on" ]; then
 		if [ "$INITSYSTEM" != "on" ]; then
-			which udevd
-			if [ $? == '0' ]; then
+			if command -v udevd &>/dev/null; then
 				udevd --daemon &> /dev/null
 			else
 				/lib/systemd/systemd-udevd --daemon &> /dev/null
@@ -36,17 +34,17 @@ function remove_buildtime_env_var()
 # Send SIGTERM to child processes of PID 1.
 function signal_handler()
 {
-	kill $pid
+	kill "$pid"
 }
 
 # On ResinOS 2.x devices, the hostname is set by the hostOS.
 # For backward compatibility, we only update the hostname for ResinOS 1.x devices.
 function update_hostname()
 {
-	if [ ${RESIN_DEVICE_UUID:0:7} != ${HOSTNAME:0:7} ]; then
+	if [ "${RESIN_DEVICE_UUID:0:7}" != "${HOSTNAME:0:7}" ]; then
 		# For 1.x Devices only.
 		HOSTNAME="$RESIN_DEVICE_TYPE-${RESIN_DEVICE_UUID:0:7}"
-		echo $HOSTNAME > /etc/hostname
+		echo "$HOSTNAME" > /etc/hostname
 		echo "127.0.1.1 $HOSTNAME" >> /etc/hosts
 		hostname "$HOSTNAME"
 	fi
@@ -79,9 +77,8 @@ function init_systemd()
 	GREEN='\033[0;32m'
 	echo -e "${GREEN}Systemd init system enabled."
 	for var in $(compgen -e); do
-		printf '%q="%q"\n' "$var" "${!var}"
+		printf '%q=%q\n' "$var" "${!var}"
 	done > /etc/docker.env
-	echo 'source /etc/docker.env' >> ~/.bashrc
 
 	printf '#!/bin/bash\n exec ' > /etc/resinApp.sh
 	printf '%q ' "$@" >> /etc/resinApp.sh
@@ -102,9 +99,8 @@ function init_non_systemd()
 	# trap the stop signal then send SIGTERM to user processes
 	trap signal_handler SIGRTMIN+3 SIGTERM
 
-	CMD=$(which "$1")
 	# echo error message, when executable file doesn't exist.
-	if [ $? == '0' ]; then
+	if CMD=$(command -v "$1" 2>/dev/null); then
 		shift
 		tini -sg -- "$CMD" "$@" &
 		pid=$!
@@ -142,7 +138,7 @@ if [ ! -z "$RESIN" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 		mount_dev
 	fi
 	start_udev
-fi 
+fi
 
 if [ "$INITSYSTEM" = "on" ]; then
 	init_systemd "$@"

--- a/resin-base-images/ubuntu/i386/xenial/entry.sh
+++ b/resin-base-images/ubuntu/i386/xenial/entry.sh
@@ -2,8 +2,7 @@
 
 set -m
 
-hostname "$HOSTNAME" &> /dev/null
-if [[ $? == 0 ]]; then
+if hostname "$HOSTNAME" &> /dev/null; then
 	PRIVILEGED=true
 else
 	PRIVILEGED=false
@@ -13,8 +12,7 @@ function start_udev()
 {
 	if [ "$UDEV" == "on" ]; then
 		if [ "$INITSYSTEM" != "on" ]; then
-			which udevd
-			if [ $? == '0' ]; then
+			if command -v udevd &>/dev/null; then
 				udevd --daemon &> /dev/null
 			else
 				/lib/systemd/systemd-udevd --daemon &> /dev/null
@@ -36,17 +34,17 @@ function remove_buildtime_env_var()
 # Send SIGTERM to child processes of PID 1.
 function signal_handler()
 {
-	kill $pid
+	kill "$pid"
 }
 
 # On ResinOS 2.x devices, the hostname is set by the hostOS.
 # For backward compatibility, we only update the hostname for ResinOS 1.x devices.
 function update_hostname()
 {
-	if [ ${RESIN_DEVICE_UUID:0:7} != ${HOSTNAME:0:7} ]; then
+	if [ "${RESIN_DEVICE_UUID:0:7}" != "${HOSTNAME:0:7}" ]; then
 		# For 1.x Devices only.
 		HOSTNAME="$RESIN_DEVICE_TYPE-${RESIN_DEVICE_UUID:0:7}"
-		echo $HOSTNAME > /etc/hostname
+		echo "$HOSTNAME" > /etc/hostname
 		echo "127.0.1.1 $HOSTNAME" >> /etc/hosts
 		hostname "$HOSTNAME"
 	fi
@@ -79,9 +77,8 @@ function init_systemd()
 	GREEN='\033[0;32m'
 	echo -e "${GREEN}Systemd init system enabled."
 	for var in $(compgen -e); do
-		printf '%q="%q"\n' "$var" "${!var}"
+		printf '%q=%q\n' "$var" "${!var}"
 	done > /etc/docker.env
-	echo 'source /etc/docker.env' >> ~/.bashrc
 
 	printf '#!/bin/bash\n exec ' > /etc/resinApp.sh
 	printf '%q ' "$@" >> /etc/resinApp.sh
@@ -102,9 +99,8 @@ function init_non_systemd()
 	# trap the stop signal then send SIGTERM to user processes
 	trap signal_handler SIGRTMIN+3 SIGTERM
 
-	CMD=$(which "$1")
 	# echo error message, when executable file doesn't exist.
-	if [ $? == '0' ]; then
+	if CMD=$(command -v "$1" 2>/dev/null); then
 		shift
 		tini -sg -- "$CMD" "$@" &
 		pid=$!
@@ -142,7 +138,7 @@ if [ ! -z "$RESIN" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 		mount_dev
 	fi
 	start_udev
-fi 
+fi
 
 if [ "$INITSYSTEM" = "on" ]; then
 	init_systemd "$@"

--- a/scripts/assets/entry-alpine.sh
+++ b/scripts/assets/entry-alpine.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
 
 
-hostname "$HOSTNAME" &> /dev/null
-if [[ $? == 0 ]]; then
+if hostname "$HOSTNAME" &> /dev/null; then
 	PRIVILEGED=true
 else
 	PRIVILEGED=false
@@ -24,10 +23,10 @@ function start_udev()
 # For backward compatibility, we only update the hostname for ResinOS 1.x devices.
 function update_hostname()
 {
-	if [ ${RESIN_DEVICE_UUID:0:7} != ${HOSTNAME:0:7} ]; then
+	if [ "${RESIN_DEVICE_UUID:0:7}" != "${HOSTNAME:0:7}" ]; then
 		# For 1.x Devices only.
 		HOSTNAME="$RESIN_DEVICE_TYPE-${RESIN_DEVICE_UUID:0:7}"
-		echo $HOSTNAME > /etc/hostname
+		echo "$HOSTNAME" > /etc/hostname
 		echo "127.0.1.1 $HOSTNAME" >> /etc/hosts
 		hostname "$HOSTNAME"
 	fi
@@ -76,9 +75,8 @@ function init_openrc()
 
 function init_non_openrc()
 {
-	CMD=$(which "$1")
 	# echo error message, when executable file doesn't exist.
-	if [ $? == '0' ]; then
+	if CMD=$(command -v "$1" 2>/dev/null); then
 		shift
 		exec tini -sg -- "$CMD" "$@"
 	else
@@ -112,7 +110,7 @@ if [ ! -z "$RESIN_SUPERVISOR_API_KEY" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 		mount_dev
 	fi
 	start_udev
-fi 
+fi
 
 if [ "$INITSYSTEM" = "on" ]; then
 	init_openrc "$@"

--- a/scripts/assets/entry-fedora.sh
+++ b/scripts/assets/entry-fedora.sh
@@ -2,8 +2,7 @@
 
 set -m
 
-hostname "$HOSTNAME" &> /dev/null
-if [[ $? == 0 ]]; then
+if hostname "$HOSTNAME" &> /dev/null; then
 	PRIVILEGED=true
 else
 	PRIVILEGED=false
@@ -13,8 +12,7 @@ function start_udev()
 {
 	if [ "$UDEV" == "on" ]; then
 		if [ "$INITSYSTEM" != "on" ]; then
-			which udevd
-			if [ $? == '0' ]; then
+			if command -v udevd &>/dev/null; then
 				udevd --daemon &> /dev/null
 			else
 				/lib/systemd/systemd-udevd --daemon &> /dev/null
@@ -36,17 +34,17 @@ function remove_buildtime_env_var()
 # Send SIGTERM to child processes of PID 1.
 function signal_handler()
 {
-	kill $pid
+	kill "$pid"
 }
 
 # On ResinOS 2.x devices, the hostname is set by the hostOS.
 # For backward compatibility, we only update the hostname for ResinOS 1.x devices.
 function update_hostname()
 {
-	if [ ${RESIN_DEVICE_UUID:0:7} != ${HOSTNAME:0:7} ]; then
+	if [ "${RESIN_DEVICE_UUID:0:7}" != "${HOSTNAME:0:7}" ]; then
 		# For 1.x Devices only.
 		HOSTNAME="$RESIN_DEVICE_TYPE-${RESIN_DEVICE_UUID:0:7}"
-		echo $HOSTNAME > /etc/hostname
+		echo "$HOSTNAME" > /etc/hostname
 		echo "127.0.1.1 $HOSTNAME" >> /etc/hosts
 		hostname "$HOSTNAME"
 	fi
@@ -79,9 +77,8 @@ function init_systemd()
 	GREEN='\033[0;32m'
 	echo -e "${GREEN}Systemd init system enabled."
 	for var in $(compgen -e); do
-		printf '%q="%q"\n' "$var" "${!var}"
+		printf '%q=%q\n' "$var" "${!var}"
 	done > /etc/docker.env
-	echo 'source /etc/docker.env' >> ~/.bashrc
 
 	printf '#!/bin/bash\n exec ' > /etc/resinApp.sh
 	printf '%q ' "$@" >> /etc/resinApp.sh
@@ -104,9 +101,8 @@ function init_non_systemd()
 	# trap the stop signal then send SIGTERM to user processes
 	trap signal_handler SIGRTMIN+3 SIGTERM
 
-	CMD=$(which "$1")
 	# echo error message, when executable file doesn't exist.
-	if [ $? == '0' ]; then
+	if CMD=$(command -v "$1" 2>/dev/null); then
 		shift
 		tini -sg -- "$CMD" "$@" &
 		pid=$!
@@ -144,7 +140,7 @@ if [ ! -z "$RESIN" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 		mount_dev
 	fi
 	start_udev
-fi 
+fi
 
 if [ "$INITSYSTEM" = "on" ]; then
 	init_systemd "$@"

--- a/scripts/assets/entry-systemd-debian.sh
+++ b/scripts/assets/entry-systemd-debian.sh
@@ -2,8 +2,7 @@
 
 set -m
 
-hostname "$HOSTNAME" &> /dev/null
-if [[ $? == 0 ]]; then
+if hostname "$HOSTNAME" &> /dev/null; then
 	PRIVILEGED=true
 else
 	PRIVILEGED=false
@@ -13,8 +12,7 @@ function start_udev()
 {
 	if [ "$UDEV" == "on" ]; then
 		if [ "$INITSYSTEM" != "on" ]; then
-			which udevd
-			if [ $? == '0' ]; then
+			if command -v udevd &>/dev/null; then
 				udevd --daemon &> /dev/null
 			else
 				/lib/systemd/systemd-udevd --daemon &> /dev/null
@@ -36,17 +34,17 @@ function remove_buildtime_env_var()
 # Send SIGTERM to child processes of PID 1.
 function signal_handler()
 {
-	kill $pid
+	kill "$pid"
 }
 
 # On ResinOS 2.x devices, the hostname is set by the hostOS.
 # For backward compatibility, we only update the hostname for ResinOS 1.x devices.
 function update_hostname()
 {
-	if [ ${RESIN_DEVICE_UUID:0:7} != ${HOSTNAME:0:7} ]; then
+	if [ "${RESIN_DEVICE_UUID:0:7}" != "${HOSTNAME:0:7}" ]; then
 		# For 1.x Devices only.
 		HOSTNAME="$RESIN_DEVICE_TYPE-${RESIN_DEVICE_UUID:0:7}"
-		echo $HOSTNAME > /etc/hostname
+		echo "$HOSTNAME" > /etc/hostname
 		echo "127.0.1.1 $HOSTNAME" >> /etc/hosts
 		hostname "$HOSTNAME"
 	fi
@@ -79,9 +77,8 @@ function init_systemd()
 	GREEN='\033[0;32m'
 	echo -e "${GREEN}Systemd init system enabled."
 	for var in $(compgen -e); do
-		printf '%q="%q"\n' "$var" "${!var}"
+		printf '%q=%q\n' "$var" "${!var}"
 	done > /etc/docker.env
-	echo 'source /etc/docker.env' >> ~/.bashrc
 
 	printf '#!/bin/bash\n exec ' > /etc/resinApp.sh
 	printf '%q ' "$@" >> /etc/resinApp.sh
@@ -102,9 +99,8 @@ function init_non_systemd()
 	# trap the stop signal then send SIGTERM to user processes
 	trap signal_handler SIGRTMIN+3 SIGTERM
 
-	CMD=$(which "$1")
 	# echo error message, when executable file doesn't exist.
-	if [ $? == '0' ]; then
+	if CMD=$(command -v "$1" 2>/dev/null); then
 		shift
 		tini -sg -- "$CMD" "$@" &
 		pid=$!
@@ -142,7 +138,7 @@ if [ ! -z "$RESIN" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 		mount_dev
 	fi
 	start_udev
-fi 
+fi
 
 if [ "$INITSYSTEM" = "on" ]; then
 	init_systemd "$@"


### PR DESCRIPTION
Connects-to: #477
Change-type: patch
Signed-off-by: Will Boyce \<will@resin.io\>

---

There are a few bash-style fixes in here too, but the bugfix is in the printf: `printf '%q="%q"\n' "$var" "${!var}"` -> `printf '%q=%q\n' "$var" "${!var}"`.